### PR TITLE
feat(api): add public producers endpoints and enhance products API

### DIFF
--- a/backend/app/Http/Controllers/Public/ProducerController.php
+++ b/backend/app/Http/Controllers/Public/ProducerController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Http\Controllers\Public;
+
+use App\Http\Controllers\Controller;
+use App\Models\Producer;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class ProducerController extends Controller
+{
+    /**
+     * Display a listing of active producers.
+     * 
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = min($request->get('per_page', 20), 100);
+        $search = $request->get('search');
+        $sort = $request->get('sort', 'name');
+        $direction = $request->get('dir', 'asc');
+        
+        // Validate sort parameters
+        $allowedSorts = ['name', 'location', 'created_at'];
+        $sort = in_array($sort, $allowedSorts) ? $sort : 'name';
+        $direction = in_array($direction, ['asc', 'desc']) ? $direction : 'asc';
+        
+        $query = Producer::query()
+            ->with(['user:id,name,email'])
+            ->where('is_active', true);
+        
+        // Apply search filter
+        if ($search) {
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'ILIKE', "%{$search}%")
+                  ->orWhere('description', 'ILIKE', "%{$search}%")
+                  ->orWhere('location', 'ILIKE', "%{$search}%")
+                  ->orWhereHas('user', function ($userQuery) use ($search) {
+                      $userQuery->where('name', 'ILIKE', "%{$search}%");
+                  });
+            });
+        }
+        
+        // Apply sorting
+        $query->orderBy($sort, $direction);
+        
+        $producers = $query->paginate($perPage);
+        
+        // Transform the data to include only public information
+        $producers->getCollection()->transform(function ($producer) {
+            return [
+                'id' => $producer->id,
+                'name' => $producer->name,
+                'description' => $producer->description,
+                'location' => $producer->location,
+                'slug' => $producer->slug,
+                'is_active' => $producer->is_active,
+                'created_at' => $producer->created_at,
+                'updated_at' => $producer->updated_at,
+                // Optional: Include product count
+                'products_count' => $producer->products()->where('is_active', true)->count(),
+            ];
+        });
+        
+        return response()->json($producers);
+    }
+    
+    /**
+     * Display the specified producer.
+     * 
+     * @param int $id
+     * @return JsonResponse
+     */
+    public function show(int $id): JsonResponse
+    {
+        $producer = Producer::with(['user:id,name,email'])
+            ->where('is_active', true)
+            ->findOrFail($id);
+        
+        // Load active products with their categories and images
+        $producer->load(['products' => function ($query) {
+            $query->where('is_active', true)
+                  ->with(['categories:id,name,slug', 'images'])
+                  ->orderBy('name');
+        }]);
+        
+        $data = [
+            'id' => $producer->id,
+            'name' => $producer->name,
+            'description' => $producer->description,
+            'location' => $producer->location,
+            'slug' => $producer->slug,
+            'is_active' => $producer->is_active,
+            'created_at' => $producer->created_at,
+            'updated_at' => $producer->updated_at,
+            'products' => $producer->products->map(function ($product) {
+                return [
+                    'id' => $product->id,
+                    'name' => $product->name,
+                    'description' => $product->description,
+                    'price' => number_format($product->price, 2),
+                    'unit' => $product->unit,
+                    'stock' => $product->stock,
+                    'is_organic' => $product->is_organic,
+                    'categories' => $product->categories,
+                    'images' => $product->images->map(function ($image) {
+                        return [
+                            'id' => $image->id,
+                            'url' => $image->url,
+                            'is_primary' => $image->is_primary,
+                            'sort_order' => $image->sort_order,
+                        ];
+                    }),
+                    'created_at' => $product->created_at,
+                    'updated_at' => $product->updated_at,
+                ];
+            }),
+            'total_active_products' => $producer->products->count(),
+        ];
+        
+        return response()->json($data);
+    }
+}

--- a/backend/app/Http/Controllers/Public/ProductController.php
+++ b/backend/app/Http/Controllers/Public/ProductController.php
@@ -82,6 +82,26 @@ class ProductController extends Controller
         $perPage = min($request->get('per_page', 15), 100);
         $products = $query->paginate($perPage);
 
+        // Transform the data to ensure consistent producer information
+        $products->getCollection()->transform(function ($product) {
+            $data = $product->toArray();
+            
+            // Ensure producer information is properly formatted
+            if ($product->producer) {
+                $data['producer'] = [
+                    'id' => $product->producer->id,
+                    'name' => $product->producer->name,
+                    'slug' => $product->producer->slug,
+                    'location' => $product->producer->location,
+                ];
+            }
+            
+            // Format price consistently
+            $data['price'] = number_format($product->price, 2);
+            
+            return $data;
+        });
+
         return response()->json($products);
     }
 
@@ -96,6 +116,22 @@ class ProductController extends Controller
             ->where('is_active', true)
             ->findOrFail($id);
 
-        return response()->json($product);
+        $data = $product->toArray();
+        
+        // Ensure producer information is properly formatted
+        if ($product->producer) {
+            $data['producer'] = [
+                'id' => $product->producer->id,
+                'name' => $product->producer->name,
+                'slug' => $product->producer->slug,
+                'location' => $product->producer->location,
+                'description' => $product->producer->description,
+            ];
+        }
+        
+        // Format price consistently
+        $data['price'] = number_format($product->price, 2);
+
+        return response()->json($data);
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -48,6 +48,10 @@ Route::prefix('v1')->group(function () {
     Route::prefix('public')->group(function () {
         Route::get('products', [App\Http\Controllers\Public\ProductController::class, 'index']);
         Route::get('products/{id}', [App\Http\Controllers\Public\ProductController::class, 'show']);
+        
+        // Public Producers API
+        Route::get('producers', [App\Http\Controllers\Public\ProducerController::class, 'index']);
+        Route::get('producers/{id}', [App\Http\Controllers\Public\ProducerController::class, 'show']);
     });
     
     // Cart (authenticated)

--- a/backend/tests/Feature/Public/ProducersApiTest.php
+++ b/backend/tests/Feature/Public/ProducersApiTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Public;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Producer;
+use App\Models\Product;
+
+class ProducersApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void {
+        parent::setUp();
+        // Αν υπάρχει DatabaseSeeder, τρέξε τον για demo data
+        $this->artisan('migrate');
+        $this->seed();
+    }
+
+    public function test_list_active_producers_returns_paginated_results(): void
+    {
+        $resp = $this->getJson('/api/v1/public/producers?per_page=5');
+        $resp->assertStatus(200)
+             ->assertJsonStructure(['data', 'links', 'current_page', 'per_page', 'total']);
+    }
+
+    public function test_show_producer_returns_details_with_products(): void
+    {
+        $producer = Producer::query()->first();
+        $resp = $this->getJson('/api/v1/public/producers/'.$producer->id);
+        $resp->assertStatus(200)
+             ->assertJsonStructure(['id','name','slug','products']);
+    }
+
+    public function test_products_list_includes_producer_info(): void
+    {
+        $resp = $this->getJson('/api/v1/public/products?per_page=5');
+        $resp->assertStatus(200)
+             ->assertJsonStructure(['data','links','current_page','per_page','total']);
+        $first = $resp->json('data')[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertArrayHasKey('producer', $first);
+        $this->assertIsArray($first['producer']);
+        $this->assertArrayHasKey('id', $first['producer']);
+        $this->assertArrayHasKey('name', $first['producer']);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive public producers API endpoints and enhances the existing products API to include producer information.

## New Endpoints

**Public Producers API:**
- GET /api/v1/public/producers - List active producers with filtering
- GET /api/v1/public/producers/{id} - Get producer details with products

**Enhanced Products API:**
- GET /api/v1/public/products - Now includes formatted producer info
- GET /api/v1/public/products/{id} - Enhanced with producer details

## Features

**Producers Listing:**
- Search by name, description, location
- Sort by name, location, created_at
- Pagination (max 100 per page)
- Active producers only
- Product count included

**Producer Details:**
- Full producer information
- List of active products with categories and images
- Product analytics (total active products)

**Enhanced Products:**
- Consistent producer info formatting
- Producer name, slug, location included
- Price formatting (decimal precision)

## Ready for Frontend Integration

These endpoints provide all necessary data for:
- Producer directory page
- Producer profile pages  
- Product listings with producer context
- Search and filtering functionality

Perfect foundation for marketplace frontend!