### PR TITLE
fix: syntax error in status-email-link test (HF-189B)

### DIFF
--- a/frontend/tests/emails/status-email-link.spec.ts
+++ b/frontend/tests/emails/status-email-link.spec.ts
@@ -31,7 +31,7 @@ test('status email contains public tracking link (if dev mailbox available)', as
 
   // mailbox (αν υπάρχει)
   const inbox = await request.get(base+`/api/dev/mailbox?to=${email}`)
-  if (inbox.status() \!== 200){ test.skip(true, 'dev mailbox not available'); return; }
+  if (inbox.status() !== 200){ test.skip(true, 'dev mailbox not available'); return; }
   const j = await inbox.json()
   expect(j.item?.html || j.item?.text || '').toMatch(/\/track\//i)
 })


### PR DESCRIPTION
## Summary
Hotfix: διορθώθηκε συντακτικό στο e2e `status-email-link.spec.ts` ( `!==` ).

## Acceptance Criteria
- [x] Build, typecheck, Danger green.
- [x] E2E (PostgreSQL) green.

## Test Plan
- CI: "CI / build-and-test", "typecheck", "E2E (PostgreSQL)".

## Reports
- CODEMAP: docs/AGENT/SYSTEM/routes.md
- TEST-REPORT: Actions → this PR run
- RISKS-NEXT: frontend/docs/OPS/STATE.md
