### PR TITLE
ci(gates): restore strict commit discipline in quality-gates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    continue-on-error: true  # Pass 43: Make commitlint advisory until Phase 2
+    # Pass 62: Strict commit discipline restored - commitlint required
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
Restore strict commit discipline by making commitlint required (remove advisory mode).

## Changes

### Commitlint: Advisory → Strict
**Before (Pass 43):**
```yaml
danger:
  continue-on-error: true  # Advisory
```

**After (Pass 62):**
```yaml
danger:
  # Pass 62: Strict commit discipline restored - commitlint required
```

### ESLint: Already Strict
ESLint is already enforced via `qa:all:ci` in the QA job:
- Runs `npm run lint:ci` using `.eslintrc.ci.mjs`
- Configured with sensible defaults (warnings for unused vars, etc.)
- Fails on errors

### Docs-Fastpath: Retained
Docs-only PRs still skip heavy steps (dependencies, tests, build) but **commitlint always runs**.

## Impact

✅ **Commitlint**: Now STRICT - PRs with bad commit messages will fail
✅ **ESLint**: Already STRICT via qa:all:ci  
✅ **Docs-only PRs**: Fast (skip heavy steps) but still enforce commit discipline
✅ **quality-gates**: Single unified gate remains (no new required checks)

## Test Plan

Create test PRs with:
1. ✅ Good commit message → should pass
2. ❌ Bad commit message (no type prefix) → should fail commitlint
3. ✅ Docs-only change with good commit → should pass (fast)

## Related

- **Phase 2 cleanup**: Completing strict discipline restoration from Pass 43
- **Issue #306**: Phase 2 E2E Stabilization umbrella
- **Previous**: PR #316 (unskip batch #2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)