### PR TITLE
Core Domain v1: Users, Producers, Products, Orders + smoke tests

### DIFF
--- a/backend/app/Http/Controllers/Api/OrderController.php
+++ b/backend/app/Http/Controllers/Api/OrderController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class OrderController extends Controller
+{
+    /**
+     * Display user's orders.
+     */
+    public function index(Request $request)
+    {
+        $orders = Order::where('user_id', $request->user()->id)
+            ->with('orderItems.product')
+            ->orderBy('created_at', 'desc')
+            ->get();
+            
+        return response()->json($orders);
+    }
+
+    /**
+     * Store a newly created order.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'items' => 'required|array|min:1',
+            'items.*.product_id' => 'required|exists:products,id',
+            'items.*.quantity' => 'required|integer|min:1',
+            'shipping_method' => 'string|nullable',
+            'notes' => 'string|nullable',
+        ]);
+
+        try {
+            DB::beginTransaction();
+
+            // Calculate totals
+            $subtotal = 0;
+            $orderItems = [];
+
+            foreach ($validated['items'] as $item) {
+                $product = Product::find($item['product_id']);
+                $unitPrice = $product->price ?? 0;
+                $totalPrice = $unitPrice * $item['quantity'];
+                $subtotal += $totalPrice;
+
+                $orderItems[] = [
+                    'product_id' => $product->id,
+                    'quantity' => $item['quantity'],
+                    'unit_price' => $unitPrice,
+                    'total_price' => $totalPrice,
+                    'product_name' => $product->name,
+                    'product_unit' => $product->unit ?? 'unit',
+                ];
+            }
+
+            $taxAmount = $subtotal * 0.10; // 10% tax
+            $shippingAmount = 5.00; // Fixed shipping
+            $totalAmount = $subtotal + $taxAmount + $shippingAmount;
+
+            // Create order
+            $order = Order::create([
+                'user_id' => $request->user()->id,
+                'subtotal' => $subtotal,
+                'tax_amount' => $taxAmount,
+                'shipping_amount' => $shippingAmount,
+                'total_amount' => $totalAmount,
+                'payment_status' => 'pending',
+                'status' => 'pending',
+                'shipping_method' => $validated['shipping_method'] ?? 'HOME',
+                'notes' => $validated['notes'] ?? null,
+            ]);
+
+            // Create order items
+            foreach ($orderItems as $itemData) {
+                $itemData['order_id'] = $order->id;
+                OrderItem::create($itemData);
+            }
+
+            DB::commit();
+
+            return response()->json($order->load('orderItems'), 201);
+
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json(['error' => 'Failed to create order'], 500);
+        }
+    }
+
+    /**
+     * Display the specified order.
+     */
+    public function show(Request $request, Order $order)
+    {
+        // Ensure user can only see their own orders
+        if ($order->user_id !== $request->user()->id) {
+            abort(404);
+        }
+
+        return response()->json($order->load('orderItems.product'));
+    }
+}

--- a/backend/app/Http/Controllers/Api/ProductController.php
+++ b/backend/app/Http/Controllers/Api/ProductController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Product;
+use Illuminate\Http\Request;
+
+class ProductController extends Controller
+{
+    /**
+     * Display a listing of products.
+     */
+    public function index()
+    {
+        $products = Product::with('producer')->get();
+        
+        return response()->json($products);
+    }
+
+    /**
+     * Display the specified product.
+     */
+    public function show(Product $product)
+    {
+        $product->load('producer');
+        
+        return response()->json($product);
+    }
+}

--- a/backend/app/Models/Order.php
+++ b/backend/app/Models/Order.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'subtotal',
+        'tax_amount',
+        'shipping_amount',
+        'total_amount',
+        'payment_status',
+        'status',
+        'shipping_method',
+        'shipping_address',
+        'billing_address',
+        'notes',
+    ];
+
+    protected $casts = [
+        'subtotal' => 'decimal:2',
+        'tax_amount' => 'decimal:2',
+        'shipping_amount' => 'decimal:2',
+        'total_amount' => 'decimal:2',
+        'shipping_address' => 'array',
+        'billing_address' => 'array',
+    ];
+
+    /**
+     * Get the user that owns the order.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the order items for the order.
+     */
+    public function orderItems()
+    {
+        return $this->hasMany(OrderItem::class);
+    }
+}

--- a/backend/app/Models/OrderItem.php
+++ b/backend/app/Models/OrderItem.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class OrderItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'product_id',
+        'quantity',
+        'unit_price',
+        'total_price',
+        'product_name',
+        'product_unit',
+    ];
+
+    protected $casts = [
+        'unit_price' => 'decimal:2',
+        'total_price' => 'decimal:2',
+    ];
+
+    /**
+     * Get the order that owns the order item.
+     */
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    /**
+     * Get the product that owns the order item.
+     */
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -56,4 +56,12 @@ class User extends Authenticatable
     {
         return $this->hasOne(Producer::class);
     }
+
+    /**
+     * Get the orders for the user.
+     */
+    public function orders()
+    {
+        return $this->hasMany(Order::class);
+    }
 }

--- a/backend/database/factories/ProducerFactory.php
+++ b/backend/database/factories/ProducerFactory.php
@@ -3,6 +3,8 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use App\Models\User;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Producer>
@@ -16,8 +18,12 @@ class ProducerFactory extends Factory
      */
     public function definition(): array
     {
+        $name = fake()->company();
+        
         return [
-            'name' => fake()->company(),
+            'user_id' => User::factory(),
+            'name' => $name,
+            'slug' => $this->generateUniqueSlug(Str::slug($name)),
             'business_name' => fake()->company() . ' LLC',
             'description' => fake()->paragraph(),
             'location' => fake()->city() . ', ' . fake()->country(),
@@ -26,5 +32,22 @@ class ProducerFactory extends Factory
             'website' => fake()->url(),
             'status' => 'active',
         ];
+    }
+    
+    /**
+     * Generate collision-safe unique slug
+     */
+    private function generateUniqueSlug(string $baseSlug): string
+    {
+        $slug = $baseSlug;
+        $counter = 1;
+        
+        // Simple unique slug generation - during testing this is usually unique anyway
+        while (\App\Models\Producer::where('slug', $slug)->exists()) {
+            $slug = $baseSlug . '-' . $counter;
+            $counter++;
+        }
+        
+        return $slug;
     }
 }

--- a/backend/database/factories/ProductFactory.php
+++ b/backend/database/factories/ProductFactory.php
@@ -3,6 +3,8 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use App\Models\Producer;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Product>
@@ -18,12 +20,17 @@ class ProductFactory extends Factory
     {
         $name = fake()->words(3, true);
         return [
+            'producer_id' => Producer::factory(),
             'name' => $name,
-            'slug' => \Str::slug($name) . '-' . fake()->unique()->randomNumber(5),
+            'slug' => Str::slug($name) . '-' . fake()->unique()->randomNumber(5),
             'description' => fake()->paragraph(),
             'price' => fake()->randomFloat(2, 5, 100),
+            'weight_per_unit' => fake()->randomFloat(3, 0.1, 5.0),
             'unit' => fake()->randomElement(['kg', 'piece', 'liter', 'box']),
+            'stock' => fake()->numberBetween(0, 200),
             'category' => fake()->randomElement(['fruits', 'vegetables', 'dairy', 'meat', 'grains']),
+            'is_organic' => fake()->boolean(40), // 40% chance of being organic
+            'status' => fake()->randomElement(['available', 'unavailable', 'seasonal']),
             'is_active' => true,
         ];
     }

--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -29,7 +29,38 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => 'consumer',
         ];
+    }
+
+    /**
+     * Create an admin user.
+     */
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'role' => 'admin',
+        ]);
+    }
+
+    /**
+     * Create a producer user.
+     */
+    public function producer(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'role' => 'producer',
+        ]);
+    }
+
+    /**
+     * Create a consumer user.
+     */
+    public function consumer(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'role' => 'consumer',
+        ]);
     }
 
     /**

--- a/backend/database/migrations/2025_08_24_191037_create_orders_table.php
+++ b/backend/database/migrations/2025_08_24_191037_create_orders_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('orders', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id'); // NO FK inline - will add later
+            $table->decimal('subtotal', 10, 2)->default(0.00);
+            $table->decimal('tax_amount', 10, 2)->default(0.00);
+            $table->decimal('shipping_amount', 10, 2)->default(0.00);
+            $table->decimal('total_amount', 10, 2)->default(0.00);
+            $table->enum('payment_status', ['pending', 'paid', 'failed'])->default('pending');
+            $table->enum('status', ['pending', 'processing', 'shipped', 'completed', 'cancelled'])->default('pending');
+            $table->string('shipping_method')->nullable()->default('HOME');
+            $table->json('shipping_address')->nullable();
+            $table->json('billing_address')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            
+            // Indexes
+            $table->index('user_id');
+            $table->index(['status', 'payment_status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('orders');
+    }
+};

--- a/backend/database/migrations/2025_08_24_191114_create_order_items_table.php
+++ b/backend/database/migrations/2025_08_24_191114_create_order_items_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('order_items', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('order_id'); // NO FK inline - will add later
+            $table->unsignedBigInteger('product_id'); // NO FK inline - will add later
+            $table->integer('quantity');
+            $table->decimal('unit_price', 10, 2);
+            $table->decimal('total_price', 10, 2);
+            $table->string('product_name'); // Store product name at time of order
+            $table->string('product_unit')->nullable(); // Store unit at time of order
+            $table->timestamps();
+            
+            // Indexes
+            $table->index('order_id');
+            $table->index('product_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('order_items');
+    }
+};

--- a/backend/database/migrations/2025_08_24_191140_add_foreign_keys_to_orders_and_items.php
+++ b/backend/database/migrations/2025_08_24_191140_add_foreign_keys_to_orders_and_items.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Add FK to orders table
+        Schema::table('orders', function (Blueprint $table) {
+            // Drop constraint if exists (Postgres-safe)
+            DB::statement('ALTER TABLE orders DROP CONSTRAINT IF EXISTS orders_user_id_foreign');
+            
+            // Add FK constraint
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+
+        // Add FKs to order_items table  
+        Schema::table('order_items', function (Blueprint $table) {
+            // Drop constraints if exist (Postgres-safe)
+            DB::statement('ALTER TABLE order_items DROP CONSTRAINT IF EXISTS order_items_order_id_foreign');
+            DB::statement('ALTER TABLE order_items DROP CONSTRAINT IF EXISTS order_items_product_id_foreign');
+            
+            // Add FK constraints
+            $table->foreign('order_id')->references('id')->on('orders')->onDelete('cascade');
+            $table->foreign('product_id')->references('id')->on('products')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->dropForeign(['order_id']);
+            $table->dropForeign(['product_id']);
+        });
+        
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+        });
+    }
+};

--- a/backend/database/migrations/2025_08_24_191140_add_foreign_keys_to_orders_and_items.php
+++ b/backend/database/migrations/2025_08_24_191140_add_foreign_keys_to_orders_and_items.php
@@ -14,8 +14,12 @@ return new class extends Migration
     {
         // Add FK to orders table
         Schema::table('orders', function (Blueprint $table) {
-            // Drop constraint if exists (Postgres-safe)
-            DB::statement('ALTER TABLE orders DROP CONSTRAINT IF EXISTS orders_user_id_foreign');
+            // Drop constraint if exists (database-agnostic way)
+            try {
+                $table->dropForeign(['user_id']);
+            } catch (\Exception $e) {
+                // Constraint doesn't exist, continue
+            }
             
             // Add FK constraint
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
@@ -23,9 +27,18 @@ return new class extends Migration
 
         // Add FKs to order_items table  
         Schema::table('order_items', function (Blueprint $table) {
-            // Drop constraints if exist (Postgres-safe)
-            DB::statement('ALTER TABLE order_items DROP CONSTRAINT IF EXISTS order_items_order_id_foreign');
-            DB::statement('ALTER TABLE order_items DROP CONSTRAINT IF EXISTS order_items_product_id_foreign');
+            // Drop constraints if exist (database-agnostic way)
+            try {
+                $table->dropForeign(['order_id']);
+            } catch (\Exception $e) {
+                // Constraint doesn't exist, continue
+            }
+            
+            try {
+                $table->dropForeign(['product_id']);
+            } catch (\Exception $e) {
+                // Constraint doesn't exist, continue
+            }
             
             // Add FK constraints
             $table->foreign('order_id')->references('id')->on('orders')->onDelete('cascade');

--- a/backend/database/migrations/2025_08_24_191140_add_foreign_keys_to_orders_and_items.php
+++ b/backend/database/migrations/2025_08_24_191140_add_foreign_keys_to_orders_and_items.php
@@ -14,11 +14,17 @@ return new class extends Migration
     {
         // Add FK to orders table
         Schema::table('orders', function (Blueprint $table) {
-            // Drop constraint if exists (database-agnostic way)
-            try {
-                $table->dropForeign(['user_id']);
-            } catch (\Exception $e) {
-                // Constraint doesn't exist, continue
+            // Database-agnostic FK constraint guard
+            if (DB::getDriverName() === 'pgsql') {
+                // Postgres: use IF EXISTS
+                DB::statement('ALTER TABLE orders DROP CONSTRAINT IF EXISTS orders_user_id_foreign');
+            } else {
+                // SQLite/MySQL: use try-catch
+                try {
+                    $table->dropForeign(['user_id']);
+                } catch (\Exception $e) {
+                    // Constraint doesn't exist, continue
+                }
             }
             
             // Add FK constraint
@@ -27,17 +33,23 @@ return new class extends Migration
 
         // Add FKs to order_items table  
         Schema::table('order_items', function (Blueprint $table) {
-            // Drop constraints if exist (database-agnostic way)
-            try {
-                $table->dropForeign(['order_id']);
-            } catch (\Exception $e) {
-                // Constraint doesn't exist, continue
-            }
-            
-            try {
-                $table->dropForeign(['product_id']);
-            } catch (\Exception $e) {
-                // Constraint doesn't exist, continue
+            // Database-agnostic FK constraint guards
+            if (DB::getDriverName() === 'pgsql') {
+                // Postgres: use IF EXISTS
+                DB::statement('ALTER TABLE order_items DROP CONSTRAINT IF EXISTS order_items_order_id_foreign');
+                DB::statement('ALTER TABLE order_items DROP CONSTRAINT IF EXISTS order_items_product_id_foreign');
+            } else {
+                // SQLite/MySQL: use try-catch
+                try {
+                    $table->dropForeign(['order_id']);
+                } catch (\Exception $e) {
+                    // Constraint doesn't exist, continue
+                }
+                try {
+                    $table->dropForeign(['product_id']);
+                } catch (\Exception $e) {
+                    // Constraint doesn't exist, continue
+                }
             }
             
             // Add FK constraints

--- a/backend/database/migrations/2025_08_24_193156_update_users_role_to_enum.php
+++ b/backend/database/migrations/2025_08_24_193156_update_users_role_to_enum.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // Guard: check if role column exists
+            if (Schema::hasColumn('users', 'role')) {
+                // Drop existing string role column
+                $table->dropColumn('role');
+            }
+        });
+        
+        // Add enum role column
+        Schema::table('users', function (Blueprint $table) {
+            $table->enum('role', ['admin', 'producer', 'consumer'])->default('consumer')->after('email_verified_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'role')) {
+                $table->dropColumn('role');
+            }
+        });
+        
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('consumer')->after('email_verified_at');
+        });
+    }
+};

--- a/backend/database/migrations/2025_08_24_193449_add_slug_to_producers_table.php
+++ b/backend/database/migrations/2025_08_24_193449_add_slug_to_producers_table.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('producers', function (Blueprint $table) {
+            // Guard: check if slug column doesn't exist
+            if (!Schema::hasColumn('producers', 'slug')) {
+                // Add as nullable first
+                $table->string('slug')->nullable()->after('name');
+            }
+        });
+        
+        // Populate existing rows with slugs
+        $producers = DB::table('producers')->whereNull('slug')->get();
+        foreach ($producers as $producer) {
+            $baseSlug = Str::slug($producer->name);
+            $slug = $this->generateUniqueSlug($baseSlug);
+            DB::table('producers')->where('id', $producer->id)->update(['slug' => $slug]);
+        }
+        
+        // Now make slug NOT NULL and unique
+        Schema::table('producers', function (Blueprint $table) {
+            $table->string('slug')->nullable(false)->unique()->change();
+        });
+    }
+    
+    private function generateUniqueSlug(string $baseSlug): string
+    {
+        $slug = $baseSlug;
+        $counter = 1;
+        
+        while (DB::table('producers')->where('slug', $slug)->exists()) {
+            $slug = $baseSlug . '-' . $counter;
+            $counter++;
+        }
+        
+        return $slug;
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('producers', function (Blueprint $table) {
+            if (Schema::hasColumn('producers', 'slug')) {
+                $table->dropColumn('slug');
+            }
+        });
+    }
+};

--- a/backend/database/migrations/2025_08_24_193813_add_missing_fields_to_products_table.php
+++ b/backend/database/migrations/2025_08_24_193813_add_missing_fields_to_products_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            // Guard: check if columns don't exist
+            if (!Schema::hasColumn('products', 'weight_per_unit')) {
+                $table->decimal('weight_per_unit', 10, 3)->nullable()->after('price');
+            }
+            if (!Schema::hasColumn('products', 'is_organic')) {
+                $table->boolean('is_organic')->default(false)->after('category');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            if (Schema::hasColumn('products', 'weight_per_unit')) {
+                $table->dropColumn('weight_per_unit');
+            }
+            if (Schema::hasColumn('products', 'is_organic')) {
+                $table->dropColumn('is_organic');
+            }
+        });
+    }
+};

--- a/backend/database/migrations/2025_08_24_193837_add_foreign_key_to_products_table.php
+++ b/backend/database/migrations/2025_08_24_193837_add_foreign_key_to_products_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            // Database-agnostic FK constraint guard
+            if (DB::getDriverName() === 'pgsql') {
+                // Postgres: use IF EXISTS
+                DB::statement('ALTER TABLE products DROP CONSTRAINT IF EXISTS products_producer_id_foreign');
+            } else {
+                // SQLite/MySQL: use try-catch
+                try {
+                    $table->dropForeign(['producer_id']);
+                } catch (\Exception $e) {
+                    // Constraint doesn't exist, continue
+                }
+            }
+            
+            // Add FK constraint
+            $table->foreign('producer_id')->references('id')->on('producers')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropForeign(['producer_id']);
+        });
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,9 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -13,16 +16,87 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        // Create users with specific roles
+        $admin = User::factory()->admin()->create([
+            'name' => 'Admin User',
+            'email' => 'admin@example.com',
+        ]);
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $producer = User::factory()->producer()->create([
+            'name' => 'Producer User', 
+            'email' => 'producer@example.com',
+        ]);
+
+        $consumer = User::factory()->consumer()->create([
+            'name' => 'Consumer User',
+            'email' => 'consumer@example.com',
         ]);
 
         $this->call([
             ProducerSeeder::class,
             ProductSeeder::class,
         ]);
+
+        // Create demo orders after products exist
+        $this->createDemoOrders($consumer);
+    }
+
+    private function createDemoOrders(User $consumer): void
+    {
+        $products = Product::take(3)->get();
+        
+        if ($products->count() > 0) {
+            // Create first demo order
+            $order1 = Order::create([
+                'user_id' => $consumer->id,
+                'subtotal' => 45.50,
+                'tax_amount' => 4.55,
+                'shipping_amount' => 5.00,
+                'total_amount' => 55.05,
+                'payment_status' => 'paid',
+                'status' => 'completed',
+                'shipping_method' => 'HOME',
+            ]);
+
+            // Add order items
+            foreach ($products->take(2) as $index => $product) {
+                $quantity = $index + 1;
+                $unitPrice = $product->price ?? 15.00;
+                OrderItem::create([
+                    'order_id' => $order1->id,
+                    'product_id' => $product->id,
+                    'quantity' => $quantity,
+                    'unit_price' => $unitPrice,
+                    'total_price' => $quantity * $unitPrice,
+                    'product_name' => $product->name,
+                    'product_unit' => $product->unit ?? 'kg',
+                ]);
+            }
+
+            // Create second demo order (pending)
+            $order2 = Order::create([
+                'user_id' => $consumer->id,
+                'subtotal' => 25.00,
+                'tax_amount' => 2.50,
+                'shipping_amount' => 3.00,
+                'total_amount' => 30.50,
+                'payment_status' => 'pending',
+                'status' => 'pending',
+                'shipping_method' => 'HOME',
+            ]);
+
+            if ($products->count() > 2) {
+                $product = $products->get(2);
+                OrderItem::create([
+                    'order_id' => $order2->id,
+                    'product_id' => $product->id,
+                    'quantity' => 1,
+                    'unit_price' => $product->price ?? 25.00,
+                    'total_price' => $product->price ?? 25.00,
+                    'product_name' => $product->name,
+                    'product_unit' => $product->unit ?? 'kg',
+                ]);
+            }
+        }
     }
 }

--- a/backend/database/seeders/ProducerSeeder.php
+++ b/backend/database/seeders/ProducerSeeder.php
@@ -5,6 +5,8 @@ namespace Database\Seeders;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use App\Models\User;
 
 class ProducerSeeder extends Seeder
 {
@@ -13,9 +15,19 @@ class ProducerSeeder extends Seeder
      */
     public function run(): void
     {
+        // Get the producer user created in DatabaseSeeder
+        $producerUser = User::where('email', 'producer@example.com')->first();
+        
+        if (!$producerUser) {
+            $this->command->warn('Producer user not found. Skipping producer seeding.');
+            return;
+        }
+        
         $producers = [
             [
+                'user_id' => $producerUser->id,
                 'name' => 'Green Farm Co.',
+                'slug' => $this->generateUniqueSlug('green-farm-co'),
                 'business_name' => 'Green Farm Company Ltd',
                 'description' => 'Organic vegetables and fruits from local farms',
                 'location' => 'Athens, Greece',
@@ -25,33 +37,25 @@ class ProducerSeeder extends Seeder
                 'status' => 'active',
                 'created_at' => now(),
                 'updated_at' => now(),
-            ],
-            [
-                'name' => 'Mediterranean Harvest',
-                'business_name' => 'Mediterranean Harvest SA',
-                'description' => 'Traditional Greek products and olive oil',
-                'location' => 'Crete, Greece',
-                'phone' => '+30 28210 98765',
-                'email' => 'contact@medharvest.gr',
-                'website' => 'https://medharvest.gr',
-                'status' => 'active',
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
-            [
-                'name' => 'Fresh Valley',
-                'business_name' => null,
-                'description' => 'Seasonal fruits and vegetables',
-                'location' => 'Thessaloniki, Greece',
-                'phone' => '+30 2310 555444',
-                'email' => 'orders@freshvalley.gr',
-                'website' => null,
-                'status' => 'active',
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
+            ]
         ];
 
         DB::table('producers')->insert($producers);
+    }
+    
+    /**
+     * Generate collision-safe unique slug
+     */
+    private function generateUniqueSlug(string $baseSlug): string
+    {
+        $slug = $baseSlug;
+        $counter = 1;
+        
+        while (DB::table('producers')->where('slug', $slug)->exists()) {
+            $slug = $baseSlug . '-' . $counter;
+            $counter++;
+        }
+        
+        return $slug;
     }
 }

--- a/backend/database/seeders/ProductSeeder.php
+++ b/backend/database/seeders/ProductSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use App\Models\Producer;
 
 class ProductSeeder extends Seeder
 {
@@ -14,74 +15,63 @@ class ProductSeeder extends Seeder
      */
     public function run(): void
     {
+        // Get the first producer (created in ProducerSeeder)
+        $producer = Producer::first();
+        
+        if (!$producer) {
+            $this->command->warn('No producers found. Skipping product seeding.');
+            return;
+        }
+        
         $products = [
             [
-                'producer_id' => 1,
+                'producer_id' => $producer->id,
                 'name' => 'Organic Tomatoes',
                 'slug' => Str::slug('Organic Tomatoes'),
                 'description' => 'Fresh organic tomatoes grown without pesticides',
                 'price' => 3.50,
+                'weight_per_unit' => 1.000,
                 'unit' => 'kg',
                 'stock' => 100,
                 'category' => 'Vegetables',
+                'is_organic' => true,
                 'image_url' => 'https://images.unsplash.com/photo-1592841200221-a6898f307baa',
                 'status' => 'available',
+                'is_active' => true,
                 'created_at' => now(),
                 'updated_at' => now(),
             ],
             [
-                'producer_id' => 1,
+                'producer_id' => $producer->id,
                 'name' => 'Fresh Lettuce',
                 'slug' => Str::slug('Fresh Lettuce'),
                 'description' => 'Crispy fresh lettuce perfect for salads',
                 'price' => 2.25,
+                'weight_per_unit' => 0.300,
                 'unit' => 'piece',
                 'stock' => 50,
                 'category' => 'Vegetables',
+                'is_organic' => false,
                 'image_url' => 'https://images.unsplash.com/photo-1622206151226-18ca2c9ab4a1',
                 'status' => 'available',
+                'is_active' => true,
                 'created_at' => now(),
                 'updated_at' => now(),
             ],
             [
-                'producer_id' => 2,
+                'producer_id' => $producer->id,
                 'name' => 'Extra Virgin Olive Oil',
                 'slug' => Str::slug('Extra Virgin Olive Oil'),
                 'description' => 'Premium Greek olive oil from Crete',
                 'price' => 12.00,
+                'weight_per_unit' => 0.500,
                 'unit' => 'bottle',
                 'stock' => 25,
                 'category' => 'Oil',
+                'is_organic' => true,
                 'image_url' => 'https://images.unsplash.com/photo-1474979266404-7eaacbcd87c5',
                 'status' => 'available',
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
-            [
-                'producer_id' => 2,
-                'name' => 'Greek Honey',
-                'slug' => Str::slug('Greek Honey'),
-                'description' => 'Pure honey from Mediterranean flowers',
-                'price' => 8.75,
-                'unit' => 'jar',
-                'stock' => 30,
-                'category' => 'Honey',
-                'image_url' => 'https://images.unsplash.com/photo-1558642452-9d2a7deb7f62',
-                'status' => 'available',
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
-            [
-                'producer_id' => 3,
-                'name' => 'Seasonal Apples',
-                'slug' => Str::slug('Seasonal Apples'),
-                'description' => 'Fresh seasonal apples from local orchards',
-                'price' => 4.20,
-                'unit' => 'kg',
-                'stock' => 0,
-                'category' => 'Fruits',
-                'image_url' => 'https://images.unsplash.com/photo-1568702846914-96b305d2aaeb',
-                'status' => 'seasonal',
+                'is_active' => true,
                 'created_at' => now(),
                 'updated_at' => now(),
             ],

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -25,6 +25,20 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
+// Public API v1 routes
+Route::prefix('v1')->group(function () {
+    // Products (public)
+    Route::get('products', [App\Http\Controllers\Api\ProductController::class, 'index']);
+    Route::get('products/{product}', [App\Http\Controllers\Api\ProductController::class, 'show']);
+    
+    // Orders (authenticated)
+    Route::middleware('auth:sanctum')->group(function () {
+        Route::get('orders', [App\Http\Controllers\Api\OrderController::class, 'index']);
+        Route::post('orders', [App\Http\Controllers\Api\OrderController::class, 'store']);
+        Route::get('orders/{order}', [App\Http\Controllers\Api\OrderController::class, 'show']);
+    });
+});
+
 // Producer API routes
 Route::middleware('auth:sanctum')->prefix('v1/producer')->group(function () {
     // Product management

--- a/backend/tests/Feature/CoreDomainSmokeTest.php
+++ b/backend/tests/Feature/CoreDomainSmokeTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Producer;
+use App\Models\Product;
+
+class CoreDomainSmokeTest extends TestCase
+{
+    use RefreshDatabase;
+    
+    /**
+     * Test health check endpoint returns 200
+     */
+    public function test_health_check_returns_success(): void
+    {
+        $response = $this->get('/api/health');
+        
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => 'ok',
+                'database' => 'connected',
+            ]);
+    }
+    
+    /**
+     * Test products index returns 200 with JSON array
+     */
+    public function test_products_index_returns_json_array(): void
+    {
+        // Create test data
+        $producer = Producer::factory()->create();
+        Product::factory()->create(['producer_id' => $producer->id]);
+        Product::factory()->create(['producer_id' => $producer->id]);
+        
+        $response = $this->get('/api/v1/products');
+        
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                '*' => [
+                    'id',
+                    'name',
+                    'slug',
+                    'price',
+                    'unit',
+                    'status',
+                    'producer' => [
+                        'id',
+                        'name',
+                    ]
+                ]
+            ]);
+    }
+    
+    /**
+     * Test create order happy path returns 201
+     */
+    public function test_create_order_happy_path(): void
+    {
+        // Create test data
+        $user = User::factory()->consumer()->create();
+        $producer = Producer::factory()->create();
+        $product = Product::factory()->create([
+            'producer_id' => $producer->id,
+            'price' => 10.00,
+            'stock' => 100,
+        ]);
+        
+        $orderData = [
+            'items' => [
+                [
+                    'product_id' => $product->id,
+                    'quantity' => 2,
+                ]
+            ],
+            'shipping_method' => 'HOME',
+            'notes' => 'Test order',
+        ];
+        
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/v1/orders', $orderData);
+        
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'id',
+                'user_id',
+                'subtotal',
+                'tax_amount',
+                'shipping_amount',
+                'total_amount',
+                'payment_status',
+                'status',
+                'order_items' => [
+                    '*' => [
+                        'id',
+                        'product_id',
+                        'quantity',
+                        'unit_price',
+                        'total_price',
+                        'product_name',
+                    ]
+                ]
+            ]);
+    }
+}


### PR DESCRIPTION
This PR introduces Core Domain v1 for Project-Dixis:
- Users (role enum: admin, producer, consumer)
- Producers (unique NOT NULL slug + collision-safe seeding)
- Products (unit, weight_per_unit, category, is_organic, status) + later FKs
- Orders & OrderItems (enums, totals, shipping_method nullable default HOME)
- Postgres-safe migrations (no inline FKs; later guarded FK migrations)
- Minimal seeders aligned with constraints
- Feature smoke tests: health, products index, create order
CI: green on branch; ready to merge.