### PR TITLE
fix(playwright): add auth-probe to CI testMatch for strict smoke

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
         ...devices['Desktop Chrome']
         // storageState disabled in CI - tests handle auth via UI or route stubs
       },
-      testMatch: ['**/smoke.spec.ts', '**/e3-docs-smoke.spec.ts', '**/shipping-*.spec.ts', '**/checkout*.spec.ts'],
+      testMatch: ['**/smoke.spec.ts', '**/e3-docs-smoke.spec.ts', '**/auth-probe.spec.ts', '**/shipping-*.spec.ts', '**/checkout*.spec.ts'],
       testIgnore: ['**/*@no-auth*.spec.ts']
     },
     // CI: Pure UI login tests (no storageState) - Phase-4.1


### PR DESCRIPTION
## Summary

Fixes smoke test execution after PR #312 enabled strict mode.

## Problem

PR #312 merged with strict smoke tests (removed `continue-on-error`), but `auth-probe.spec.ts` was missing from the `consumer-ci` project's `testMatch` array in `playwright.config.ts`.

This caused:
```
Error: No tests found.
Make sure that arguments are regular expressions matching test files.
```

## Solution

Add `'**/auth-probe.spec.ts'` to the testMatch array in the consumer-ci project configuration.

## Changes

```diff
- testMatch: ['**/smoke.spec.ts', '**/e3-docs-smoke.spec.ts', '**/shipping-*.spec.ts', '**/checkout*.spec.ts'],
+ testMatch: ['**/smoke.spec.ts', '**/e3-docs-smoke.spec.ts', '**/auth-probe.spec.ts', '**/shipping-*.spec.ts', '**/checkout*.spec.ts'],
```

## Test Plan

- [x] Added auth-probe.spec.ts to testMatch
- [ ] Verify smoke tests pass in CI with auth-probe
- [ ] Confirm strict smoke works (no continue-on-error)

## Related

- PR #312: Continuity pack + strict smoke (merged)
- Pass 56-57: Smoke strict implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)