### PR TITLE
docs: Pass 200A completion summary

### DIFF
--- a/frontend/docs/OPS/PASSES/200A-tracking-public-token.md
+++ b/frontend/docs/OPS/PASSES/200A-tracking-public-token.md
@@ -1,0 +1,121 @@
+# Pass 200A — Public Tracking via Token (Complete)
+
+**Status**: ✅ MERGED (#520)
+**Branch**: `feat/tracking-public-token-200A`
+**Duration**: HF-200A.1 + HF-200A.2 + HF-200A.3 → GREEN
+**Outcome**: Public order tracking via token fully functional
+
+---
+
+## 🎯 Objectives (100% Complete)
+
+- [x] API: `GET /api/orders/public/[token]` returns order summary (safe fields only)
+- [x] Page: `/track/[token]` displays status, products, totals (EL format)
+- [x] Dev helper: `/api/dev/order-token?id=X` for E2E testing
+- [x] E2E test: Full tracking flow (seed → checkout → token → page)
+- [x] No schema changes required
+- [x] TypeScript strict mode compliance
+
+---
+
+## 📦 Deliverables
+
+### HF-200A.1 — Route Conflict Fix
+**Problem**: Duplicate tracking route (storefront group vs root)
+**Solution**: Removed `(storefront)/track/[token]`, kept `/track/[token]` from Pass 189A
+**Files**: Deleted `frontend/src/app/(storefront)/track/`
+
+### HF-200A.2 — Initial Implementation
+**Files Created**:
+- `frontend/src/app/api/orders/public/[token]/route.ts` - Public API endpoint
+- `frontend/src/app/api/dev/order-token/route.ts` - Dev helper to get token from ID
+- `frontend/src/app/api/dev/seed-product/route.ts` - Product seeding (❌ missing producer)
+- `frontend/tests/tracking/public-token.spec.ts` - E2E test coverage
+
+**Result**: ❌ TypeCheck failed (Product schema requires producer relation)
+
+### HF-200A.3 — Producer-Aware Dev Seed (Final Fix)
+**Problem**: Product schema requires `producerId` field
+**Root Cause**: `frontend/src/app/api/dev/seed-product/route.ts` created products without producer
+
+**Solution**:
+```typescript
+// frontend/src/app/api/dev/seed-producer-product/route.ts
+// 1) Upsert Producer first
+const producer = await prisma.producer.upsert({
+  where: { slug: 'test-dev-producer' },
+  update: {},
+  create: {
+    slug: 'test-dev-producer',
+    name: 'Δοκιμαστικός Παραγωγός',
+    region: 'Αττική',
+    category: 'Δοκιμή',
+    isActive: true
+  }
+})
+
+// 2) Create Product with producerId
+const item = await prisma.product.create({
+  data: { ...productFields, producerId: producer.id }
+})
+```
+
+**Changes**:
+- Created `/api/dev/seed-producer-product` (replaces seed-product)
+- Updated E2E test to use producer-aware endpoint
+- Removed old `/api/dev/seed-product`
+
+**Result**: ✅ ALL CHECKS GREEN (typecheck, build, E2E, QA, CodeQL)
+
+---
+
+## ✅ CI Results (All Passing)
+
+```
+✅ typecheck (33s)
+✅ build-and-test (1m 3s)
+✅ E2E (PostgreSQL) (3m 11s)
+✅ Quality Assurance (1m 26s)
+✅ quality-gates (4s)
+✅ CodeQL (3s)
+✅ Analyze (javascript) (1m 43s)
+✅ danger (13s, 20s)
+✅ gate (6s)
+✅ triage (4s)
+```
+
+---
+
+## 🔍 Key Technical Decisions
+
+1. **Reused Existing Tracking Page**: `/track/[token]` from Pass 189A (no duplication)
+2. **Schema Compliance**: No new migrations, used existing `publicToken` field
+3. **Dev Helpers Only**: Production-blocked endpoints (`DIXIS_ENV === 'production'`)
+4. **Producer Upsert Pattern**: Ensures test stability (idempotent seeding)
+5. **E2E Coverage**: Full flow test (seed → checkout → token fetch → page render)
+
+---
+
+## 📊 Impact
+
+- **Public Tracking**: Users can track orders without login (via token link)
+- **E2E Stability**: Producer-aware seeding prevents schema violations
+- **Dev Experience**: Clean dev helper endpoints for testing
+- **Code Quality**: TypeScript strict mode, all checks passing
+
+---
+
+## 🎖️ Related PRs
+
+- **#520**: ✅ MERGED (Pass 200A implementation)
+- **#484**: Already closed (superseded by #520)
+- **#485**: Already closed (superseded by #520)
+
+---
+
+## 🚀 Next Steps
+
+Tracking functionality complete. Ready for next replay bucket or feature work.
+
+**Generated**: 2025-10-13
+**Pass**: 200A → HF-200A.3 → MERGED


### PR DESCRIPTION
## Summary
Documentation for Pass 200A completion (public tracking via token implementation).

## Changes
- Add comprehensive Pass 200A summary document
- Documents all 3 hotfixes (HF-200A.1, HF-200A.2, HF-200A.3)
- CI results, technical decisions, and impact analysis

## Acceptance Criteria
- [x] Complete timeline of Pass 200A execution
- [x] All hotfixes documented with technical details
- [x] CI results captured (all checks passing)
- [x] Technical decisions explained
- [x] Impact analysis included

## Test Plan
- CI Smoke/E2E tests pass (no code changes, docs only)
- Manual: Review markdown rendering in docs viewer
- Verify no broken links in documentation

## Reports
- **CODEMAP**: `frontend/docs/OPS/PASSES/200A-tracking-public-token.md`
- **TEST-REPORT**: Actions → this PR run (all passing)
- **RISKS-NEXT**: `frontend/docs/OPS/STATE.md`

## Related
- PR #520: ✅ MERGED (implementation)
- Superseded: #484, #485 (older tracking PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
