### PR TITLE
feat(tracking): invalid-token UX + A11Y polish (Pass 180T.F)

### DIFF
--- a/frontend/docs/OPS/STATE.md
+++ b/frontend/docs/OPS/STATE.md
@@ -956,6 +956,7 @@ export default function Page() { redirect('/my/orders'); }
 - Pass 179S: UX polish for /track/[token] — loading + error boundary ✅
 - Pass 179R: Legacy redirect /orders/track/[token] → /track/[token] + e2e ✅
 - Pass 180T: Tracking Timeline UI — visual order flow (PAID → PACKING → SHIPPED → DELIVERED) + Greek labels ✅
+- Pass 180T.F: Invalid-token UX + A11Y polish (role/aria-current/alert) ✅
 
 ## Pass 179E — Status Email Tracking Links (2025-10-11)
 **Goal**: Add deep links to public order tracking page in status change emails
@@ -1046,3 +1047,32 @@ export default function Page() { redirect('/my/orders'); }
 - Greek-first labels maintain local market focus
 - No database or API changes required
 - Complements existing text-based status display
+
+## Pass 180T.F — Invalid-Token UX + A11Y Polish (2025-10-12)
+**Goal**: Improve accessibility and user experience for invalid tokens on tracking page
+
+**Changes**:
+- ✅ Added A11Y roles to Timeline: `<ol role="list">`, `<li role="listitem">`, `aria-current="step"`
+- ✅ Added `role="alert"` to cancelled status indicator in Timeline
+- ✅ Enhanced invalid-token UX: Friendly Greek error message with `role="alert"`
+- ✅ Created e2e test `tests/tracking/invalid-token.spec.ts`: Validates error message for invalid tokens
+
+**Technical Details**:
+- **Timeline A11Y**: Semantic list structure with ARIA roles for screen readers
+- **Current Step**: `aria-current="step"` marks active order status in timeline
+- **Alert Roles**: Important messages (cancelled, invalid token) use `role="alert"` for immediate announcement
+- **Invalid Token Message**: "Μη έγκυρο token. Δεν βρέθηκε παραγγελία. Ελέγξτε το link στο email ή επικοινωνήστε μαζί μας."
+- **Visual Styling**: Red alert box (#fff4f4 background, #f5c2c7 border) for error state
+
+**Implementation Notes**:
+- Changed Timeline from `<div>` to semantic `<ol>` with proper list item roles
+- `aria-current` dynamically set only on current status step
+- Error message provides actionable guidance (check email link, contact support)
+- No business logic changes - purely UX/A11Y enhancement
+
+**Impact**:
+- Better screen reader support for visually impaired users
+- Clear error messaging for invalid/expired tracking links
+- WCAG compliance improvements
+- More helpful UX when users have token issues
+- Maintains Greek-first approach with accessible patterns

--- a/frontend/src/app/track/[token]/components/Timeline.tsx
+++ b/frontend/src/app/track/[token]/components/Timeline.tsx
@@ -11,13 +11,13 @@ export default function Timeline({ currentStatus }: TimelineProps) {
 
   return (
     <div style={{ padding: '20px 0' }}>
-      <div style={{ display: 'flex', alignItems: 'center', position: 'relative' }}>
+      <ol role="list" style={{ display: 'flex', alignItems: 'center', position: 'relative', listStyle: 'none', margin: 0, padding: 0 }}>
         {STATUS_ORDER.map((status, idx) => {
           const isCompleted = !isCancelled && idx <= currentIdx
           const isCurrent = status === currentStatus && !isCancelled
 
           return (
-            <div key={status} style={{ flex: 1, position: 'relative', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <li key={status} role="listitem" aria-current={isCurrent ? "step" : undefined} style={{ flex: 1, position: 'relative', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
               {/* Connecting line */}
               {idx < STATUS_ORDER.length - 1 && (
                 <div style={{
@@ -62,14 +62,14 @@ export default function Timeline({ currentStatus }: TimelineProps) {
               }}>
                 {EL_LABEL[status]}
               </div>
-            </div>
+            </li>
           )
         })}
-      </div>
+      </ol>
 
       {/* Cancelled status indicator */}
       {isCancelled && (
-        <div style={{
+        <div role="alert" style={{
           marginTop: '20px',
           padding: '12px',
           backgroundColor: '#fef2f2',

--- a/frontend/src/app/track/[token]/page.tsx
+++ b/frontend/src/app/track/[token]/page.tsx
@@ -16,11 +16,13 @@ async function getData(token:string){
 
 export default async function TrackPage({ params }:{ params:{ token:string } }){
   const data = await getData(params.token)
-  if(!data?.ok){
+  if(!data?.ok || !data?.order){
     return (
       <main style={{maxWidth:680, margin:'40px auto', fontFamily:'system-ui, Arial'}}>
         <h1>Παρακολούθηση παραγγελίας</h1>
-        <p>Δεν βρέθηκε παραγγελία για το συγκεκριμένο token.</p>
+        <div role="alert" style={{background:'#fff4f4', border:'1px solid #f5c2c7', padding:12, borderRadius:8, marginTop:12}}>
+          <b>Μη έγκυρο token.</b> Δεν βρέθηκε παραγγελία. Ελέγξτε το link στο email ή επικοινωνήστε μαζί μας.
+        </div>
       </main>
     )
   }

--- a/frontend/tests/tracking/invalid-token.spec.ts
+++ b/frontend/tests/tracking/invalid-token.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test'
+const base = process.env.PLAYWRIGHT_BASE_URL || process.env.BASE_URL || 'http://127.0.0.1:3001'
+
+test('invalid token shows friendly Greek message', async ({ page }) => {
+  await page.goto(`${base}/track/__definitely_invalid__`)
+  await expect(page.getByRole('heading', { name: 'Παρακολούθηση παραγγελίας' })).toBeVisible()
+  await expect(page.getByRole('alert')).toContainText(/Μη έγκυρο token|Δεν βρέθηκε παραγγελία/)
+})


### PR DESCRIPTION
## Summary
Enhance accessibility and user experience for public order tracking page with A11Y improvements and better invalid token messaging.

## Changes
- ✅ Timeline A11Y: Converted to semantic `<ol role="list">` with `<li role="listitem">`
- ✅ Current step marked with `aria-current="step"` for screen reader navigation
- ✅ Cancelled status uses `role="alert"` for immediate announcement
- ✅ Invalid token shows friendly Greek error message with actionable guidance
- ✅ Created e2e test `tests/tracking/invalid-token.spec.ts`
- ✅ Updated STATE.md with Pass 180T.F documentation

## Accessibility Improvements
- **Semantic Lists**: Timeline now uses proper `<ol>` instead of generic `<div>`
- **ARIA Roles**: `role="list"`, `role="listitem"` for better screen reader support
- **Current Step**: `aria-current="step"` marks active order status
- **Alert Roles**: Critical messages (cancelled, invalid token) use `role="alert"`

## Invalid Token UX
**Before**: Generic "Δεν βρέθηκε παραγγελία για το συγκεκριμένο token."  
**After**: 
```
Μη έγκυρο token. Δεν βρέθηκε παραγγελία. 
Ελέγξτε το link στο email ή επικοινωνήστε μαζί μας.
```

## Reports
- CODEMAP: docs/AGENT/SYSTEM/routes.md
- TEST-REPORT: Actions → this PR run
- RISKS-NEXT: frontend/docs/OPS/STATE.md

## Test Summary
- `frontend/tests/tracking/invalid-token.spec.ts` επιβεβαιώνει φιλικό μήνυμα (role=alert)

## Impact
- ✅ Better screen reader support for visually impaired users
- ✅ Clear, actionable error messaging for invalid tokens
- ✅ WCAG 2.1 compliance improvements
- ✅ More helpful UX when tracking links have issues
- ✅ Zero breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
