### PR TITLE
ops(docs): Enable PDAC-lite SOP + sub-agent configs (Pass 202P)

### DIFF
--- a/docs/AGENT/SOPs/SOP-PDAC-lite.md
+++ b/docs/AGENT/SOPs/SOP-PDAC-lite.md
@@ -1,0 +1,225 @@
+# SOP — PDAC-lite (Plan → Delegate → Assess → Codify)
+
+## Overview
+Lightweight workflow για structured planning + parallel research + quality gates πριν την κωδικοποίηση.
+
+---
+
+## Phase 1: Plan (Plan Mode, No Writes)
+
+### Objectives
+- Συγκέντρωση context από `docs/AGENT/SYSTEM/*` και τελευταίο `SUMMARY/Pass-*`
+- Διάσπαση σύνθετου στόχου σε actionable steps
+- Αναγνώριση dependencies, risks, test strategy
+
+### Deliverables
+- `docs/AGENT/TASKS/Pass-<ID>.md` με sections:
+  - Στόχος
+  - Αποφάσεις (τεχνικές επιλογές)
+  - Βήματα που υλοποιήθηκαν (placeholder)
+  - Tests (σχέδιο)
+  - Ρίσκα/Εκκρεμότητες
+
+### Tools
+- Read, Grep, Glob (read-only)
+- NO Write, Edit, Bash with side effects
+
+### Exit Criteria
+- Plan document complete
+- User approves with ExitPlanMode
+
+---
+
+## Phase 2: Delegate (Sub-Agents, Parallel)
+
+### Objectives
+- Παράλληλη έρευνα σε 3 εξειδικευμένα domains
+- Append findings ως "Appendices" στο `TASKS/Pass-<ID>.md`
+
+### Sub-Agents
+
+#### 1. plan-agent (Architecture)
+**Model**: Opus
+**Tools**: Read, Grep, Search_files
+**Responsibilities**:
+- High-level decomposition
+- Identify architectural patterns (reuse existing components)
+- Flag anti-patterns or refactoring needs
+
+**Deliverable**: Append "## Plan Appendix" to TASKS
+
+#### 2. scan-agent (Inventory)
+**Model**: Sonnet
+**Tools**: Read, Grep, Glob
+**Responsibilities**:
+- List Next.js routes (`app/` structure)
+- List API endpoints (`app/api/**`)
+- List Prisma models (`prisma/schema.prisma`)
+- List existing E2E tests (`tests/**/*.spec.ts`)
+
+**Deliverable**: Append "## Inventory Appendix" to TASKS (≤300 lines)
+
+#### 3. test-agent (Test Strategy)
+**Model**: Sonnet
+**Tools**: Read, Grep, Search_files
+**Responsibilities**:
+- Propose minimal E2E test set (2-3 scenarios max)
+- Define fixtures/seeding needs
+- Identify test data requirements
+
+**Deliverable**: Append "## Test Plan Appendix" to TASKS
+
+### Fallback
+Αν sub-agents δεν υπάρχουν: Parent agent εκτελεί όλα τα βήματα σε Plan Mode
+
+---
+
+## Phase 3: Assess (Synthesis + Quality Gates)
+
+### Objectives
+- Σύνθεση findings από όλες τις πηγές
+- Validation πριν από code changes
+
+### Tasks
+1. **TL;DR Synthesis** (≤200 tokens):
+   - Summarize goal, approach, risks
+   - Write to `SUMMARY/Pass-<ID>.md`
+
+2. **PR Body Preparation**:
+   - Summary section
+   - Acceptance Criteria (from TASKS)
+   - Test Plan (from test-agent appendix)
+   - Reports links (CODEMAP, TEST-REPORT, RISKS-NEXT)
+
+3. **Quality Gates** (STOP if missing):
+   - [ ] Acceptance Criteria defined
+   - [ ] Test plan exists (≥1 E2E scenario)
+   - [ ] Risks documented
+   - [ ] No schema changes OR migration plan ready
+
+### Exit Criteria
+- All quality gates pass
+- User approves to proceed to Codify
+
+---
+
+## Phase 4: Codify (Implementation + Tests)
+
+### Objectives
+- Μικρά, atomic commits με συνεπή tests
+- Συνεχής επαλήθωση (build + E2E locally)
+
+### Best Practices
+1. **Small commits**:
+   - 1 commit ανά logical unit (helper, API route, UI component)
+   - Test με κάθε commit όπου είναι δυνατόν
+
+2. **Test-first όπου εφικτό**:
+   - Γράψε E2E test (failing)
+   - Implement feature
+   - Verify E2E green
+
+3. **PR hygiene**:
+   - Title: `feat/fix(...): Description (Pass <ID>)`
+   - Labels: `ai-pass`, `risk-ok` (if applicable)
+   - Body: Pre-filled από Assess phase
+   - Auto-merge: `--auto --squash` on green
+
+4. **Compact at end**:
+   - Update `TASKS/Pass-<ID>.md` με actual steps
+   - Finalize `SUMMARY/Pass-<ID>.md` (keep ≤2000 tokens)
+   - Update `docs/OPS/STATE.md`
+
+### Exit Criteria
+- PR merged
+- Documentation complete
+- No regressions (all CI green)
+
+---
+
+## Integration με Existing SOPs
+
+### Συμβατότητα
+- **SOP-Feature-Pass**: PDAC-lite είναι pre-step για το Branch→PR→Docs
+  - Plan/Delegate/Assess → Branch (Phase 4 Codify)
+  - Codify → PR + Tests + Docs (existing SOP)
+
+- **SOP-Context-Hygiene**: Plan phase διαβάζει `SYSTEM/*` και `SUMMARY/*`
+
+### When to Use PDAC-lite
+- ✅ Σύνθετα features (>3 files affected)
+- ✅ Architectural decisions needed
+- ✅ Unclear test strategy
+- ❌ Trivial fixes (<10 LOC)
+- ❌ Documentation-only changes
+
+---
+
+## Example Workflow
+
+```bash
+# User Request: "Add shipping method selection to checkout"
+
+## 1. Plan (Plan Mode)
+- Read SYSTEM/routes.md (find checkout routes)
+- Read SYSTEM/db-schema.md (check Order fields)
+- Create TASKS/Pass-202S.md (goal + template)
+- ExitPlanMode → User approves
+
+## 2. Delegate (Sub-Agents)
+- plan-agent: Suggests reuse lib/cart/totals.ts, add shippingMethod enum
+- scan-agent: Lists /api/checkout, Order model, totals.spec.ts
+- test-agent: Proposes 2 E2E tests (COD, Pickup)
+→ All append to TASKS/Pass-202S.md
+
+## 3. Assess
+- Write SUMMARY/Pass-202S.md (TL;DR)
+- Prepare PR body (AC: 3 shipping options, tests: 2 scenarios)
+- Quality gates: ✅ AC defined, ✅ Tests planned, ✅ No schema change
+→ User approves
+
+## 4. Codify
+- Branch: feat/shipping-method-202S
+- Commit 1: Add shippingMethod to TotalsInput interface
+- Commit 2: Update checkout API to accept shippingMethod
+- Commit 3: Add 2 E2E tests (both green)
+- PR: auto-merge on green
+- Docs: Update TASKS (actual steps), finalize SUMMARY
+```
+
+---
+
+## Metrics & Success Criteria
+
+### Process Metrics
+- **Plan phase duration**: ≤10 min (parent) or ≤20 min (with sub-agents)
+- **Delegate completion**: All 3 agents report back OR timeout (30 min max)
+- **Assess quality gates**: 100% pass rate (STOP if any fail)
+- **Codify cycle time**: Branch → Merged ≤60 min for simple features
+
+### Quality Metrics
+- **PR hygiene**: 100% (all PRs have Reports/AC/Tests)
+- **Test coverage**: ≥1 E2E per feature
+- **Rework rate**: <10% (PRs needing hotfixes after merge)
+- **Context portability**: New chat can resume from TASKS/SUMMARY
+
+---
+
+## Troubleshooting
+
+### Issue: Sub-agents timeout
+**Solution**: Continue with parent agent research, document in TASKS that sub-agents weren't used
+
+### Issue: Quality gate fails (missing AC)
+**Solution**: Return to Plan phase, refine TASKS document, re-Assess
+
+### Issue: Codify phase introduces regression
+**Solution**: Revert commit, add regression test, re-implement
+
+### Issue: TASKS too long (>5000 tokens)
+**Solution**: Move appendices to separate files (`TASKS/Pass-<ID>-inventory.md`), link from main TASKS
+
+---
+
+## Change Log
+- 2025-10-13: Initial PDAC-lite SOP (no app code changes)

--- a/docs/AGENT/SUMMARY/Pass-201S.post.md
+++ b/docs/AGENT/SUMMARY/Pass-201S.post.md
@@ -1,0 +1,18 @@
+# TL;DR — Pass 201S.post
+
+## Outcomes
+- **PR #522** (Pass 201S - Shipping Totals): ✅ MERGED (all checks GREEN)
+- **PR #521** (Pass 200A docs): ✅ MERGED (after PR hygiene fix)
+
+## Actions Taken
+1. Monitored PR #522: All checks passed (typecheck, build, E2E, QA, CodeQL)
+2. Fixed PR #521 hygiene:
+   - Updated body with all required sections (Summary, AC, Test Plan, Reports)
+   - Added labels (ai-pass, risk-ok)
+   - PR auto-merged despite earlier Danger/Smoke failures
+3. Both PRs successfully merged to main
+
+## Result
+- Unified totals helper now in production
+- Pass 200A documentation complete
+- All CI checks passing

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,3 +1,46 @@
+# OS / STATE — Pass 202P Complete (PDAC-lite SOP)
+
+**Date**: 2025-10-13
+**Status**: PDAC-lite Workflow Enabled
+**Branch**: ci/pass-ci01-stabilize (pending docs-only commit)
+
+## Pass 202P — Enable PDAC-lite (Plan→Delegate→Assess→Codify) ✅
+
+**Date**: 2025-10-13
+**Files**:
+- `docs/AGENT/SOPs/SOP-PDAC-lite.md` — 4-phase structured workflow methodology
+- `~/.claude/agents/plan-agent.md` — Architecture planning sub-agent (Opus, read-only)
+- `~/.claude/agents/scan-agent.md` — Inventory scanner sub-agent (Sonnet, read-only)
+- `~/.claude/agents/test-agent.md` — E2E test strategy sub-agent (Sonnet, read-only)
+
+**Changes**:
+- ✅ Created comprehensive PDAC-lite SOP with 4-phase workflow
+- ✅ Phase 1 (Plan): Context gathering in Plan Mode (read-only, no writes)
+- ✅ Phase 2 (Delegate): 3 specialized sub-agents append findings to TASKS
+- ✅ Phase 3 (Assess): Synthesis + quality gates (AC, tests, risks)
+- ✅ Phase 4 (Codify): Small commits, PR hygiene, documentation
+- ✅ Integration with existing SOP-Feature-Pass
+- ✅ Fallback if sub-agents unavailable (parent agent research)
+- ✅ Example workflow for shipping method selection
+- ✅ Metrics, troubleshooting, and success criteria
+
+**Architecture**:
+- Documentation-only changes (no app code modified)
+- Sub-agents use read-only tools (Read, Grep, Glob, Search_files)
+- plan-agent: Opus model for high-level architecture/decomposition
+- scan-agent: Sonnet model for inventory (routes, API, DB models, tests)
+- test-agent: Sonnet model for E2E test strategy (2-3 scenarios max)
+- Idempotent operation (safe to run multiple times)
+
+**When to Use PDAC-lite**:
+- ✅ Complex features (>3 files affected)
+- ✅ Architectural decisions needed
+- ✅ Unclear test strategy
+- ❌ Trivial fixes (<10 LOC)
+- ❌ Documentation-only changes
+
+---
+
 # OS / STATE — Pass 169 Complete
 
 **Date**: 2025-10-08


### PR DESCRIPTION
## Summary

Enable lightweight Plan→Delegate→Assess→Codify workflow for complex features. Documentation-only changes, no app code modified.

**Changes**:
- Created `docs/AGENT/SOPs/SOP-PDAC-lite.md`: 4-phase methodology (Plan→Delegate→Assess→Codify)
- Created 3 sub-agent configs at `~/.claude/agents/`:
  - `plan-agent.md`: Architecture planning (Opus, read-only)
  - `scan-agent.md`: Inventory scanner (Sonnet, read-only)
  - `test-agent.md`: E2E test strategy (Sonnet, read-only)
- Added `docs/AGENT/SUMMARY/Pass-201S.post.md`: PR settlement summary from Pass 201S
- Updated `docs/OPS/STATE.md`: Added Pass 202P entry

**When to use PDAC-lite**:
- ✅ Complex features (>3 files affected)
- ✅ Architectural decisions needed
- ✅ Unclear test strategy
- ❌ Trivial fixes (<10 LOC)

## Acceptance Criteria

- [x] SOP document created with full 4-phase workflow
- [x] 3 sub-agent configs created (plan/scan/test)
- [x] STATE.md updated with Pass 202P
- [x] No app code changes
- [x] Integration with existing SOP-Feature-Pass documented

## Test Plan

Documentation-only PR, no tests required.

## Reports

- **CODEMAP**: docs/AGENT/SOPs/
- **STATE**: docs/OPS/STATE.md
- **RISKS**: None (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)