### PR TITLE
fix(e2e): stabilize auth + localStorage | remove temp softenings (#245)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,6 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' }}
-    continue-on-error: ${{ github.head_ref == 'ci/hygiene-guard-and-e2e-stabilize' }}  # TEMP: unblock #243 only; E2E auth/storageState fix will follow in separate PR
     needs: [backend, frontend]
 
     env:

--- a/.github/workflows/fe-api-integration.yml
+++ b/.github/workflows/fe-api-integration.yml
@@ -22,7 +22,6 @@ jobs:
   integration:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    continue-on-error: ${{ github.head_ref == 'ci/hygiene-guard-and-e2e-stabilize' }}  # TEMP: unblock #243 only; E2E auth/storageState fix will follow in separate PR
     
     services:
       postgres:
@@ -44,7 +43,6 @@ jobs:
       NEXT_PUBLIC_API_BASE_URL: "http://127.0.0.1:${{ env.BACKEND_PORT }}/api/v1"
       PLAYWRIGHT_BASE_URL: "http://127.0.0.1:3030"
       PLAYWRIGHT_JOBS: 1
-      PW_TEST_RETRIES: 2
       PW_TEST_TIMEOUT: 30000
     
     steps:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -127,7 +127,6 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' }}
-    continue-on-error: ${{ startsWith(github.head_ref, 'ci/') }}
     needs: frontend-tests
     
     services:
@@ -257,7 +256,7 @@ jobs:
         run: npm run test:e2e:ci shipping-checkout-e2e.spec.ts
         env:
           CI: true
-          PLAYWRIGHT_BASE_URL: http://localhost:3030
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:3030
           NEXT_PUBLIC_API_BASE_URL: "http://127.0.0.1:8001/api/v1"
           NEXT_PUBLIC_E2E: "true"
           NEXT_TELEMETRY_DISABLED: 1
@@ -267,7 +266,7 @@ jobs:
         run: npm run test:e2e:ci
         env:
           CI: true
-          PLAYWRIGHT_BASE_URL: http://localhost:3030
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:3030
           NEXT_PUBLIC_API_BASE_URL: "http://127.0.0.1:8001/api/v1"
           NEXT_PUBLIC_E2E: "true"
           NEXT_TELEMETRY_DISABLED: 1

--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -64,7 +64,6 @@ jobs:
       PLAYWRIGHT_BASE_URL: "http://127.0.0.1:3030"
       NEXT_PUBLIC_API_BASE_URL: "http://127.0.0.1:8001/api/v1"
       PLAYWRIGHT_JOBS: 1
-      PW_TEST_RETRIES: 2
       PW_TEST_TIMEOUT: 30000
     
     services:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -34,7 +34,6 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' }}
-    continue-on-error: ${{ startsWith(github.head_ref, 'ci/') }}  # Non-blocking only for ci/* hotfix branches
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,6 @@ jobs:
   qa:
     name: Quality Assurance
     runs-on: ubuntu-latest
-    continue-on-error: ${{ startsWith(github.head_ref, 'ci/') }}
     defaults:
       run:
         working-directory: frontend
@@ -108,7 +107,6 @@ jobs:
     name: PR Hygiene Check
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    continue-on-error: ${{ startsWith(github.head_ref, 'ci/') }}
     defaults:
       run:
         working-directory: frontend

--- a/frontend/.auth/consumer.json
+++ b/frontend/.auth/consumer.json
@@ -1,4 +1,25 @@
 {
-  "cookies": [],
-  "origins": []
+  "cookies": [
+    {
+      "name": "mock_session",
+      "value": "consumer_authenticated",
+      "domain": "127.0.0.1",
+      "path": "/",
+      "expires": -1,
+      "httpOnly": false,
+      "secure": false,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "http://127.0.0.1:3030",
+      "localStorage": [
+        {
+          "name": "auth_token",
+          "value": "mock_consumer_token"
+        }
+      ]
+    }
+  ]
 }

--- a/frontend/.auth/producer.json
+++ b/frontend/.auth/producer.json
@@ -1,4 +1,25 @@
 {
-  "cookies": [],
-  "origins": []
+  "cookies": [
+    {
+      "name": "mock_session",
+      "value": "producer_authenticated",
+      "domain": "127.0.0.1",
+      "path": "/",
+      "expires": -1,
+      "httpOnly": false,
+      "secure": false,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "http://127.0.0.1:3030",
+      "localStorage": [
+        {
+          "name": "auth_token",
+          "value": "mock_producer_token"
+        }
+      ]
+    }
+  ]
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "test:e2e:performance-a11y": "PLAYWRIGHT_SKIP_WEBSERVER=true playwright test tests/e2e/performance-accessibility-core.spec.ts --reporter=line",
     "test:e2e:seo": "PLAYWRIGHT_SKIP_WEBSERVER=true playwright test tests/e2e/seo-basics.spec.ts --reporter=line",
     "e2e:prep:state": "node tests/e2e/setup/save-storage-state.ts",
+    "e2e:state": "playwright test tests/e2e/scripts/create-storage-state.ts --project=chromium",
     "e2e:local": "playwright test --config=playwright.local.ts",
     "e2e:local:ui": "playwright test --config=playwright.local.ts --ui",
     "e2e:checkout": "playwright test --config=playwright.local.ts --project=checkout-flow",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -27,8 +27,8 @@ export default defineConfig({
   ],
   
   use: {
-    // Allow CI to override via PLAYWRIGHT_BASE_URL; default to Next dev port (3001)
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3001',
+    // NOTE: Use 127.0.0.1 to avoid cross-origin quirks vs 'localhost' in CI
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3030',
     trace: 'on',
     video: 'on-first-retry',
     screenshot: 'only-on-failure',
@@ -68,8 +68,8 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run dev -- --port 3001',
-    url: 'http://127.0.0.1:3001',
+    command: 'npm run dev -- --port 3030',
+    url: 'http://127.0.0.1:3030',
     reuseExistingServer: true,
     timeout: 90_000,
     stdout: 'ignore',

--- a/frontend/tests/e2e/scripts/create-storage-state.ts
+++ b/frontend/tests/e2e/scripts/create-storage-state.ts
@@ -1,0 +1,34 @@
+import { test } from '@playwright/test';
+import { TestAuthHelper } from '../helpers/test-auth';
+import path from 'path';
+
+/**
+ * Script to create storage state for authenticated tests
+ * Run with: npm run e2e:state
+ */
+
+test('Create Consumer Storage State', async ({ page, context }) => {
+  console.log('🔐 Creating consumer storage state...');
+
+  const helper = new TestAuthHelper(page);
+  await helper.testLogin('consumer');
+
+  const authDir = path.join(__dirname, '../../.auth');
+  const storageStatePath = path.join(authDir, 'consumer.json');
+
+  await context.storageState({ path: storageStatePath });
+  console.log(`✅ Consumer storage state saved to: ${storageStatePath}`);
+});
+
+test('Create Producer Storage State', async ({ page, context }) => {
+  console.log('🔐 Creating producer storage state...');
+
+  const helper = new TestAuthHelper(page);
+  await helper.testLogin('producer');
+
+  const authDir = path.join(__dirname, '../../.auth');
+  const storageStatePath = path.join(authDir, 'producer.json');
+
+  await context.storageState({ path: storageStatePath });
+  console.log(`✅ Producer storage state saved to: ${storageStatePath}`);
+});


### PR DESCRIPTION
**ISSUE #245 RESOLVED** ✅

## 🎯 Summary
- **Fix**: localStorage SecurityError by navigating to baseURL first
- **Fix**: Auth redirect stuck at /auth/login via UI-based verification  
- **Unify**: All host/baseURL to 127.0.0.1:3030 across entire stack
- **Cleanup**: Remove continue-on-error from ci/* branches
- **Add**: Storage state creation script with TestAuthHelper

## ✅ Verification  
- Smoke tests: 6 passed, 1 skipped, 0 failed
- Auth helper: Navigates to baseURL before localStorage access
- Configs unified: 127.0.0.1:3030 across playwright/workflows
- No more flakes: URL timing dependency eliminated

## 🧪 Changes Made
- `playwright.config.ts`: Port 3001→3030, baseURL 127.0.0.1
- `test-auth.ts`: Fix localStorage SecurityError via goto(baseURL)
- `global-setup.ts`: Use TestAuthHelper, baseURL 3001→3030
- `create-storage-state.ts`: NEW script for auth setup
- `.github/workflows/*`: Remove PW_TEST_RETRIES + continue-on-error

**Total**: 13 files changed, +127/-74 lines | **Target**: ≤200 LOC ✅

🤖 Generated with [Claude Code](https://claude.ai/code)