### PR TITLE
docs(STATE): Pass 203A complete - Admin Orders totals display

### DIFF
--- a/frontend/docs/OPS/STATE.md
+++ b/frontend/docs/OPS/STATE.md
@@ -1,3 +1,11 @@
+## Pass 203A — Admin Orders Totals Display (read-only) + E2E ✅
+- **Totals Presenter**: Created `lib/admin/orders/totalsPresenter.ts` for safe read-only totals computation
+- **Admin Orders Detail**: Wired to display full breakdown (Υποσύνολο, Μεταφορικά, Αντικαταβολή, ΦΠΑ) via unified helper
+- **E2E Test**: New `tests/admin/orders/totals-ui.spec.ts` verifies Greek labels + € format
+- **Data Safety**: `data-testid="totals-card"` added for test stability
+- **No Breaking Changes**: NO schema changes, NO API changes (read-only presenter), backward compatible
+- **TypeScript**: 0 errors in strict mode ✅
+
 ## Pass 174Q.reapply — PR Template/Hygiene Sweep + Pre-Plan 203A (docs-only) ✅
 - **PR Template**: Added `.github/pull_request_template.md` with required sections (Summary, AC, Test Plan, Reports)
 - **Labeler Config**: Created `.github/labeler.yml` for automated PR labeling (ai-pass, risk-ok)


### PR DESCRIPTION
## Summary

Document Pass 203A completion in STATE.md.

**Changes**:
- Updated STATE.md with Pass 203A entry
- Documented totalsPresenter creation
- Documented Admin Orders detail page totals display
- Documented E2E test coverage

## Acceptance Criteria

- [x] STATE.md updated with Pass 203A entry
- [x] Pass 203A deliverables documented

## Test Plan

- **No tests required** (docs-only PR)

## Reports

- **CODEMAP**: N/A (docs-only)
- **TEST-REPORT**: N/A (docs-only)
- **RISKS-NEXT**: frontend/docs/OPS/STATE.md
- **STATE**: frontend/docs/OPS/STATE.md (Pass 203A entry added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)