### PR TITLE
sec(admin): Admin guard hardening (Pass 149)

### DIFF
--- a/frontend/docs/OPS/STATE.md
+++ b/frontend/docs/OPS/STATE.md
@@ -602,3 +602,31 @@ export default function Page() { redirect('/my/orders'); }
 - Greek-first UI and email templates
 - Configurable threshold via environment variable
 - Graceful email failures (log only, don't break checkout)
+
+## Pass 149 — Admin Guard Hardening
+- **Admin Pages Security**:
+  - All `/admin/**` pages: `export const dynamic = 'force-dynamic'`
+  - Direct `requireAdmin()` import and server-side call
+  - Products page: Try/catch with unauthorized fallback
+  - Orders pages: Updated to use requireAdmin directly
+- **Unauthorized Fallback UI**:
+  - "Δεν επιτρέπεται" message
+  - "Απαιτείται σύνδεση διαχειριστή" explanation
+  - No data exposure for unauthorized users
+- **E2E Tests** (`frontend/tests/admin/auth.spec.ts`):
+  - Test 1: Unauthorized user sees guard message on /admin/products
+  - Test 2: Authorized admin can view /admin/products list
+- **Pages Hardened**:
+  - `frontend/src/app/admin/products/page.tsx` (with unauthorized fallback)
+  - `frontend/src/app/admin/orders/page.tsx` (force-dynamic + requireAdmin)
+  - `frontend/src/app/admin/orders/[id]/page.tsx` (force-dynamic + requireAdmin)
+- **Files**:
+  - `frontend/src/app/admin/products/page.tsx` (hardened with fallback)
+  - `frontend/src/app/admin/orders/page.tsx` (hardened)
+  - `frontend/src/app/admin/orders/[id]/page.tsx` (hardened)
+  - `frontend/tests/admin/auth.spec.ts` (e2e auth tests)
+  - `frontend/docs/OPS/STATE.md` (Pass 149 docs)
+- No schema changes, no new dependencies
+- Server-side authentication enforcement
+- Dynamic SSR for proper auth checks
+- Graceful unauthorized fallback (no crashes)

--- a/frontend/src/app/admin/orders/[id]/page.tsx
+++ b/frontend/src/app/admin/orders/[id]/page.tsx
@@ -1,9 +1,11 @@
 import { prisma } from '@/lib/db/client';
+import { requireAdmin } from '@/lib/auth/admin';
 import Link from 'next/link';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { CopyTrackingLink } from './CopyTrackingLink';
 
+export const dynamic = 'force-dynamic';
 export const metadata = { title: 'Παραγγελία (Admin) | Dixis' };
 
 const transitions: Record<string, string[]> = {
@@ -14,11 +16,6 @@ const transitions: Record<string, string[]> = {
   DELIVERED: [],
   CANCELLED: []
 };
-
-async function checkAdmin() {
-  const { requireAdmin } = await import('@/lib/auth/admin');
-  await requireAdmin();
-}
 
 async function changeStatusAction(orderId: string, newStatus: string) {
   'use server';
@@ -49,7 +46,7 @@ export default async function AdminOrderDetailPage({
 }: {
   params: { id: string };
 }) {
-  await checkAdmin();
+  await requireAdmin?.();
 
   const id = params.id;
   const order = await prisma.order.findUnique({

--- a/frontend/src/app/admin/orders/page.tsx
+++ b/frontend/src/app/admin/orders/page.tsx
@@ -1,21 +1,18 @@
 import { prisma } from '@/lib/db/client';
+import { requireAdmin } from '@/lib/auth/admin';
 import Link from 'next/link';
 
+export const dynamic = 'force-dynamic';
 export const metadata = { title: 'Παραγγελίες (Admin) | Dixis' };
 
 const statuses = ['PENDING', 'PAID', 'PACKING', 'SHIPPED', 'DELIVERED', 'CANCELLED'] as const;
-
-async function checkAdmin() {
-  const { requireAdmin } = await import('@/lib/auth/admin');
-  await requireAdmin();
-}
 
 export default async function AdminOrdersPage({
   searchParams
 }: {
   searchParams?: { q?: string; status?: string };
 }) {
-  await checkAdmin();
+  await requireAdmin?.();
 
   const q = searchParams?.q?.trim() || '';
   const st = (searchParams?.status || '').toUpperCase();

--- a/frontend/src/app/admin/products/page.tsx
+++ b/frontend/src/app/admin/products/page.tsx
@@ -1,17 +1,9 @@
 import { prisma } from '@/lib/db/client';
+import { requireAdmin } from '@/lib/auth/admin';
 import Link from 'next/link';
 
 export const dynamic = 'force-dynamic';
 export const metadata = { title: 'Admin — Προϊόντα | Dixis' };
-
-async function checkAdmin() {
-  try {
-    const { requireAdmin } = await import('@/lib/auth/admin');
-    await requireAdmin();
-  } catch {
-    throw new Error('Unauthorized');
-  }
-}
 
 function thr() {
   return Number.parseInt(process.env.LOW_STOCK_THRESHOLD || '3') || 3;
@@ -22,7 +14,8 @@ export default async function Page({
 }: {
   searchParams?: { q?: string; active?: string; low?: string; page?: string };
 }) {
-  await checkAdmin();
+  try {
+    await requireAdmin?.();
 
   const q = (searchParams?.q || '').trim();
   const active = searchParams?.active || '';
@@ -130,4 +123,12 @@ export default async function Page({
       </nav>
     </main>
   );
+  } catch {
+    return (
+      <main style={{ padding: 16 }}>
+        <h1>Δεν επιτρέπεται</h1>
+        <p>Απαιτείται σύνδεση διαχειριστή.</p>
+      </main>
+    );
+  }
 }

--- a/frontend/tests/admin/auth.spec.ts
+++ b/frontend/tests/admin/auth.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect, request as pwRequest } from '@playwright/test';
+
+const base = process.env.PLAYWRIGHT_BASE_URL || process.env.BASE_URL || 'http://127.0.0.1:3001';
+const bypass = process.env.OTP_BYPASS || '000000';
+const adminPhone = (process.env.ADMIN_PHONES || '+306900000084').split(',')[0];
+
+async function adminCookie() {
+  const ctx = await pwRequest.newContext();
+  try {
+    await ctx.post(base + '/api/auth/request-otp', { data: { phone: adminPhone } });
+    const vr = await ctx.post(base + '/api/auth/verify-otp', {
+      data: { phone: adminPhone, code: bypass }
+    });
+    const headers = await vr.headersArray();
+    const setCookie = headers.find((h) => h.name.toLowerCase() === 'set-cookie')?.value || '';
+    const match = setCookie.match(/dixis_session=([^;]+)/);
+    return match ? match[1] : '';
+  } finally {
+    await ctx.dispose();
+  }
+}
+
+test.describe('Admin Authentication Guard', () => {
+  test('unauthorized user sees guard message on /admin/products', async ({ page }) => {
+    test.skip(!bypass, 'OTP_BYPASS not configured');
+
+    await page.goto(base + '/admin/products');
+    await expect(page.getByText('Δεν επιτρέπεται')).toBeVisible();
+  });
+
+  test('authorized admin can view /admin/products', async ({ page }) => {
+    test.skip(!bypass, 'OTP_BYPASS not configured');
+
+    const cookie = await adminCookie();
+    await page.context().addCookies([{ name: 'dixis_session', value: cookie, url: base }]);
+    await page.goto(base + '/admin/products');
+    // Simple indication of successful render
+    await expect(page.getByText('Προϊόντα')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Restored/confirmed `requireAdmin()` guards on all `/admin/**` pages
- Products page: Try/catch with unauthorized fallback ("Δεν επιτρέπεται")
- Orders pages: Direct requireAdmin import + `force-dynamic` export
- E2E tests: Unauthorized/authorized access scenarios
- STATE.md: Pass 149 documentation

## Test Plan
- [x] Build passes (Next.js 15.5.0, TypeScript strict)
- [x] Admin products page shows fallback UI when unauthorized
- [x] Admin products page renders for authorized admin
- [x] E2E tests cover both scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)