### PR TITLE
docs(pass-204): add typecheck script + env examples

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -62,4 +62,7 @@ DIXIS_CRON_KEY="change-me-strong"
 # ── API Guardrails & Ops (Passes 118–120) ────────────────────────────
 # Rate limiting uses DB-backed time-bucket strategy
 # Automatic cleanup via /api/jobs/maintenance/rl-clean (weekly cron)
-# Ops metrics dashboard: /ops/metrics (dev-only or DIXIS_DEV=1)
+# Ops metrics dashboard: /ops/metrics (dev-only or DIXIS_DEV=1)ADMIN_PHONES=+306900000084
+
+# Environment identifier
+DIXIS_ENV=local

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -94,7 +94,8 @@
     "agent:routes": "node ../scripts/scan-routes.mjs",
     "agent:schema": "node ../scripts/scan-prisma.mjs",
     "agent:docs": "npm run agent:routes && npm run agent:schema",
-    "test:e2e:smoke": "npx -y dotenv-cli -e .env.ci -- playwright test --grep @smoke --reporter=line,html --global-timeout=300000 --max-failures=1"
+    "test:e2e:smoke": "npx -y dotenv-cli -e .env.ci -- playwright test --grep @smoke --reporter=line,html --global-timeout=300000 --max-failures=1",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",


### PR DESCRIPTION
## Summary

Follow-up to Pass 204 (#533) - adds missing wire-ups for OTP authentication.

## Changes

- **typecheck script**: Added  ERR_PNPM_NO_SCRIPT  Missing script: typecheck

Command "typecheck" not found. (tsc --noEmit) to package.json
- **.env.example**: Added ADMIN_PHONES, DIXIS_ENV for OTP bypass setup
- **.env.ci**: Already contains OTP_BYPASS and ADMIN_PHONES

## Purpose

Ensures developers can:
- Run TypeScript type-check locally with  ERR_PNPM_NO_SCRIPT  Missing script: typecheck

Command "typecheck" not found.
- Configure OTP bypass for local testing via .env.example template

## Related

- PR #533 (Pass 204 - Cookie Security)
- No business logic changes
- Documentation/tooling only

🤖 Generated with [Claude Code](https://claude.com/claude-code)