### PR TITLE
docs(agent): fix scanners output + regenerate (Pass AG1.2)

### DIFF
--- a/frontend/docs/AGENT/SYSTEM/routes.md
+++ b/frontend/docs/AGENT/SYSTEM/routes.md
@@ -1,3 +1,36 @@
 # App Routes
 
-
+- `/`
+- `/account/orders`
+- `/account/orders/[orderId]`
+- `/admin/analytics`
+- `/admin/orders`
+- `/admin/pricing`
+- `/admin/producers`
+- `/admin/producers/images`
+- `/admin/toggle`
+- `/auth/login`
+- `/auth/register`
+- `/cart`
+- `/checkout`
+- `/checkout/payment/[orderId]`
+- `/dev-check`
+- `/dev/notifications`
+- `/my/orders`
+- `/my/products`
+- `/my/products/[id]/edit`
+- `/my/products/create`
+- `/ops/metrics`
+- `/order/confirmation/[orderId]`
+- `/orders/[id]`
+- `/producer/analytics`
+- `/producer/dashboard`
+- `/producer/onboarding`
+- `/producer/orders`
+- `/producer/products`
+- `/producer/products/[id]/edit`
+- `/producer/products/create`
+- `/product/[id]`
+- `/products`
+- `/products/[id]`
+- `/test-error`

--- a/frontend/docs/OPS/STATE.md
+++ b/frontend/docs/OPS/STATE.md
@@ -411,3 +411,20 @@ export default function Page() { redirect('/my/orders'); }
 
 **Επόμενα**: Χρήση AGENT docs σε επόμενους passes για μείωση context bloat.
 
+
+## Pass AG1.2 — Scanners fixed & docs regenerated (2025-10-07)
+
+**Στόχος**: Διόρθωση scanners για σωστή έξοδο σε `frontend/docs/AGENT/SYSTEM/`
+
+**Υλοποίηση**:
+- ✅ Scanners γράφουν πάντα σε `frontend/docs/AGENT/SYSTEM/` (absolute paths)
+- ✅ Αναγέννηση `routes.md` (30+ routes, non-empty)
+- ✅ Αναγέννηση `db-schema.md` (Prisma schema)
+- ✅ npm scripts verified: `agent:routes`, `agent:schema`, `agent:docs`
+
+**Αλλαγές**:
+- scripts/scan-routes.mjs: Χρήση `path.join('frontend','docs','AGENT','SYSTEM','routes.md')`
+- scripts/scan-prisma.mjs: Χρήση `path.join('frontend','docs','AGENT','SYSTEM','db-schema.md')`
+- Logs: Εμφανίζουν count routes & bytes
+
+**Επόμενα**: Scanners λειτουργούν σωστά από οποιοδήποτε directory.

--- a/scripts/scan-prisma.mjs
+++ b/scripts/scan-prisma.mjs
@@ -1,9 +1,26 @@
-import fs from 'fs';
-const out = 'docs/AGENT/SYSTEM/db-schema.md';
-const candidates = ['prisma/schema.prisma','backend/prisma/schema.prisma','frontend/prisma/schema.prisma'];
+import fs from 'fs'; import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Detect repo root (where scripts/ exists)
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+const OUT = path.join(repoRoot, 'frontend', 'docs', 'AGENT', 'SYSTEM', 'db-schema.md');
+const candidates = [
+  path.join(repoRoot, 'prisma/schema.prisma'),
+  path.join(repoRoot, 'backend/prisma/schema.prisma'),
+  path.join(repoRoot, 'frontend/prisma/schema.prisma')
+];
+
 const P = candidates.find(f=>fs.existsSync(f));
-fs.mkdirSync('docs/AGENT/SYSTEM', { recursive:true });
-if(!P){ fs.writeFileSync(out, '# DB Schema\n\n(Prisma schema not found)\n'); process.exit(0); }
+fs.mkdirSync(path.dirname(OUT), { recursive:true });
+
+if(!P){ 
+  fs.writeFileSync(OUT, '# DB Schema\n\n(Prisma schema not found)\n'); 
+  console.log(`db schema written: ${OUT} (missing)`); 
+  process.exit(0); 
+}
+
 const s = fs.readFileSync(P,'utf8');
-fs.writeFileSync(out, '# DB Schema (Prisma)\n\n```prisma\n'+s+'\n```\n');
-console.log('db schema written:', out);
+fs.writeFileSync(OUT, '# DB Schema (Prisma)\n\n```prisma\n'+s+'\n```\n');
+console.log(`db schema written: ${OUT} (bytes=${s.length}) from ${P}`);

--- a/scripts/scan-routes.mjs
+++ b/scripts/scan-routes.mjs
@@ -1,16 +1,59 @@
 import fs from 'fs'; import path from 'path';
-const ROOTS = ['frontend/src/app','frontend/app'];
-const out = 'docs/AGENT/SYSTEM/routes.md';
-function walk(dir){
-  if(!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir).flatMap(name=>{
-    const p = path.join(dir,name);
-    if(fs.statSync(p).isDirectory()) return walk(p);
-    if(/page\.tsx?$/.test(name)) return [p.replace(/^.*\/app\//,'/').replace(/\/page\.tsx?$/,'') || '/'];
-    return [];
-  });
+import { fileURLToPath } from 'url';
+
+// Detect repo root (where scripts/ exists)
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+const APP_CANDIDATES = [
+  path.join(repoRoot, 'frontend/src/app'),
+  path.join(repoRoot, 'frontend/app')
+];
+const OUT = path.join(repoRoot, 'frontend', 'docs', 'AGENT', 'SYSTEM', 'routes.md');
+
+function findAppRoot(){
+  for(const p of APP_CANDIDATES){ 
+    if(fs.existsSync(p)) {
+      console.log(`[scan-routes] Found app dir: ${p}`);
+      return p;
+    }
+  }
+  console.log('[scan-routes] No app dir found in:', APP_CANDIDATES);
+  return null;
 }
-const routes = ROOTS.flatMap(walk).filter(Boolean).sort();
-fs.mkdirSync(path.dirname(out), { recursive:true });
-fs.writeFileSync(out, '# App Routes\n\n'+routes.map(r=>`- \`${r}\``).join('\n')+'\n');
-console.log('routes written:', out);
+
+function walk(dir, acc){
+  for(const name of fs.readdirSync(dir)){
+    const p = path.join(dir,name);
+    const st = fs.statSync(p);
+    if(st.isDirectory()){
+      if(['node_modules','.next','.git'].includes(name)) continue;
+      walk(p, acc);
+    }else{
+      if(/^page\.tsx?$/.test(name)) acc.push(p);
+    }
+  }
+}
+
+function toRoute(appRoot, file){
+  const rel = file.substring(appRoot.length);
+  const noPage = rel.replace(/\/page\.tsx?$/,'').replace(/\\/g,'/');
+  return noPage === '' ? '/' : noPage;
+}
+
+const appRoot = findAppRoot();
+const routes = new Set();
+if(appRoot){
+  const files = []; 
+  walk(appRoot, files);
+  console.log(`[scan-routes] Found ${files.length} page files`);
+  for(const f of files){ 
+    const r = toRoute(appRoot, f);
+    routes.add(r);
+  }
+}
+
+fs.mkdirSync(path.dirname(OUT), { recursive:true });
+const list = Array.from(routes).sort();
+fs.writeFileSync(OUT, '# App Routes\n\n' + list.map(r=>`- \`${r}\``).join('\n') + (list.length? '\n':''));
+console.log(`routes written: ${OUT} (count=${list.length})`);


### PR DESCRIPTION
## Summary
Fixes scanner output paths to use absolute paths to `frontend/docs/AGENT/SYSTEM/`.

## Changes
- ✅ scan-routes.mjs: Use `path.join('frontend','docs','AGENT','SYSTEM','routes.md')`
- ✅ scan-prisma.mjs: Use `path.join('frontend','docs','AGENT','SYSTEM','db-schema.md')`
- ✅ Regenerated routes.md with 30+ routes (non-empty)
- ✅ Regenerated db-schema.md with Prisma schema
- ✅ Added logging: count routes & bytes
- ✅ Updated STATE.md

## Testing
```bash
cd frontend && npm run agent:docs
# Verify routes.md has content
cat frontend/docs/AGENT/SYSTEM/routes.md
```

## Results
- routes.md: 30+ Next.js routes listed
- db-schema.md: Full Prisma schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)