### PR TITLE
feat(ux): add SSR-safe apiPath util + smoke tests (UX-BASE-01b)

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -1,12 +1,12 @@
 import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
-import { apiUrl } from '@/lib/http/apiBase';
+import { apiPath } from '@/lib/runtime/urls';
 import { parse, toQuery, type ProductFilters } from '@/lib/search/params';
 
 async function getProducts(filters: ProductFilters) {
   try {
     const qs = toQuery({ per_page: 20, ...filters });
-    const url = apiUrl(`/api/public/products${qs ? `?${qs}` : ''}`);
+    const url = apiPath(`/api/public/products${qs ? `?${qs}` : ''}`);
     const res = await fetch(url, { next: { revalidate: 300 } });
     if (!res.ok) return [];
     const j = await res.json();

--- a/frontend/src/app/Home.tsx
+++ b/frontend/src/app/Home.tsx
@@ -1,11 +1,11 @@
 import { Product } from '@/lib/api';
 import HomeClient from './HomeClient';
 import { getTranslations } from 'next-intl/server';
-import { apiUrl } from '@/lib/http/apiBase';
+import { apiPath } from '@/lib/runtime/urls';
 
 async function getInitialProducts(): Promise<Product[]> {
   try {
-    const url = apiUrl('/api/public/products?per_page=20&sort=created_at');
+    const url = apiPath('/api/public/products?per_page=20&sort=created_at');
     const res = await fetch(url, { cache: 'no-store' });
 
     if (!res.ok) {

--- a/frontend/src/lib/runtime/urls.ts
+++ b/frontend/src/lib/runtime/urls.ts
@@ -1,0 +1,34 @@
+/**
+ * apiPath: SSR-safe URL builder for fetch
+ *
+ * SSR context (Node.js):
+ *   - Returns absolute URL (required for fetch in Node)
+ *   - Uses NEXT_PUBLIC_API_BASE_URL or defaults to http://127.0.0.1:8001
+ *
+ * CSR context (browser):
+ *   - Returns relative path (works with proxy/same-origin)
+ *   - Falls back to NEXT_PUBLIC_API_BASE_URL if configured
+ *
+ * Usage:
+ *   const url = apiPath('/api/public/products');
+ *   const res = await fetch(url);
+ */
+
+export function apiPath(path: string): string {
+  // Normalize path to start with /
+  if (!path.startsWith('/')) {
+    path = '/' + path;
+  }
+
+  const isServer = typeof window === 'undefined';
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL?.trim();
+
+  if (isServer) {
+    // SSR: Must use absolute URL for Node.js fetch
+    const absoluteBase = base || 'http://127.0.0.1:8001';
+    return absoluteBase.replace(/\/+$/, '') + path;
+  } else {
+    // CSR: Prefer relative path, fallback to base if configured
+    return base ? (base.replace(/\/+$/, '') + path) : path;
+  }
+}

--- a/frontend/tests/smoke/smoke-home.spec.ts
+++ b/frontend/tests/smoke/smoke-home.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Smoke Test: Home page ("/") loads without i18n/hydration errors
+ *
+ * Purpose: Verify baseline functionality after URL handling changes
+ * Success: Page loads, no console errors for i18n/hydration
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Home page smoke test', () => {
+  test('should load Home without i18n or hydration errors', async ({ page }) => {
+    const errors: string[] = [];
+
+    page.on('console', msg => {
+      const text = msg.text();
+      if (
+        text.includes('INVALID_KEY') ||
+        text.includes('MISSING_MESSAGE') ||
+        text.includes('hydration') ||
+        text.includes('Hydration')
+      ) {
+        errors.push(text);
+      }
+    });
+
+    await page.goto('/', { waitUntil: 'networkidle' });
+
+    // Verify page loaded with LCP anchor
+    await expect(page.locator('[data-lcp-anchor="hero-raster"]')).toBeVisible();
+
+    // Verify no i18n/hydration errors
+    expect(errors, 'Found i18n or hydration errors on Home').toHaveLength(0);
+  });
+});

--- a/frontend/tests/smoke/smoke-products.spec.ts
+++ b/frontend/tests/smoke/smoke-products.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Smoke Test: Products page ("/products") loads without i18n/hydration errors
+ *
+ * Purpose: Verify baseline functionality after URL handling changes
+ * Success: Page loads, products grid visible, no console errors for i18n/hydration
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Products page smoke test', () => {
+  test('should load Products page without i18n or hydration errors', async ({ page }) => {
+    const errors: string[] = [];
+
+    page.on('console', msg => {
+      const text = msg.text();
+      if (
+        text.includes('INVALID_KEY') ||
+        text.includes('MISSING_MESSAGE') ||
+        text.includes('hydration') ||
+        text.includes('Hydration')
+      ) {
+        errors.push(text);
+      }
+    });
+
+    await page.goto('/products', { waitUntil: 'networkidle' });
+
+    // Verify page loaded with products grid or empty state
+    const hasProducts = await page.locator('[data-testid="products-grid"]').isVisible();
+    const hasEmpty = await page.locator('[data-testid="empty-state"]').isVisible();
+
+    expect(hasProducts || hasEmpty, 'Products page should show grid or empty state').toBe(true);
+
+    // Verify no i18n/hydration errors
+    expect(errors, 'Found i18n or hydration errors on Products').toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds SSR-safe URL handling for Next.js 15 fetch + baseline smoke tests. No i18n changes per protocol.

## Changes

- **Add `apiPath()` util** (`frontend/src/lib/runtime/urls.ts`): SSR returns absolute URL, CSR returns relative path
- **Patch Home.tsx**: Use `apiPath` instead of `apiUrl` for SSR fetch
- **Patch Products page**: Use `apiPath` for SSR-safe product fetching
- **Add 2 smoke tests** (`frontend/tests/smoke/`): Home & Products i18n/hydration regression checks

## Acceptance Criteria

- ✅ `apiPath()` util handles SSR (absolute) vs CSR (relative) URLs
- ✅ Home and Products pages use `apiPath` for fetch
- ✅ 2 Playwright smoke tests added (detect i18n/hydration errors)
- ✅ No changes to `frontend/messages/**` (i18n protected)
- ✅ Build compiles successfully

## Test Plan

```bash
# Smoke tests
cd frontend
npx playwright test tests/smoke/smoke-home.spec.ts
npx playwright test tests/smoke/smoke-products.spec.ts

# Build verification
npm run build
```

## Reports

### Files Changed (5 files, +109/-4 LOC)
```
M  frontend/src/app/Home.tsx
M  frontend/src/app/(storefront)/products/page.tsx
A  frontend/src/lib/runtime/urls.ts
A  frontend/tests/smoke/smoke-home.spec.ts
A  frontend/tests/smoke/smoke-products.spec.ts
```

### Evidence
- Commit: 3ce1a91
- Branch: feat/ux-base-01b-additive
- No i18n file changes: ✅ Verified (zero diff in frontend/messages/**)

### Risk Assessment
- **Risk Level**: Low
- **Reason**: Additive changes only, no i18n modifications, smoke tests added for regression detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)