### PR TITLE
test(e2e): Phase 2 — Unquarantine shipping E2E + optimize artifacts

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -136,7 +136,7 @@ jobs:
           npx --yes wait-on http://127.0.0.1:3000 --timeout 120000
           echo "✅ Next.js app ready on port 3000"
 
-      - name: Run smoke tests (auth-probe only, skip @quarantine)
+      - name: Run smoke tests (auth-probe only)
         continue-on-error: true  # Pass 45: Make smoke advisory until fully stable
         run: npx playwright test tests/e2e/auth-probe.spec.ts --reporter=list
         env:

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -57,7 +57,7 @@ export default defineConfig({
   use: {
     // Phase-4: Use normalized baseURL for cookie compatibility
     baseURL,
-    trace: 'on',
+    trace: 'on-first-retry',
     video: 'on-first-retry',
     screenshot: 'only-on-failure',
   },

--- a/frontend/tests/e2e/shipping-checkout-e2e.spec.ts
+++ b/frontend/tests/e2e/shipping-checkout-e2e.spec.ts
@@ -9,7 +9,7 @@ const ADMIN_UI_AVAILABLE = process.env.ADMIN_UI_AVAILABLE === 'true';
 // Use test auth when in E2E mode
 const USE_TEST_AUTH = process.env.NEXT_PUBLIC_E2E === 'true';
 
-test.describe('Shipping Integration E2E @quarantine', () => {
+test.describe('Shipping Integration E2E', () => {
   // Auth edge-case fixes: Clear cookies before each test
   test.beforeEach(async ({ page, context }) => {
     await context.clearCookies();


### PR DESCRIPTION
## Goal
Make shipping E2E pass in CI with ≤1 retry and optimize test artifacts for CI storage.

## Changes
- ✅ **Unquarantined** `shipping-checkout-e2e.spec.ts` (removed @quarantine tag)
- ✅ **Optimized Playwright config**: Changed trace from 'on' → 'on-first-retry' (saves CI storage)
- ✅ **Updated CI workflow**: Removed outdated quarantine reference from step name
- ✅ **Locators**: Already robust with en/el fallbacks (no changes needed)

## Skipped Tests Status
**Decision**: Did NOT unskip tests in this PR

**Reason**: All 10 skipped tests require production code changes per `skip-register.md`:
- Circuit breaker implementation
- AbortSignal support  
- MSW error handlers
- CheckoutShipping component completion
- Hook method additions

Unskipping without implementing these features would cause test failures.

**Protocol**: No business code changes in test-only PRs (Code-as-Canon)

## Test Configuration
```typescript
retries: isCI ? 1 : 0  // 1 retry in CI (unchanged)
trace: 'on-first-retry'  // Changed from 'on' - saves storage
video: 'on-first-retry'  // Unchanged
screenshot: 'only-on-failure'  // Unchanged
```

## Expected Behavior
- Shipping E2E runs in CI (no longer skipped via @quarantine)
- If first run fails, retries once with trace/video capture
- Artifacts only generated on failures (optimized storage)
- quality-gates runtime should remain ≤12 minutes

## Test Plan
- [x] Removed @quarantine tag from shipping-checkout-e2e.spec.ts
- [x] Updated Playwright config for artifact optimization
- [x] Updated CI workflow step name
- [ ] Verify shipping E2E passes in CI (or fails with useful trace)
- [ ] Check CI runtime remains within budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)