### PR TITLE
feat(admin): Orders totals (read-only) via unified helper + e2e (Pass 203A)

### DIFF
--- a/frontend/src/lib/admin/orders/totalsPresenter.ts
+++ b/frontend/src/lib/admin/orders/totalsPresenter.ts
@@ -1,0 +1,40 @@
+import { calcTotals, fmtEUR } from '@/lib/cart/totals'
+
+type Line = { price?: number; qty?: number; quantity?: number }
+type OrderLike = Record<string, any>
+
+/** Προσπάθησε να εξάγεις lines/shipping από το αντικείμενο παραγγελίας, αλλιώς κάνε ασφαλείς προσεγγίσεις. */
+export function computeDisplayTotals(order: OrderLike){
+  const items: Line[] =
+    Array.isArray(order?.items) ? order.items :
+    Array.isArray(order?.lines) ? order.lines :
+    Array.isArray(order?.orderItems) ? order.orderItems :
+    []
+
+  const shippingMethod: 'PICKUP'|'COURIER'|'COURIER_COD' =
+    (order?.shippingMethod as any) || 'COURIER'
+
+  const baseShipping =
+    typeof order?.computedShipping === 'number' ? order.computedShipping :
+    typeof order?.shippingCost === 'number' ? order.shippingCost :
+    undefined
+
+  const codFee =
+    typeof order?.codFee === 'number' ? order.codFee : undefined
+
+  const taxRate =
+    typeof order?.taxRate === 'number' ? order.taxRate : undefined
+
+  const normalized = items.map(x => ({ price: Number(x?.price||0), qty: Number(x?.qty||x?.quantity||1) }))
+  const t = calcTotals({ items: normalized, shippingMethod, baseShipping, codFee, taxRate })
+  return {
+    ...t,
+    fmt: {
+      subtotal: fmtEUR(t.subtotal),
+      shipping: fmtEUR(t.shipping),
+      codFee: fmtEUR(t.codFee),
+      tax: fmtEUR(t.tax),
+      grandTotal: fmtEUR(t.grandTotal),
+    }
+  }
+}

--- a/frontend/tests/admin/orders/totals-ui.spec.ts
+++ b/frontend/tests/admin/orders/totals-ui.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect, request as pwRequest } from '@playwright/test';
+const base = process.env.PLAYWRIGHT_BASE_URL || process.env.BASE_URL || 'http://127.0.0.1:3001';
+const bypass = process.env.OTP_BYPASS || '000000';
+const adminPhone = (process.env.ADMIN_PHONES||'+306900000084').split(',')[0];
+
+async function adminCookie(){
+  const ctx = await pwRequest.newContext();
+  await ctx.post(base+'/api/auth/request-otp', { data: { phone: adminPhone }});
+  const vr = await ctx.post(base+'/api/auth/verify-otp', { data:{ phone: adminPhone, code: bypass }});
+  const c = (await vr.headersArray()).find(h=>h.name.toLowerCase()==='set-cookie')?.value||'';
+  return c.includes('dixis_session=') ? c.split('dixis_session=')[1].split(';')[0] : '';
+}
+
+test('Admin Orders detail shows totals (read-only)', async ({ request, page }) => {
+  const cookie = await adminCookie();
+  
+  // seed product
+  const p = await request.post(base+'/api/me/products', { 
+    headers:{ cookie:`dixis_session=${cookie}` },
+    data:{ title:'Ελιές Θρούμπες', category:'Ελιές', price:5.2, unit:'τεμ', stock:5, isActive:true }
+  });
+  expect([200,201]).toContain(p.status());
+  const pid = (await p.json()).item.id;
+
+  // checkout one order (anonymous)
+  const ord = await request.post(base+'/api/checkout', { 
+    data:{ 
+      items:[{ productId: pid, qty:2 }], 
+      shipping:{ name:'Πελάτης', line1:'Οδός 1', city:'Αθήνα', postal:'11111', phone:'+306900000555', email:'admin-totals-ui@example.com' }, 
+      payment:{ method:'COD' } 
+    }
+  });
+  expect([200,201]).toContain(ord.status());
+  const body = await ord.json();
+  const oid = body.orderId || body.id;
+
+  // go to admin order detail page
+  await page.context().addCookies([{ name:'dixis_session', value:cookie, url: base }]);
+  await page.goto(base+`/admin/orders/${oid}`);
+
+  // Wait for totals card
+  const totalsCard = page.locator('[data-testid="totals-card"]');
+  await expect(totalsCard).toBeVisible({ timeout: 10000 });
+
+  // Verify Greek labels present
+  const html = await page.content();
+  expect(html).toMatch(/Υποσύνολο/);
+  expect(html).toMatch(/Μεταφορικά/);
+  expect(html).toMatch(/ΦΠΑ/);
+  
+  // Verify EL currency format (€ symbol)
+  expect(html).toMatch(/€/);
+});


### PR DESCRIPTION
## Summary

Admin Orders detail page displays read-only totals breakdown (Subtotal/Shipping/COD/Tax/GrandTotal) using unified `@/lib/cart/totals` helper.

**Changes**:
- Created `totalsPresenter.ts` helper for safe read-only totals computation
- Wired Admin Orders detail page (`app/admin/orders/[id]/page.tsx`) to display full breakdown
- Display: Υποσύνολο, Μεταφορικά, Αντικαταβολή (if > 0), ΦΠΑ with Greek labels
- Added `data-testid="totals-card"` for E2E stability
- New E2E test: `tests/admin/orders/totals-ui.spec.ts` (verifies labels + € format)

**Technical Details**:
- NO schema changes (read-only presenter)
- NO API changes (computes from existing order data)
- TypeScript strict mode: 0 errors ✅
- Fallback-safe: handles missing/old order data gracefully
- EL-first formatting (`fmtEUR`, Greek labels)

## Acceptance Criteria

- [x] Admin Orders detail displays full totals breakdown (Υποσύνολο, Μεταφορικά, Αντικαταβολή, ΦΠΑ, Σύνολο)
- [x] Totals card has `data-testid="totals-card"`
- [x] All amounts formatted with `fmtEUR()` (Greek locale)
- [x] E2E test verifies Greek labels + € symbol present
- [x] NO TypeScript errors (0 errors)
- [x] NO schema changes (backward compatible)

## Test Plan

- **New E2E test**: `tests/admin/orders/totals-ui.spec.ts`
  - Seeds 1 product (€5.20: "Ελιές Θρούμπες")
  - Creates order via checkout API
  - Admin navigates to order detail page
  - Verifies `data-testid="totals-card"` is visible
  - Verifies Greek labels present (Υποσύνολο, Μεταφορικά, ΦΠΑ)
  - Verifies EL currency format (€ symbol)
- **TypeScript check**: `npm run type-check` → 0 errors ✅
- **CI**: Build, typecheck, E2E (PostgreSQL)

## Reports

- **CODEMAP**: `docs/AGENT/SYSTEM/routes.md` (Admin Orders detail)
- **TEST-REPORT**: GitHub Actions → this PR run
- **RISKS-NEXT**: `docs/OPS/STATE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)