### PR TITLE
Pass AG8 — UI polish (shadcn-style primitives) + ShippingBreakdown refactor

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG8.md
+++ b/docs/AGENT/SUMMARY/Pass-AG8.md
@@ -1,0 +1,175 @@
+# Pass AG8 — UI Polish (shadcn-style primitives)
+
+**Date**: 2025-10-15
+**Status**: COMPLETE ✅
+
+## Objective
+
+Add lightweight shadcn-style UI primitives to establish consistent styling patterns across the frontend, and refactor ShippingBreakdown component to use them.
+
+## Changes
+
+### 1. UI Primitives Created ✅
+
+**Directory**: `frontend/src/components/ui/`
+
+All components follow shadcn/ui design patterns with Tailwind CSS:
+
+1. **`button.tsx`** - Button component with variants (default, ghost, outline)
+2. **`input.tsx`** - Input component with focus ring and consistent styling
+3. **`select.tsx`** - Select dropdown with matching input styling
+4. **`card.tsx`** - Card container with CardTitle subcomponent
+5. **`skeleton.tsx`** - Loading skeleton with pulse animation
+6. **`tooltip.tsx`** - Details/summary-based tooltip (Greek default: "Γιατί;")
+7. **`toast.tsx`** - useToast hook with Toaster component (dismissible error toasts)
+
+**Helper**: `frontend/src/lib/cn.ts` - Utility function for conditional className merging
+
+### 2. ShippingBreakdown Refactor ✅
+
+**File**: `frontend/src/components/checkout/ShippingBreakdown.tsx`
+
+**Before**: Inline styles, plain HTML elements
+**After**: UI primitives with consistent Tailwind classes
+
+**Changes**:
+- Container: `<div style={...}>` → `<Card>`
+- Title: `<h3 style={...}>` → `<CardTitle>`
+- Inputs: `<input style={...}>` → `<Input className="...">`
+- Select: `<select style={...}>` → `<Select className="...">`
+- Loading: Custom div → `<Skeleton className="h-14 w-full">`
+- Error: Inline styled div → `toast()` (floating dismissible)
+- Tooltip: `<details>` → `<Tooltip>` component
+
+**Backward Compatibility**:
+- All `data-testid` attributes preserved
+- `toast-error` testid kept (hidden div) for E2E tests
+- No logic changes, only UI presentation
+
+### 3. Demo Page Polish ✅
+
+**File**: `frontend/src/app/dev/quote-demo/page.tsx`
+
+**Before**: Inline styles
+**After**: Tailwind utility classes
+
+- Container: `style={{maxWidth:720, ...}}` → `className="max-w-3xl mx-auto px-4 py-10"`
+- Title: `<h2>` → `<h2 className="text-2xl font-bold mb-2">`
+- Description: Plain `<p>` → `<p className="text-neutral-600 mb-6">`
+- Code tag: Styled with `className="px-1.5 py-0.5 bg-neutral-100 rounded text-sm"`
+
+## Acceptance Criteria
+
+- [x] 7 UI primitive components created in `frontend/src/components/ui/`
+- [x] `cn()` utility helper added
+- [x] ShippingBreakdown refactored to use primitives
+- [x] All testids preserved for E2E compatibility
+- [x] Demo page polished with Tailwind classes
+- [x] No backend changes
+- [x] No business logic changes
+
+## Technical Details
+
+### Design System Patterns
+
+**Color Palette**:
+- Primary: Black (#000)
+- Neutral: Gray scale (neutral-100 to neutral-800)
+- Error: Red (red-50 to red-800)
+- Green: Green scale (for success states)
+
+**Spacing**: Tailwind spacing scale (0.5 = 2px, 1 = 4px, etc.)
+**Border Radius**: `rounded-md` (0.375rem), `rounded-lg` (0.5rem)
+**Focus Rings**: `focus:ring-2 focus:ring-black ring-offset-2`
+
+### Component API
+
+```tsx
+// Button
+<Button variant="default|ghost|outline" className="..." {...props} />
+
+// Input
+<Input type="text|number" placeholder="..." className="..." {...props} />
+
+// Select
+<Select className="..." {...props}><option>...</option></Select>
+
+// Card
+<Card className="..."><CardTitle>Title</CardTitle>Content</Card>
+
+// Skeleton
+<Skeleton className="h-14 w-full" />
+
+// Tooltip
+<Tooltip summary="Custom text?"><ul>...</ul></Tooltip>
+
+// Toast
+const { toast, Toaster } = useToast();
+toast('Error message');
+<Toaster />
+```
+
+### Toast Behavior
+
+- Positioned: Fixed top-right (z-50)
+- Auto-generates unique ID (Date.now())
+- Dismissible: Click to dismiss
+- Styling: Red border/background for errors
+- Queue support: Multiple toasts stack vertically
+
+## Impact
+
+**Risk**: VERY LOW
+- Frontend-only changes
+- No API modifications
+- No database changes
+- Backward compatible (testids preserved)
+
+**Files Changed**: 11
+- Created: 7 UI primitives + 1 utility
+- Modified: ShippingBreakdown.tsx, quote-demo/page.tsx
+- Created: Pass-AG8.md
+
+**Lines Added**: ~350 LOC
+
+## Deliverables
+
+1. ✅ `frontend/src/lib/cn.ts` - className utility
+2. ✅ `frontend/src/components/ui/button.tsx`
+3. ✅ `frontend/src/components/ui/input.tsx`
+4. ✅ `frontend/src/components/ui/select.tsx`
+5. ✅ `frontend/src/components/ui/card.tsx`
+6. ✅ `frontend/src/components/ui/skeleton.tsx`
+7. ✅ `frontend/src/components/ui/tooltip.tsx`
+8. ✅ `frontend/src/components/ui/toast.tsx`
+9. ✅ `frontend/src/components/checkout/ShippingBreakdown.tsx` - Refactored
+10. ✅ `frontend/src/app/dev/quote-demo/page.tsx` - Polished
+11. ✅ `docs/AGENT/SUMMARY/Pass-AG8.md` - This summary
+
+## Next Steps
+
+**Future UI Components** (when needed):
+- Badge (for statuses)
+- Dialog/Modal
+- Alert (different from toast)
+- Tabs
+- Dropdown Menu
+- Form validation helpers
+
+**Integration Opportunities**:
+- Use Button in checkout forms
+- Use Input/Select in other forms
+- Use Card for product listings
+- Use Toast for global error handling
+
+## Conclusion
+
+**Pass AG8: UI PRIMITIVES ADDED ✅**
+
+Established consistent shadcn-style design system with 7 reusable UI primitives. ShippingBreakdown successfully refactored with improved visual consistency, no logic changes, and full E2E test compatibility.
+
+**Pure frontend UI enhancement** - Ready for review and merge.
+
+---
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Pass: AG8 | UI primitives (Button/Input/Select/Card/Skeleton/Tooltip/Toast) + ShippingBreakdown polish

--- a/frontend/src/app/dev/quote-demo/page.tsx
+++ b/frontend/src/app/dev/quote-demo/page.tsx
@@ -3,9 +3,11 @@ import ShippingBreakdown from '../../../components/checkout/ShippingBreakdown';
 export const dynamic = 'force-dynamic';
 export default function Page() {
   return (
-    <main style={{maxWidth:720, margin:'40px auto', padding:16}}>
-      <h2>Checkout — Shipping Breakdown (Demo)</h2>
-      <p>Δοκίμασε διαφορετικό Τ.Κ., μέθοδο και βάρος. Το UI καλεί το <code>/api/checkout/quote</code>.</p>
+    <main className="max-w-3xl mx-auto px-4 py-10">
+      <h2 className="text-2xl font-bold mb-2">Checkout — Shipping Breakdown (Demo)</h2>
+      <p className="text-neutral-600 mb-6">
+        Δοκίμασε διαφορετικό Τ.Κ., μέθοδο και βάρος. Το UI καλεί το <code className="px-1.5 py-0.5 bg-neutral-100 rounded text-sm">/api/checkout/quote</code>.
+      </p>
       <ShippingBreakdown initialPostalCode="10431" />
     </main>
   );

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { cn } from '../../lib/cn';
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'default' | 'ghost' | 'outline'
+};
+
+export function Button({ className, variant='default', ...props }: Props) {
+  const base = 'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none h-9 px-3';
+  const variants = {
+    default: 'bg-black text-white hover:bg-black/90 focus:ring-black',
+    ghost: 'bg-transparent hover:bg-neutral-100',
+    outline: 'border border-neutral-300 hover:bg-neutral-100'
+  } as const;
+  return <button className={cn(base, variants[variant], className)} {...props} />;
+}

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { cn } from '../../lib/cn';
+
+export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('rounded-lg border border-neutral-200 bg-white p-4 shadow-sm', className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn('text-base font-semibold leading-none tracking-tight', className)} {...props} />;
+}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { cn } from '../../lib/cn';
+
+export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={cn('flex h-9 w-full rounded-md border border-neutral-300 bg-white px-3 py-1 text-sm outline-none ring-offset-2 focus:ring-2 focus:ring-black', className)}
+      {...props}
+    />
+  )
+);
+Input.displayName='Input';

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { cn } from '../../lib/cn';
+
+export function Select({ className, ...props }: React.SelectHTMLAttributes<HTMLSelectElement>) {
+  return (
+    <select
+      className={cn('h-9 w-full rounded-md border border-neutral-300 bg-white px-2 text-sm outline-none ring-offset-2 focus:ring-2 focus:ring-black', className)}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { cn } from '../../lib/cn';
+
+export function Skeleton({ className }: { className?: string }) {
+  return <div className={cn('animate-pulse rounded-md bg-neutral-200', className)} />;
+}

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,0 +1,27 @@
+'use client';
+import * as React from 'react';
+
+type T = { id: number; msg: string };
+
+export function useToast() {
+  const [items, set] = React.useState<T[]>([]);
+
+  const toast = (msg: string) => set(s => [...s, { id: Date.now(), msg }]);
+  const dismiss = (id: number) => set(s => s.filter(i => i.id !== id));
+
+  const Toaster = () => (
+    <div className="fixed right-4 top-4 z-50 flex w-80 flex-col gap-2">
+      {items.map(i => (
+        <div
+          key={i.id}
+          className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-800 shadow cursor-pointer"
+          onClick={() => dismiss(i.id)}
+        >
+          {i.msg}
+        </div>
+      ))}
+    </div>
+  );
+
+  return { toast, Toaster };
+}

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,19 @@
+'use client';
+import * as React from 'react';
+
+export function Tooltip({
+  summary='Γιατί;',
+  children
+}: {
+  summary?: string;
+  children: React.ReactNode
+}) {
+  return (
+    <details>
+      <summary className="cursor-pointer text-sm text-neutral-700 hover:underline">{summary}</summary>
+      <div className="mt-2 rounded-md border border-neutral-200 bg-white p-2 text-sm text-neutral-800 shadow">
+        {children}
+      </div>
+    </details>
+  );
+}

--- a/frontend/src/lib/cn.ts
+++ b/frontend/src/lib/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary

Adds 7 lightweight shadcn-style UI primitives and refactors ShippingBreakdown component for consistent styling.

## Changes

**UI Primitives Created** (`frontend/src/components/ui/`):
- ✅ Button (default/ghost/outline variants)
- ✅ Input (focus rings, consistent styling)
- ✅ Select (matching input design)
- ✅ Card + CardTitle
- ✅ Skeleton (loading animation)
- ✅ Tooltip (details/summary based)
- ✅ Toast (dismissible error notifications)
- ✅ `cn()` utility helper

**ShippingBreakdown Refactor**:
- Replaced inline styles with UI primitives
- Added Toaster for floating error messages
- Maintained all `data-testid` attributes for E2E compatibility
- No logic changes, pure UI presentation polish

**Demo Page Polish**:
- Converted inline styles to Tailwind utility classes
- Improved typography and spacing

## Impact

- **Risk**: VERY LOW
- **Scope**: Frontend-only
- **Backend**: No changes
- **Tests**: All testids preserved, E2E compatible
- **Files Changed**: 11 (7 new UI components, 2 refactored, 1 util, 1 docs)
- **Lines Added**: ~356 LOC

## Testing

Existing E2E tests will validate:
- `checkout-shipping-ui.spec.ts` - ShippingBreakdown functionality
- `checkout-totals-update.spec.ts` - Totals integration

## Deliverables

1. ✅ 7 UI primitive components
2. ✅ ShippingBreakdown refactored with primitives
3. ✅ Demo page polished
4. ✅ Documentation (Pass-AG8.md)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Pass: AG8 | UI primitives + ShippingBreakdown polish