### PR TITLE
ci(test): fix Smoke Tests DATABASE_URL mismatch (SMOKE-TRIAGE-552)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Run Prisma migrations
         env:
-          DATABASE_URL: "postgresql://dixis:dixis_dev_pass@localhost:5432/dixis_dev?schema=public"
+          DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1:5432/dixis?schema=public"
         run: |
           npx prisma generate
           npx prisma migrate deploy
@@ -211,7 +211,7 @@ jobs:
       - name: Build and start Next.js app
         env:
           NODE_ENV: production
-          DATABASE_URL: "postgresql://dixis:dixis_dev_pass@localhost:5432/dixis_dev?schema=public"
+          DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1:5432/dixis?schema=public"
           BASIC_AUTH: "admin:dixis_ci_pass"
           NEXT_PUBLIC_API_BASE_URL: "http://127.0.0.1:8001"
           API_BASE_URL: "http://127.0.0.1:8001"
@@ -226,7 +226,7 @@ jobs:
         run: bash scripts/ci/run-playwright.sh
         env:
           CI: true
-          DATABASE_URL: "postgresql://dixis:dixis_dev_pass@localhost:5432/dixis_dev?schema=public"
+          DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1:5432/dixis?schema=public"
           BASIC_AUTH: "admin:dixis_ci_pass"
           BASE_URL: http://127.0.0.1:3000
           PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000

--- a/frontend/docs/OPS/STATE.md
+++ b/frontend/docs/OPS/STATE.md
@@ -97,3 +97,18 @@ $(head -1607 docs/OPS/STATE.md)
 - No schema changes, no new dependencies (React Context + localStorage only)
 - Build passed successfully with Next.js 15.5.0 (cart: dynamic route, checkout: Suspense wrapper)
 - No backend/business logic changes, UI/state/i18n only
+
+## Pass STORE-05.1 — PR Hygiene + Lightweight E2E ✅
+**Date**: 2025-10-15
+- PR #552: added Summary/AC/Test Plan/Reports (Danger compliance)
+- Created 2 lightweight E2E tests (no DB dependency, localStorage preseed):
+  - cart-persist.spec.ts: verifies cart state persistence and Greek totals display
+  - checkout-validate.spec.ts: verifies EL-first labels and form structure
+- Created docs/AGENT/SUMMARY/Pass-STORE-05.1.md for QA hygiene documentation
+- No business logic changes, QA hygiene only
+
+## Pass SMOKE-TRIAGE-552 — Fix Smoke Tests DATABASE_URL mismatch ✅
+**Date**: 2025-10-15
+- Root cause: Prisma migrations failed due to DATABASE_URL using `dixis:dixis_dev_pass@localhost:5432/dixis_dev` while PostgreSQL service only creates `postgres:postgres@127.0.0.1:5432/dixis`
+- Fixed 3 DATABASE_URL references in .github/workflows/pr.yml to match service config
+- No application code changes, CI infrastructure fix only


### PR DESCRIPTION
## Summary
Fixes Smoke Tests failure in PR #552 caused by DATABASE_URL mismatch between PostgreSQL service config and Prisma migrations.

## Root Cause
- Smoke Tests job creates PostgreSQL service with user `postgres:postgres` and database `dixis`
- Prisma migrations step used incorrect DATABASE_URL: `dixis:dixis_dev_pass@localhost:5432/dixis_dev`
- Result: P1000 authentication error (role "dixis" does not exist)

## Changes
- Updated 3 DATABASE_URL environment variables in `.github/workflows/pr.yml`:
  - Run Prisma migrations step
  - Build and start Next.js app step
  - Run smoke tests step
- Changed from `dixis:dixis_dev_pass@localhost:5432/dixis_dev` to `postgres:postgres@127.0.0.1:5432/dixis`

## Impact
- ✅ Smoke Tests will now pass (database authentication fixed)
- ✅ No application code changes
- ✅ No schema or business logic changes

## Test Plan
- CI Smoke Tests job should pass with green check

## Reports
- **CODEMAP**: `.github/workflows/pr.yml` (lines 197, 214, 229)
- **TEST-REPORT**: CI Smoke Tests workflow
- **RISKS-NEXT**: None - infrastructure fix only

Generated with [Claude Code](https://claude.com/claude-code)