### PR TITLE
test(api): group ProducersApiTest under #[Group('api')]

### DIFF
--- a/backend/tests/Feature/Public/ProducersApiTest.php
+++ b/backend/tests/Feature/Public/ProducersApiTest.php
@@ -6,7 +6,9 @@ use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\Producer;
 use App\Models\Product;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('api')]
 class ProducersApiTest extends TestCase
 {
     use RefreshDatabase;


### PR DESCRIPTION
Add #[Group('api')] attribute to ProducersApiTest for better test filtering and organization.