### PR TITLE
feat(media): Pass 109 — Secure uploads with fs/S3 storage

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -13,8 +13,16 @@ NEXT_ENABLE_CSP_REPORT_ONLY=false
 # Basic Auth for Admin (format: username:password)
 BASIC_AUTH="admin:dixis_admin_pass"
 
+# ── Auth (OTP dev stub) ────────────────────────────────────────────────
+OTP_BYPASS="000000"      # Στα tests/dev, αυτός ο κωδικός περνά πάντα
+OTP_DEV_ECHO="1"         # Στο dev επιστρέφει τον κωδικό από /request-otp (ΜΗΝ το χρησιμοποιείτε production)
+
+# ── Storage (uploads) ─────────────────────────────────────────────────
 # Storage driver: fs | s3
 STORAGE_DRIVER="fs"
+
+# Optional: Enable image processing with sharp (resize to 1200x1200, quality 85)
+ENABLE_IMAGE_PROCESSING="false"
 
 # S3/R2 (only if STORAGE_DRIVER=s3)
 S3_BUCKET=""

--- a/frontend/src/app/api/me/uploads/route.ts
+++ b/frontend/src/app/api/me/uploads/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { getStorage } from '@/lib/storage/driver';
+import { getSessionPhone } from '@/lib/auth/session';
+
+export const runtime = 'nodejs';
+const ALLOWED = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX = 5 * 1024 * 1024; // 5MB limit
+
+export async function POST(req: Request) {
+  const phone = await getSessionPhone();
+  if (!phone) return new NextResponse('Auth required', { status: 401 });
+
+  const form = await (req as any).formData().catch((): null => null);
+  if (!form) return NextResponse.json({ error: 'No formdata' }, { status: 400 });
+
+  const file = form.get('file') as File | null;
+  if (!file) return NextResponse.json({ error: 'file missing' }, { status: 400 });
+  if (!ALLOWED.includes(file.type))
+    return NextResponse.json({ error: 'type not allowed' }, { status: 415 });
+  if (file.size > MAX) return NextResponse.json({ error: 'too large' }, { status: 413 });
+
+  let buf = Buffer.from(await file.arrayBuffer());
+
+  // Optional: Image processing with sharp
+  if (process.env.ENABLE_IMAGE_PROCESSING === 'true') {
+    try {
+      const sharp = (await import('sharp')).default;
+      const processedBuffer = await sharp(buf)
+        .resize(1200, 1200, { fit: 'inside', withoutEnlargement: true })
+        .jpeg({ quality: 85 })
+        .toBuffer();
+      buf = Buffer.from(processedBuffer);
+    } catch (err) {
+      console.error('Image processing failed, using original:', err);
+    }
+  }
+
+  const storage = getStorage();
+  const result = await storage
+    .putObject({ contentType: file.type, body: buf })
+    .catch((e: any): { error: string } => ({ error: e?.message || 'upload failed' }));
+  if ((result as any).error) return NextResponse.json(result, { status: 500 });
+  return NextResponse.json(result);
+}

--- a/frontend/tests/uploads/upload-and-use.spec.ts
+++ b/frontend/tests/uploads/upload-and-use.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+
+const base = process.env.BASE_URL || 'http://127.0.0.1:3000';
+const phone = '+306912345685';
+const bypass = process.env.OTP_BYPASS || '000000';
+
+test.describe('Secure Uploads', () => {
+  test('Upload image → create product → render image', async ({ request, page }) => {
+    // 1. Login and get session
+    await request.post(base + '/api/auth/request-otp', { data: { phone } });
+    const vr = await request.post(base + '/api/auth/verify-otp', { data: { phone, code: bypass } });
+    const cookies = await vr.headers();
+    const sessMatch = cookies['set-cookie']?.match(/dixis_session=([^;]+)/);
+    const sess = sessMatch?.[1] || '';
+    if (!sess) throw new Error('No session');
+
+    // 2. Create producer
+    const make = await request.post(base + '/api/me/producers', {
+      headers: { cookie: `dixis_session=${sess}` },
+      data: { name: 'Upload Test', region: 'Αττική', category: 'Μέλι', email: 'upload@ex.com' }
+    });
+    expect(make.ok()).toBeTruthy();
+
+    // 3. Create a test image (1x1 PNG)
+    const testImageBuffer = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      'base64'
+    );
+    const testImagePath = path.join(process.cwd(), '.tmp', 'test-upload.png');
+    await fs.promises.mkdir(path.dirname(testImagePath), { recursive: true });
+    await fs.promises.writeFile(testImagePath, testImageBuffer);
+
+    // 4. Upload image
+    const formData = new FormData();
+    const blob = new Blob([testImageBuffer], { type: 'image/png' });
+    formData.append('file', blob, 'test.png');
+
+    const uploadRes = await request.post(base + '/api/me/uploads', {
+      headers: { cookie: `dixis_session=${sess}` },
+      multipart: {
+        file: {
+          name: 'test.png',
+          mimeType: 'image/png',
+          buffer: testImageBuffer
+        }
+      }
+    });
+    expect(uploadRes.ok()).toBeTruthy();
+    const uploadData = await uploadRes.json();
+    expect(uploadData.url).toBeTruthy();
+    const imageUrl = uploadData.url;
+
+    // 5. Create product with uploaded image
+    const productRes = await request.post(base + '/api/me/products', {
+      headers: { cookie: `dixis_session=${sess}` },
+      data: {
+        title: 'Μέλι με Εικόνα',
+        category: 'Μέλι',
+        price: 15,
+        stock: 10,
+        unit: 'τεμ',
+        images: [{ url: imageUrl, altText: 'Μέλι' }]
+      }
+    });
+    expect(productRes.ok()).toBeTruthy();
+    const productData = await productRes.json();
+    const productId = productData.item.id;
+
+    // 6. Verify image renders on product page
+    await page.goto(base + '/products/' + productId);
+    const img = page.locator(`img[src*="${imageUrl.replace(/^\//, '')}"]`).first();
+    await expect(img).toBeVisible({ timeout: 10000 });
+
+    // Cleanup
+    await fs.promises.unlink(testImagePath).catch(() => {});
+  });
+
+  test('Upload fails for unauthenticated user', async ({ request }) => {
+    const testImageBuffer = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      'base64'
+    );
+
+    const uploadRes = await request.post(base + '/api/me/uploads', {
+      multipart: {
+        file: {
+          name: 'test.png',
+          mimeType: 'image/png',
+          buffer: testImageBuffer
+        }
+      }
+    });
+    expect(uploadRes.status()).toBe(401);
+  });
+
+  test('Upload fails for file too large (>5MB)', async ({ request }) => {
+    // Login
+    await request.post(base + '/api/auth/request-otp', { data: { phone } });
+    const vr = await request.post(base + '/api/auth/verify-otp', {
+      data: { phone, code: bypass }
+    });
+    const cookies = await vr.headers();
+    const sessMatch = cookies['set-cookie']?.match(/dixis_session=([^;]+)/);
+    const sess = sessMatch?.[1] || '';
+
+    // Create 6MB buffer
+    const largeBuffer = Buffer.alloc(6 * 1024 * 1024);
+
+    const uploadRes = await request.post(base + '/api/me/uploads', {
+      headers: { cookie: `dixis_session=${sess}` },
+      multipart: {
+        file: {
+          name: 'large.png',
+          mimeType: 'image/png',
+          buffer: largeBuffer
+        }
+      }
+    });
+    expect(uploadRes.status()).toBe(413);
+  });
+
+  test('Upload fails for invalid MIME type', async ({ request }) => {
+    // Login
+    await request.post(base + '/api/auth/request-otp', { data: { phone } });
+    const vr = await request.post(base + '/api/auth/verify-otp', {
+      data: { phone, code: bypass }
+    });
+    const cookies = await vr.headers();
+    const sessMatch = cookies['set-cookie']?.match(/dixis_session=([^;]+)/);
+    const sess = sessMatch?.[1] || '';
+
+    const testBuffer = Buffer.from('test file content');
+
+    const uploadRes = await request.post(base + '/api/me/uploads', {
+      headers: { cookie: `dixis_session=${sess}` },
+      multipart: {
+        file: {
+          name: 'test.txt',
+          mimeType: 'text/plain',
+          buffer: testBuffer
+        }
+      }
+    });
+    expect(uploadRes.status()).toBe(415);
+  });
+
+  test('Upload succeeds for all allowed MIME types', async ({ request }) => {
+    // Login
+    await request.post(base + '/api/auth/request-otp', { data: { phone } });
+    const vr = await request.post(base + '/api/auth/verify-otp', {
+      data: { phone, code: bypass }
+    });
+    const cookies = await vr.headers();
+    const sessMatch = cookies['set-cookie']?.match(/dixis_session=([^;]+)/);
+    const sess = sessMatch?.[1] || '';
+
+    // Create producer if needed
+    await request.post(base + '/api/me/producers', {
+      headers: { cookie: `dixis_session=${sess}` },
+      data: { name: 'Upload Test 2', region: 'Αττική', category: 'Μέλι', email: 'upload2@ex.com' }
+    });
+
+    const testImageBuffer = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      'base64'
+    );
+
+    const mimeTypes = ['image/jpeg', 'image/png', 'image/webp'];
+
+    for (const mimeType of mimeTypes) {
+      const uploadRes = await request.post(base + '/api/me/uploads', {
+        headers: { cookie: `dixis_session=${sess}` },
+        multipart: {
+          file: {
+            name: `test.${mimeType.split('/')[1]}`,
+            mimeType,
+            buffer: testImageBuffer
+          }
+        }
+      });
+      expect(uploadRes.ok()).toBeTruthy();
+      const data = await uploadRes.json();
+      expect(data.url).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Secure image upload system με fs/S3 storage drivers και optional sharp processing.

## Changes
- **Storage drivers**: fs (hash-based `yyyymm/hash.ext`) + S3/R2 (MinIO/AWS)
- **Upload API**: `POST /api/me/uploads` (5MB limit, jpeg/png/webp only)
- **Security**: OTP auth, MIME whitelist, size validation
- **Optional**: sharp image processing (resize 1200x1200, quality 85)
- **Tests**: Playwright E2E (upload → product → render, 401, 413, 415)
- **Docs**: .env.example με `ENABLE_IMAGE_PROCESSING` flag

## Files Changed
- `frontend/src/lib/storage/driver.ts`: Hash-based filenames + yyyymm structure
- `frontend/src/app/api/me/uploads/route.ts`: 5MB limit + sharp integration
- `frontend/tests/uploads/upload-and-use.spec.ts`: Comprehensive E2E tests
- `frontend/.env.example`: ENABLE_IMAGE_PROCESSING documentation

## Test Plan
- [x] Upload API accepts jpeg/png/webp
- [x] Upload API rejects >5MB files (413)
- [x] Upload API rejects invalid MIME types (415)
- [x] Upload API requires authentication (401)
- [x] Upload → product → render workflow
- [x] Build passes (55 pages)

## Evidence
- Build: 55 pages, /api/me/uploads 222 B
- Tests: 5 scenarios covering all edge cases
- Storage: Hash-based paths prevent collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)