### PR TITLE
fix(ci): run corepack enable before setup-node in e2e-full

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -24,14 +24,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Setup Node & pnpm
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
           cache-dependency-path: 'frontend/pnpm-lock.yaml'
-      - name: Enable corepack
-        run: corepack enable
 
       - name: Install deps
         run: pnpm i --frozen-lockfile
@@ -77,12 +78,12 @@ jobs:
           --health-interval=10s --health-timeout=5s --health-retries=10
     steps:
       - uses: actions/checkout@v4
+      - run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
           cache-dependency-path: 'frontend/pnpm-lock.yaml'
-      - run: corepack enable
       - run: pnpm i --frozen-lockfile
       - run: npx playwright install --with-deps chromium
       - name: Prepare Postgres env


### PR DESCRIPTION
## 🔥 Hotfix #2: E2E Full Workflow Step Ordering

### Root Cause
Workflow runs [#18531549065](https://github.com/lomendor/Project-Dixis/actions/runs/18531549065) and [#18531827077](https://github.com/lomendor/Project-Dixis/actions/runs/18531827077) both failed at "Setup Node & pnpm" step.

**Issue**: `actions/setup-node@v4` with pnpm caching requires corepack to be enabled BEFORE the setup-node action runs. Our workflow had these steps in the wrong order.

**Evidence**: Working `e2e-postgres.yml` workflow has this correct order:
```yaml
- name: Enable corepack
  run: corepack enable

- name: Setup Node.js
  uses: actions/setup-node@v4
  with:
    cache: 'pnpm'
```

### Fix Applied
Moved "Enable corepack" step to run **before** "Setup Node & pnpm" in both jobs:
- ✅ `e2e-sqlite` (nightly/main)
- ✅ `e2e-postgres` (manual/gated)

### Acceptance Criteria
- [ ] CI passes with successful node setup
- [ ] E2E tests execute successfully
- [ ] JUnit artifacts uploaded

### Impact
**Files Changed**: 1 file, ~4 lines  
**Risk**: MINIMAL - Only reordering existing steps  
**Urgency**: HIGH - Blocks nightly E2E execution

### Related
- Follows PR #559 (cache-dependency-path fix)
- Part of Pass AG2a validation cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)