### PR TITLE
ci: add missing install-deps.sh script

### DIFF
--- a/scripts/ci/install-deps.sh
+++ b/scripts/ci/install-deps.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WD="${1:-.}"
+cd "$WD"
+PM="npm"
+if [ -f pnpm-lock.yaml ]; then PM="pnpm"
+elif [ -f yarn.lock ]; then PM="yarn"
+fi
+echo "⚙️ Using package manager: $PM in $WD"
+case "$PM" in
+  pnpm)
+    corepack enable || true
+    npm i -g pnpm >/dev/null 2>&1 || true
+    pnpm i --frozen-lockfile
+    ;;
+  yarn)
+    corepack enable || true
+    if yarn -v | grep -qE '^(3|4)\.'; then
+      yarn install --immutable
+    else
+      yarn install --frozen-lockfile
+    fi
+    ;;
+  npm)
+    if [ -f package-lock.json ]; then npm ci; else npm i --no-audit --no-fund; fi
+    ;;
+esac


### PR DESCRIPTION
## Summary
Adds the missing `scripts/ci/install-deps.sh` helper script that PR #331 workflows depend on.

## Context
PR #331 updated workflows to use this script but the script itself was never committed to main, causing CI failures.

## Changes
- Creates `scripts/ci/install-deps.sh` with package manager autodetection (pnpm/yarn/npm)
- Makes script executable

## Dependencies
- Required for PR #331 CI checks to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)