### PR TITLE
docs(state): Pass 203B completion — Admin Orders LIST e2e coverage

### DIFF
--- a/frontend/docs/OPS/STATE.md
+++ b/frontend/docs/OPS/STATE.md
@@ -1,3 +1,22 @@
+## Pass 203B — Admin Orders LIST Totals E2E Test Coverage ✅
+- **Test Coverage**: Added `tests/admin/orders/totals-list.spec.ts` for Admin Orders LIST page
+- **Discovery**: LIST page already displays totals correctly in EL format via `Intl.NumberFormat('el-GR')` (line 52)
+- **Test-Only PR**: No application code changes required - existing implementation already correct
+- **E2E Validation**: Test verifies € symbol presence, "Σύνολο" column header, and table rendering
+- **Greek Localization**: Confirms EL currency formatting works as expected in LIST view
+- **Minimal Impact**: +48 LOC test-only, zero risk to production code
+- **PR #529**: feat/pass-203b-admin-orders-list-e2e → main (auto-merge enabled)
+
+## Pass 203A — Admin Orders Detail Totals Display (read-only) + E2E ✅
+- **Totals Presenter**: Created `lib/admin/orders/totalsPresenter.ts` for safe read-only totals computation
+- **Admin Orders Detail**: Wired to display full breakdown (Υποσύνολο, Μεταφορικά, Αντικαταβολή, ΦΠΑ) via unified helper
+- **E2E Test**: New `tests/admin/orders/totals-ui.spec.ts` verifies Greek labels + € format
+- **Data Safety**: `data-testid="totals-card"` added for test stability
+- **No Breaking Changes**: NO schema changes, NO API changes (read-only presenter), backward compatible
+- **TypeScript**: 0 errors in strict mode ✅
+- **PR #527**: feat/pass-203a-admin-orders-totals → main (MERGED ✅)
+- **PR #528**: docs/pass-203a-state → main (STATE.md update, auto-merge enabled)
+
 ## Pass 174Q.reapply — PR Template/Hygiene Sweep + Pre-Plan 203A (docs-only) ✅
 - **PR Template**: Added `.github/pull_request_template.md` with required sections (Summary, AC, Test Plan, Reports)
 - **Labeler Config**: Created `.github/labeler.yml` for automated PR labeling (ai-pass, risk-ok)


### PR DESCRIPTION
## Summary
Documents Pass 203B completion in STATE.md. This pass added E2E test coverage for Admin Orders LIST page totals display.

**Key Discovery**: Admin Orders LIST already displays totals correctly in EL format via `Intl.NumberFormat('el-GR')` (line 52 in `page.tsx`), so Pass 203B became a test-only PR with zero production code changes.

## Changes
- ✅ Added Pass 203B entry to `frontend/docs/OPS/STATE.md`
- ✅ Documented discovery: LIST page already shows totals in € format
- ✅ Test-only approach (no application code changes needed)
- ✅ E2E test verifies € symbol and "Σύνολο" column header

## Acceptance Criteria
- [x] STATE.md updated with Pass 203B entry
- [x] Entry documents discovery (existing EL format)
- [x] Entry references PR #529 (test-only implementation)
- [x] Chronological ordering preserved (203B before 203A)

## Test Plan
1. **State Documentation Review**
   ```bash
   head -n 30 frontend/docs/OPS/STATE.md
   # Verify Pass 203B entry appears before Pass 203A
   # Verify discovery documented (LIST already correct)
   ```

2. **Formatting Check**
   ```bash
   grep -A 7 "Pass 203B" frontend/docs/OPS/STATE.md
   # Verify bullet points match project style
   # Verify PR #529 referenced
   ```

## Reports
- **TypeScript**: N/A (docs-only PR)
- **Linting**: N/A (docs-only PR)
- **Test Suite**: N/A (docs-only PR)
- **Build**: Not required (Markdown only)

---

**Related PRs**:
- PR #529 (feat/pass-203b-admin-orders-list-e2e) — Test implementation
- PR #527 (feat/pass-203a-admin-orders-totals) — MERGED ✅
- PR #528 (docs/pass-203a-state) — Pass 203A STATE update

**Pass**: 203B (Admin Orders LIST e2e coverage)  
**Impact**: Documentation-only, zero production risk  
**LOC**: +19 lines (STATE.md entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)