### PR TITLE
feat(ux): Home API fallback + dev stub + EL messages (UX-EL03)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ DEV_MAIL_TO=dev@localhost
 LOW_STOCK_THRESHOLD=3
 NEXT_PUBLIC_SITE_URL=http://127.0.0.1:3001
 DIXIS_TAX_RATE=0
+
+# Dev env
+DIXIS_ENV=local
+# αφήστε κενό για internal API
+NEXT_PUBLIC_API_BASE_URL=

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -2837,3 +2837,10 @@ unitLabel('pcs')   // "τεμ."
 - Consider adding English translations (en.json)
 - Extend unit tests for validation logic
 - Pass 202S: Checkout UI wired to unified totals helper (calcTotals/fmtEUR) + 1 E2E test. No schema changes.
+
+## Pass UX-EL03 — API fallback + dev stub + Home sanity test ✅
+**Date**: 2025-10-14
+- Created apiBase() helper with internal API fallback
+- API returns Prisma data when available
+- Home sanity test: no console errors + EL text visible
+- Updated .env.example with DIXIS_ENV + NEXT_PUBLIC_API_BASE_URL

--- a/frontend/src/lib/http/apiBase.ts
+++ b/frontend/src/lib/http/apiBase.ts
@@ -1,0 +1,12 @@
+export function apiBase() {
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL?.trim();
+  return base ? base.replace(/\/+$/, '') : '';
+}
+
+export function apiUrl(path: string) {
+  if (!path.startsWith('/')) {
+    path = '/' + path;
+  }
+  const base = apiBase();
+  return base ? (base + path) : path; // internal when empty
+}

--- a/frontend/tests/storefront/home.sanity.spec.ts
+++ b/frontend/tests/storefront/home.sanity.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('Home renders without console errors & shows EL texts', async ({ page }) => {
+  const errs: string[] = [];
+  page.on('pageerror', e => errs.push(String(e)));
+  page.on('console', m => {
+    if (m.type() === 'error') errs.push(m.text());
+  });
+
+  await page.goto('http://localhost:3000/', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('h1')).toContainText(/Dixis|Καλώς/i);
+  expect(errs, 'console/page errors should be empty').toEqual([]);
+});


### PR DESCRIPTION
## Summary
API fallback helper for dev/preview environments. When NEXT_PUBLIC_API_BASE_URL is empty, uses internal route. Dev-only /api/public/products returns Prisma data. EL messages already complete. Home sanity test ensures no console errors.

## Acceptance Criteria
- [x] apiBase() helper with fallback to internal API
- [x] Existing /api/public/products route returns Prisma data  
- [x] Home sanity test: no console errors + EL text visible
- [x] .env.example documents DIXIS_ENV and NEXT_PUBLIC_API_BASE_URL

## Test Plan
- Home sanity test: `frontend/tests/storefront/home.sanity.spec.ts`
- CI: typecheck + build-and-test pass
- Dev: open http://localhost:3000 → see products from Prisma

## Reports
- CODEMAP: docs/AGENT/SYSTEM/routes.md
- TEST-REPORT: Actions → this PR run
- RISKS-NEXT: docs/OPS/STATE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>