### PR TITLE
test(backend): make order total assertion tolerant to float precision

### DIFF
--- a/backend/tests/Feature/Public/OrdersDemoTest.php
+++ b/backend/tests/Feature/Public/OrdersDemoTest.php
@@ -40,15 +40,16 @@ class OrdersDemoTest extends TestCase
         $this->assertLessThanOrEqual(4, $itemCount, 'Order should have at most 4 items');
         
         // Assert total calculation is correct (subtotal + shipping_cost = total)
+        // Use delta due to floating point arithmetic; business rounding is handled at persistence
         $expectedTotal = $order->subtotal + $order->shipping_cost;
-        $this->assertEquals($expectedTotal, $order->total, 'Order total should equal subtotal + shipping_cost');
+        $this->assertEqualsWithDelta($expectedTotal, $order->total, 0.01, 'Order total should equal subtotal + shipping_cost');
         
         // Assert order items have valid data
         foreach ($order->orderItems as $item) {
             $this->assertNotNull($item->product_id, 'Order item should have a product_id');
             $this->assertGreaterThan(0, $item->quantity, 'Order item should have positive quantity');
             $this->assertGreaterThan(0, $item->unit_price, 'Order item should have positive unit_price');
-            $this->assertEquals($item->quantity * $item->unit_price, $item->total_price, 'Item total_price should equal quantity * unit_price');
+            $this->assertEqualsWithDelta($item->quantity * $item->unit_price, $item->total_price, 0.01, 'Item total_price should equal quantity * unit_price');
         }
     }
 


### PR DESCRIPTION
## Problem
Backend CI failing on OrdersDemoTest due to floating point precision:
```
FAILED: Order total should equal subtotal + shipping_cost
Failed asserting that '15.12' matches expected 15.120000000000001.
```

## Solution
Replace exact equality assertions with delta-tolerance assertions:
- `assertEquals()` → `assertEqualsWithDelta()` with 0.01 tolerance
- Applied to both order total and order item calculations

## Changes
- **1 file modified**: `backend/tests/Feature/Public/OrdersDemoTest.php` (~5 LOC)
- Added explanatory comment about floating point arithmetic
- Business logic unchanged - test-only fix

## Acceptance Criteria
- [x] OrdersDemoTest passes locally (`php artisan test --filter=OrdersDemoTest`)
- [x] Backend CI check passes
- [x] No functional changes to order calculation logic
- [x] Delta tolerance of 0.01 (1 cent) appropriate for currency

## Evidence
**Before Fix:**
```
⨯ order items relations                                                0.28s  
Failed asserting that '15.12' matches expected 15.120000000000001.
```

**After Fix:**
```
✓ orders seeded count                                                  0.83s  
✓ order items relations                                                0.07s  
✓ order statuses are valid                                             0.05s  
Tests:    3 passed (49 assertions)
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>