### PR TITLE
feat(admin): Producers UX — search/filter/sort + nav link + e2e (Pass 193)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-193.md
+++ b/docs/AGENT/SUMMARY/Pass-193.md
@@ -1,0 +1,20 @@
+# TL;DR — Pass 193: Admin Producers UX polish
+
+## Changes
+- **UI Refactor**: Converted `/admin/producers` from client to server component
+- **Search**: Text search on producer name via `?q=` URL parameter
+- **Filter**: Active/All toggle via `?active=only` parameter
+- **Sort**: Name ascending/descending via `?sort=name-asc|name-desc`
+- **API**: Enhanced GET /api/admin/producers with q/active/sort support
+- **E2E Test**: `frontend/tests/admin/producers-ux.spec.ts`
+
+## Technical Details
+- Server component uses Next.js 15.5 searchParams (async)
+- API queries Prisma with dynamic orderBy based on sort param
+- Greek-first UI labels throughout
+- No schema/migration changes (idempotent)
+
+## Testing
+```bash
+npm run test:e2e frontend/tests/admin/producers-ux.spec.ts
+```

--- a/frontend/docs/OPS/STATE.md
+++ b/frontend/docs/OPS/STATE.md
@@ -1,3 +1,21 @@
+## Pass 193 — Admin Producers UX polish (search/filter/sort + nav link) + e2e ✅
+- **Search**: Text search on producer name via `?q=` parameter
+- **Filter**: Active/All filter via `?active=only` or `?active=` (all)
+- **Sort**: Name ascending/descending via `?sort=name-asc` or `?sort=name-desc`
+- **Server Component**: Converted from client to server component using Next.js searchParams
+- **Greek UI**: EL-first labels (Αναζήτηση ονόματος, Μόνο ενεργοί, Όνομα ↑/↓)
+- **E2E Test**: `tests/admin/producers-ux.spec.ts` - validates search, filter, and sort functionality
+- **API Enhancement**: GET /api/admin/producers now supports q/active/sort parameters
+
+### UX Features
+```typescript
+// URL-based filtering
+/admin/producers?q=Ελιές&active=only&sort=name-desc
+
+// API parameters
+GET /api/admin/producers?q=search&active=only&sort=name-asc|name-desc
+```
+
 ## Pass 192 — Observability Lite rollout (x-request-id + /api/dev/health db-ping) + e2e ✅
 - **x-request-id Header**: Added to all admin producers API responses (GET/POST/PATCH/DELETE)
 - **Structured Logging**: `logWithId(rid, msg, details)` helper logs with request ID prefix for traceability

--- a/frontend/src/app/api/admin/producers/route.ts
+++ b/frontend/src/app/api/admin/producers/route.ts
@@ -19,22 +19,24 @@ export async function GET(req: Request) {
   // TODO: Add admin session check (assume middleware/guard exists)
   const { searchParams } = new URL(req.url)
   const q = searchParams.get('q') || ''
-  const onlyActive = searchParams.get('active') === '1'
+  const active = searchParams.get('active') || ''
+  const sort = searchParams.get('sort') || 'name-asc'
 
+  // UX-FILTERS: q (search), active (only/all), sort (name-asc/name-desc)
   const items = await prisma.producer.findMany({
     where: {
       AND: [
         q ? { name: { contains: q } } : {},
-        onlyActive ? { isActive: true } : {}
+        active === 'only' ? { isActive: true } : {}
       ]
     },
-    orderBy: { name: 'asc' },
+    orderBy: { name: sort === 'name-desc' ? 'desc' : 'asc' },
     take: 100
   })
 
   const res = NextResponse.json({ items })
   res.headers.set('x-request-id', rid)
-  logWithId(rid, 'GET /api/admin/producers', { count: items.length, q, onlyActive })
+  logWithId(rid, 'GET /api/admin/producers', { count: items.length, q, active, sort })
   return res
 }
 

--- a/frontend/tests/admin/producers-ux.spec.ts
+++ b/frontend/tests/admin/producers-ux.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test'
+const base = process.env.PLAYWRIGHT_BASE_URL || process.env.BASE_URL || 'http://127.0.0.1:3001'
+const adminPhone = (process.env.ADMIN_PHONES||'+306900000084').split(',')[0]
+const bypass = process.env.OTP_BYPASS || '000000'
+
+async function adminCookie(request:any){
+  await request.post(base+'/api/auth/request-otp', { data:{ phone: adminPhone }})
+  const vr = await request.post(base+'/api/auth/verify-otp', { data:{ phone: adminPhone, code: bypass }})
+  return (await vr.headersArray()).find((h:any)=>h.name.toLowerCase()==='set-cookie')?.value?.split('dixis_session=')[1]?.split(';')[0] || ''
+}
+
+// Helper: seed via API
+async function createProducer(request:any, cookie:string, name:string, region='Αττική', category='Είδη τροφίμων', isActive=true){
+  const slug = name.toLowerCase().replace(/\s+/g, '-')
+  const res = await request.post(base + '/api/admin/producers', {
+    headers:{ cookie:`dixis_session=${cookie}` },
+    data:{ name, slug, region, category, isActive }
+  })
+  expect([200,201]).toContain(res.status())
+  return await res.json()
+}
+
+test('Admin producers: search / filter / sort works', async ({ request, page }) => {
+  const cookie = await adminCookie(request)
+  const ts = Date.now()
+
+  // Seed 3 producers with different names
+  await createProducer(request, cookie, `Α-Ελιές ${ts}`, 'Χαλκιδική', 'Ελιές', true)
+  await createProducer(request, cookie, `Μ-Μέλι ${ts}`, 'Εύβοια', 'Μέλι', true)
+  await createProducer(request, cookie, `Ω-Οίνος ${ts}`, 'Νεμέα', 'Κρασί', false)
+
+  // Test 1: Search with q filter (should show only Ελιές)
+  await page.goto(`/admin/producers?q=${encodeURIComponent('Ελιές')}&active=only&sort=name-asc`)
+  await expect(page.getByText('Παραγωγοί')).toBeVisible()
+
+  // Should see only "Α-Ελιές"
+  await expect(page.getByText(`Α-Ελιές ${ts}`)).toBeVisible()
+  await expect(page.getByText(`Μ-Μέλι ${ts}`)).not.toBeVisible({ timeout: 500 })
+
+  // Test 2: Sort descending (clear search, show all)
+  await page.goto(`/admin/producers?sort=name-desc`)
+
+  // Wait for table to load
+  const rows = page.locator('tbody tr')
+  await expect(rows.first()).toBeVisible()
+
+  // Desc → "Ω-Οίνος" should be first
+  await expect(rows.first()).toContainText(`Ω-Οίνος ${ts}`)
+
+  // Test 3: Filter only active
+  await page.goto(`/admin/producers?active=only`)
+
+  // Should see "Α-Ελιές" and "Μ-Μέλι" but not "Ω-Οίνος" (inactive)
+  await expect(page.getByText(`Α-Ελιές ${ts}`)).toBeVisible()
+  await expect(page.getByText(`Μ-Μέλι ${ts}`)).toBeVisible()
+  await expect(page.getByText(`Ω-Οίνος ${ts}`)).not.toBeVisible({ timeout: 500 })
+})


### PR DESCRIPTION
## Summary
UI enhancements for `/admin/producers` with URL-based search, filtering, and sorting capabilities.

## Changes

### 🎨 UI Refactor (`app/admin/producers/page.tsx`)
- **Server Component**: Converted from client to server component using Next.js 15.5 async searchParams
- **Search**: Text input with `?q=` parameter for producer name search
- **Filter**: Dropdown for Active/All producers via `?active=only` parameter
- **Sort**: Dropdown for Name ↑/↓ via `?sort=name-asc|name-desc`
- **Greek UI**: EL-first labels (Αναζήτηση ονόματος, Μόνο ενεργοί, Όνομα ↑/↓)

### 🔌 API Enhancement (`api/admin/producers/route.ts`)
- **Search**: `?q=` parameter filters by producer name (contains)
- **Filter**: `?active=only` shows only active producers
- **Sort**: `?sort=name-asc|name-desc` sorts by name ascending/descending
- **Logging**: Updated to include new filter parameters in observability logs

### ✅ E2E Test (`tests/admin/producers-ux.spec.ts`)
- Seeds 3 test producers with different names/regions/categories
- Tests search functionality (filters by name)
- Tests active/all filtering (shows only active producers)
- Tests sort order (ascending/descending by name)
- Uses admin authentication with OTP bypass

## Technical Notes
- **Idempotent**: No schema/migration changes
- **Cross-env**: Works with SQLite (CI) and PostgreSQL (prod)
- **Server-side**: Fetch happens on server, no client-side JS for filtering
- **URL-based**: All state in URL, shareable/bookmarkable

## Testing
```bash
npm run test:e2e frontend/tests/admin/producers-ux.spec.ts
```

## Example Usage
```
# Search for producers with "Ελιές" in name, show only active, sort by name descending
/admin/producers?q=Ελιές&active=only&sort=name-desc
```

## Acceptance Criteria
- [x] Search input filters producers by name
- [x] Active filter shows only active producers
- [x] Sort dropdown changes order (asc/desc)
- [x] E2E test validates all functionality
- [x] Greek UI labels throughout

## Reports
- **STATE**: frontend/docs/OPS/STATE.md (Pass 193)
- **SUMMARY**: docs/AGENT/SUMMARY/Pass-193.md
- **TEST**: GitHub Actions → E2E PostgreSQL workflow

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)