### PR TITLE
ci(lhci): add contracts dependency installation step

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -27,6 +27,16 @@ jobs:
       - name: Install deps (frontend)
         run: bash scripts/ci/install-deps.sh frontend
 
+      - name: Install and build contracts dependencies
+        run: |
+          if [ -d "packages/contracts" ]; then
+            cd packages/contracts
+            npm ci
+            npm run build
+          else
+            echo "No contracts directory found"
+          fi
+
       - name: Build frontend (prod)
         working-directory: frontend
         run: npx --yes next build


### PR DESCRIPTION
## Summary

Fixes LHCI workflow build failure caused by missing `zod` dependency in `packages/contracts`.

## Problem

LHCI workflow run ID 18249754020 failed with:
```
Module not found: Can't resolve 'zod'
../packages/contracts/src/shipping.ts
```

## Root Cause

The LHCI workflow installed frontend dependencies but skipped `packages/contracts` installation and build, causing Next.js build to fail when importing from `@dixis/contracts`.

## Solution

Added two steps between "Install deps (frontend)" and "Build frontend (prod)":
1. **Install contracts dependencies**: `cd packages/contracts && npm ci`
2. **Build contracts package**: `cd packages/contracts && npm run build`

Both steps include conditional checks for `packages/contracts` directory existence.

## Testing

- ✅ Follows pattern from `lighthouse.yml` (lines 52-66)
- ✅ Compatible with monorepo structure
- ✅ Idempotent (safe to run multiple times)

## AC

- [x] Contracts dependencies installed before frontend build
- [x] Contracts package built before frontend build
- [x] Graceful handling if contracts directory doesn't exist

**Refs**: LIGHTHOUSE-PROGRESS.md Pass 80

🤖 Generated with [Claude Code](https://claude.com/claude-code)