### PR TITLE
docs: validate paths-ignore on main (2025-09-21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,4 +290,4 @@ This project is open source and available under the [MIT License](LICENSE).
 
 ---
 
-**🏆 Production-ready Laravel 11 template with PostgreSQL CI/CD**
+**🏆 Production-ready Laravel 11 template with PostgreSQL CI/CD**- Docs-only validation 2025-09-21T12:00:57+03:00

--- a/docs/reports/2025-09-21/CI-DOCS-ONLY-VALIDATION.md
+++ b/docs/reports/2025-09-21/CI-DOCS-ONLY-VALIDATION.md
@@ -1,0 +1,11 @@
+# CI Docs-only Validation (2025-09-21)
+
+This file tests docs-only change behavior against main branch.
+
+Expected behavior:
+- **Without guardrails**: All workflows will run (current main)
+- **With guardrails**: Workflows should skip due to paths-ignore
+
+Test purpose: Validate paths-ignore functionality works correctly.
+
+Created: 2025-09-21T12:00:57+03:00


### PR DESCRIPTION
Docs-only change to confirm workflows behavior. 

Since PR #216 (guardrails) is still pending merge, this tests against current main branch.

**Expected**: All workflows will run (no paths-ignore in current main)
**Goal**: After PR #216 merges, docs-only changes should skip workflows entirely.

**Changes**: 
- README.md: Added timestamp line
- docs/reports/: Created validation file

**Test Type**: Documentation validation for CI noise guardrails