### PR TITLE
fix(ci): add cache-dependency-path for pnpm in e2e-full workflow

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+          cache-dependency-path: 'frontend/pnpm-lock.yaml'
       - name: Enable corepack
         run: corepack enable
 
@@ -80,6 +81,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+          cache-dependency-path: 'frontend/pnpm-lock.yaml'
       - run: corepack enable
       - run: pnpm i --frozen-lockfile
       - run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## 🔥 Hotfix: E2E Full Workflow Cache Failure

### Root Cause
Workflow run [#18531549065](https://github.com/lomendor/Project-Dixis/actions/runs/18531549065) failed at "Setup Node & pnpm" step.

**Issue**: `actions/setup-node@v4` with `cache: 'pnpm'` expects `pnpm-lock.yaml` at repository root, but our lockfile is in `frontend/` subdirectory.

### Fix Applied
Added `cache-dependency-path: 'frontend/pnpm-lock.yaml'` to both jobs:
- `e2e-sqlite` (nightly/main)
- `e2e-postgres` (manual/gated)

### Acceptance Criteria
- [ ] CI passes with successful cache setup
- [ ] E2E tests execute successfully
- [ ] JUnit artifacts uploaded

### Impact
**Files Changed**: 1 file, +2 lines  
**Risk**: LOW - Only adds cache path specification  
**Urgency**: HIGH - Blocks nightly E2E execution

### Related
- Triggered from Pass AG2a manual run
- Closes umbrella tracking for e2e-full workflow stabilization

🤖 Generated with [Claude Code](https://claude.com/claude-code)