### PR TITLE
fix(ci): add docs-only fastpath to quality-gates workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -307,9 +307,9 @@ jobs:
             echo "DOCS_ONLY=false" >> $GITHUB_ENV
           fi
 
-      - name: Docs-only fastpath: mark success
+      - name: "Docs-only fastpath: mark success"
         if: env.DOCS_ONLY == 'true'
-        run: echo "✅ Docs-only PR: skipping dependent job checks; quality-gates success via fastpath."
+        run: echo "✅ Docs-only PR - skipping dependent job checks, quality-gates success via fastpath."
 
       - name: Check all gates passed
         if: env.DOCS_ONLY != 'true'


### PR DESCRIPTION
## Summary
- Fixes issue where docs-only PRs were unmergeable due to missing `quality-gates` check
- Removes path filters from `pr.yml` to run on all PRs including docs-only
- Adds docs-only detection with fastpath optimization to skip heavy CI steps

## Changes
- **Removed**: Path filters from `on.pull_request.paths` in pr.yml
- **Added**: Docs-only detection in `quality-gates` job with fastpath success
- **Added**: Docs-only detection in `qa` job with conditional heavy steps
- **Optimized**: Skip npm install, contracts build, QA suite, and build for docs-only PRs

## Behavior
- **Docs-only PRs**: quality-gates runs via fastpath, returns SUCCESS, skips heavy steps
- **Code PRs**: Full QA suite runs as before
- **Mixed PRs**: Treated as code PRs, full QA suite runs

## Validation
- After merge, will create docs-only PR to verify quality-gates runs and PR is mergeable

## Test Plan
- [x] Verified path filters removed from pr.yml trigger
- [x] Verified docs-only detection logic in quality-gates job
- [x] Verified docs-only detection logic in qa job
- [x] Verified conditional skips on heavy steps (install, build, tests)
- [ ] Create validation PR after merge to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)