### PR TITLE
docs(agent): Canonicalize Agent Docs to frontend/docs (Pass AG1.1)

### DIFF
--- a/frontend/docs/AGENT/SYSTEM/db-schema.md
+++ b/frontend/docs/AGENT/SYSTEM/db-schema.md
@@ -1,0 +1,134 @@
+# DB Schema (Prisma)
+
+```prisma
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Producer {
+  id          String    @id @default(cuid())
+  slug        String    @unique
+  name        String
+  region      String
+  category    String
+  description String?
+  phone       String?
+  email       String?
+  products    Int       @default(0)
+  rating      Float?    @default(0)
+  imageUrl    String?
+  isActive    Boolean   @default(true)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  Product     Product[]
+
+  @@index([region, category])
+  @@index([name])
+}
+
+model Product {
+  id          String      @id @default(cuid())
+  producerId  String
+  title       String
+  category    String
+  price       Float
+  unit        String
+  stock       Int         @default(0)
+  description String?
+  imageUrl    String?
+  isActive    Boolean     @default(true)
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
+  producer    Producer    @relation(fields: [producerId], references: [id], onDelete: Cascade)
+  OrderItem   OrderItem[]
+
+  @@index([producerId, createdAt])
+  @@index([category])
+  @@index([isActive])
+}
+
+model Order {
+  id             String      @id @default(cuid())
+  buyerPhone     String
+  buyerName      String
+  shippingLine1  String
+  shippingLine2  String?
+  shippingCity   String
+  shippingPostal String
+  total          Float
+  status         String      @default("pending")
+  createdAt      DateTime    @default(now())
+  updatedAt      DateTime    @updatedAt
+  items          OrderItem[]
+
+  @@index([buyerPhone, createdAt])
+  @@index([status, createdAt])
+}
+
+model OrderItem {
+  id         String   @id @default(cuid())
+  orderId    String
+  productId  String
+  producerId String
+  qty        Int
+  price      Float
+  titleSnap  String?
+  priceSnap  Float?
+  status     String   @default("pending")
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  order      Order    @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  product    Product  @relation(fields: [productId], references: [id], onDelete: Restrict)
+
+  @@index([orderId])
+  @@index([producerId, status])
+  @@index([productId])
+}
+
+model Event {
+  id        String   @id @default(cuid())
+  type      String // e.g., order.created, orderItem.status.changed
+  payload   Json
+  createdAt DateTime @default(now())
+
+  @@index([type, createdAt])
+}
+
+model Notification {
+  id            String    @id @default(cuid())
+  channel       String // 'SMS' | 'EMAIL'
+  to            String
+  template      String // logical template id
+  payload       Json // rendered variables
+  status        String    @default("QUEUED") // QUEUED | SENT | FAILED
+  sentAt        DateTime?
+  error         String?
+  attempts      Int       @default(0)
+  nextAttemptAt DateTime?
+  dedupId       String?   @db.VarChar(64)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  @@index([channel, status, createdAt])
+  @@index([status, nextAttemptAt])
+  @@index([dedupId])
+}
+
+model RateLimit {
+  id        String   @id @default(cuid())
+  name      String // e.g., 'cron-run', 'dev-deliver', 'checkout'
+  key       String // e.g., IP address, cron key, user ID
+  bucket    Int // time bucket = floor(now / windowSec)
+  count     Int      @default(0)
+  createdAt DateTime @default(now())
+
+  @@unique([name, key, bucket])
+  @@index([name, key, bucket])
+}
+
+```

--- a/frontend/docs/AGENT/SYSTEM/routes.md
+++ b/frontend/docs/AGENT/SYSTEM/routes.md
@@ -1,0 +1,3 @@
+# App Routes
+
+

--- a/frontend/docs/OPS/STATE.md
+++ b/frontend/docs/OPS/STATE.md
@@ -381,3 +381,33 @@ export default function Page() { redirect('/my/orders'); }
 - CI checks will complete automatically
 - Auto-merge will trigger when all checks pass
 - PR #392 will be squashed and merged to main
+
+## Pass AG1 — Agent Docs & Context Hygiene (2025-10-07)
+
+**Στόχος**: Δημιουργία `docs/AGENT` δομής για καλύτερη διαχείριση context και ομαλή συνέχεια σε νέα chats.
+
+**Υλοποίηση**:
+- ✅ Δομή `docs/AGENT/{SYSTEM,SOPs,TASKS,COMMANDS,SUMMARY}`
+- ✅ README.md με οδηγίες για agents
+- ✅ SYSTEM docs: architecture.md, env.md (registry)
+- ✅ SOPs: SOP-Feature-Pass.md, SOP-Context-Hygiene.md
+- ✅ COMMANDS/update-doc.md με init/after-pass modes
+- ✅ Templates: Pass-000-Template.md, Pass-000-TLDR.md
+- ✅ Helper scripts (.mjs): scan-routes.mjs, scan-prisma.mjs
+- ✅ npm scripts: `agent:routes`, `agent:schema`, `agent:docs`
+- ✅ Auto-generated: routes.md, db-schema.md
+
+**Αρχεία**:
+- docs/AGENT/README.md
+- docs/AGENT/SYSTEM/{architecture,env,routes,db-schema}.md
+- docs/AGENT/SOPs/{SOP-Feature-Pass,SOP-Context-Hygiene}.md
+- docs/AGENT/COMMANDS/update-doc.md
+- docs/AGENT/TASKS/Pass-000-Template.md
+- docs/AGENT/SUMMARY/Pass-000-TLDR.md
+- scripts/{scan-routes,scan-prisma}.mjs
+- frontend/package.json (npm scripts)
+
+**PR**: #410 (merged)
+
+**Επόμενα**: Χρήση AGENT docs σε επόμενους passes για μείωση context bloat.
+


### PR DESCRIPTION
## Summary
Unifies Agent Docs under canonical path `frontend/docs/AGENT/` with updated scanners.

## Changes
- ✅ Merge root `docs/AGENT/**` → `frontend/docs/AGENT/**` (safe, no overwrites)
- ✅ Update scanners: output paths → `frontend/docs/AGENT/SYSTEM/`
- ✅ Regenerate `routes.md` & `db-schema.md` in canonical location
- ✅ Update STATE.md with Pass AG1.1

## Canonical Structure
```
frontend/docs/
├── AGENT/
│   ├── SYSTEM/{architecture,env,routes,db-schema}.md
│   ├── SOPs/{SOP-Feature-Pass,SOP-Context-Hygiene}.md
│   ├── COMMANDS/update-doc.md
│   ├── TASKS/Pass-000-Template.md
│   └── SUMMARY/Pass-000-TLDR.md
└── OPS/STATE.md
```

## Testing
```bash
cd frontend && npm run agent:docs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)