### PR TITLE
feat(tracking): public /track/[token] + public API + e2e smoke (Pass 179T)

### DIFF
--- a/frontend/docs/OPS/STATE.md
+++ b/frontend/docs/OPS/STATE.md
@@ -951,3 +951,4 @@ export default function Page() { redirect('/my/orders'); }
 - Pass 178Q: PR template; totals/taxes helper + tests; /api/dev/health + x-request-id
 - Pass 178A: Hardening shipping/tracking — @@unique(publicToken), backfill, dev endpoints, e2e checks
 - Release v0.3.0-alpha prepared (CHANGELOG)
+- Pass 179T: Public tracking page (/track/[token]) + read-only API + e2e smoke + noindex

--- a/frontend/src/app/api/public/track/[token]/route.ts
+++ b/frontend/src/app/api/public/track/[token]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+const prisma = new PrismaClient()
+
+export async function GET(_req: Request, ctx: { params: { token: string } }) {
+  const token = String(ctx.params?.token||'').trim()
+  if (!token) return NextResponse.json({ error:'missing token' }, { status:400 })
+  // Read-only public projection (no PII)
+  const o = await prisma.order.findFirst({
+    where: { publicToken: token },
+    select: {
+      id: true,
+      status: true,
+      createdAt: true,
+      updatedAt: true,
+      shippingMethod: true,
+      computedShipping: true,
+      total: true
+    }
+  })
+  if (!o) return NextResponse.json({ error:'not found' }, { status:404 })
+  return NextResponse.json({ ok:true, order:o }, { status:200 })
+}

--- a/frontend/src/app/track/[token]/page.tsx
+++ b/frontend/src/app/track/[token]/page.tsx
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import { statusLabel, shippingLabel } from '@/lib/tracking/labels'
+
+export const metadata = {
+  title: 'Παρακολούθηση παραγγελίας — Dixis',
+  robots: { index:false, follow:false }
+}
+
+async function getData(token:string){
+  const res = await fetch((process.env.NEXT_PUBLIC_SITE_URL||'') + '/api/public/track/' + token, { cache:'no-store' })
+  if(!res.ok) return null
+  return res.json()
+}
+
+export default async function TrackPage({ params }:{ params:{ token:string } }){
+  const data = await getData(params.token)
+  if(!data?.ok){
+    return (
+      <main style={{maxWidth:680, margin:'40px auto', fontFamily:'system-ui, Arial'}}>
+        <h1>Παρακολούθηση παραγγελίας</h1>
+        <p>Δεν βρέθηκε παραγγελία για το συγκεκριμένο token.</p>
+      </main>
+    )
+  }
+  const o = data.order
+  return (
+    <main style={{maxWidth:680, margin:'40px auto', fontFamily:'system-ui, Arial'}}>
+      <h1>Παρακολούθηση παραγγελίας</h1>
+      <section style={{padding:'12px 0'}}>
+        <div><b>Κωδικός:</b> {params.token}</div>
+        <div><b>Κατάσταση:</b> {statusLabel(o.status)}</div>
+        <div><b>Τρόπος αποστολής:</b> {shippingLabel(o.shippingMethod)}</div>
+        {typeof o.computedShipping === 'number' ? <div><b>Μεταφορικά:</b> {new Intl.NumberFormat('el-GR',{style:'currency',currency:'EUR'}).format(o.computedShipping)}</div> : null}
+        {typeof o.total === 'number' ? <div><b>Σύνολο:</b> {new Intl.NumberFormat('el-GR',{style:'currency',currency:'EUR'}).format(o.total)}</div> : null}
+        <div style={{marginTop:10, fontSize:13, color:'#666'}}>Τελευταία ενημέρωση: {new Date(o.updatedAt||o.createdAt).toLocaleString('el-GR')}</div>
+      </section>
+    </main>
+  )
+}

--- a/frontend/src/app/track/page.tsx
+++ b/frontend/src/app/track/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function TrackIndex(){
+  const [token,setToken] = useState('')
+  const router = useRouter()
+  return (
+    <main style={{maxWidth:560, margin:'40px auto', fontFamily:'system-ui, Arial'}}>
+      <h1>Παρακολούθηση παραγγελίας</h1>
+      <p>Εισάγετε τον κωδικό παρακολούθησης (token) που λάβατε με email.</p>
+      <form onSubmit={(e)=>{ e.preventDefault(); if(token.trim()) router.push('/track/' + token.trim()) }}>
+        <input value={token} onChange={e=>setToken(e.target.value)} placeholder="π.χ. d3x...token" style={{width:'100%',padding:'10px',fontSize:16}} />
+        <button type="submit" style={{marginTop:10,padding:'10px 16px',fontSize:16}}>Προβολή</button>
+      </form>
+    </main>
+  )
+}

--- a/frontend/src/lib/tracking/labels.ts
+++ b/frontend/src/lib/tracking/labels.ts
@@ -1,0 +1,18 @@
+export function statusLabel(s?: string){
+  const map: Record<string,string> = {
+    PAID:'Πληρωμή',
+    PACKING:'Συσκευασία',
+    SHIPPED:'Απεστάλη',
+    DELIVERED:'Παραδόθηκε',
+    CANCELLED:'Ακυρώθηκε'
+  }
+  return map[String(s||'').toUpperCase()] || String(s||'—')
+}
+export function shippingLabel(m?: string){
+  const map: Record<string,string> = {
+    PICKUP:'Παραλαβή από κατάστημα',
+    COURIER:'Κούριερ',
+    COURIER_COD:'Κούριερ (Αντικαταβολή)'
+  }
+  return map[String(m||'').toUpperCase()] || '—'
+}

--- a/frontend/tests/tracking/track-ui.spec.ts
+++ b/frontend/tests/tracking/track-ui.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test'
+const base = process.env.PLAYWRIGHT_BASE_URL || process.env.BASE_URL || 'http://127.0.0.1:3001'
+
+test('track index renders', async ({ page }) => {
+  await page.goto(base + '/track')
+  await expect(page.getByRole('heading', { name: 'Παρακολούθηση παραγγελίας' })).toBeVisible()
+})
+
+test('public API invalid token returns 404/400', async ({ request }) => {
+  const r = await request.get(base + '/api/public/track/__invalid__token__')
+  expect([400,404]).toContain(r.status())
+})


### PR DESCRIPTION
## Summary
- Public tracking UI (/track, /track/[token])
- Read-only GET /api/public/track/[token]
- noindex meta
- e2e smoke for UI & invalid token

## Reports
- CODEMAP: docs/AGENT/SYSTEM/routes.md
- TEST-REPORT: Actions → this PR run
- RISKS-NEXT: frontend/docs/OPS/STATE.md