### PR TITLE
Pass AG20 — Friendly Order Number (DX-YYYYMMDD-####)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG20.md
+++ b/docs/AGENT/SUMMARY/Pass-AG20.md
@@ -1,0 +1,120 @@
+# Pass AG20 — Friendly Order Number (DX-YYYYMMDD-####)
+
+**Date**: 2025-10-17 (continued)
+**Branch**: feat/AG20-friendly-order-number
+**Status**: Complete
+
+## Summary
+
+Adds human-friendly order numbers (DX-YYYYMMDD-####) derived from createdAt + id. API returns orderNumber on order create, confirmation/admin pages display it, and CSV export includes it as the first column. No database schema changes - purely derived values.
+
+## Changes
+
+### New Files
+
+**frontend/src/lib/orderNumber.ts**:
+- Helper function `orderNumber(id: string, createdAt?: string | Date): string`
+- Format: `DX-{YYYY}{MM}{DD}-{last 4 chars of ID uppercased}`
+- Example: `DX-20251017-A1B2`
+- Pad function for zero-padding month and day
+- Uses last 4 characters of ID (alphanumeric only) as suffix
+
+### Modified Files
+
+**frontend/src/app/api/orders/route.ts**:
+- Import orderNumber helper
+- Compute orderNumber after order creation
+- Return in JSON response: `{ ok: true, id, orderNumber }`
+- Applied to all 3 code paths: Prisma success, Prisma fallback, in-memory only
+
+**frontend/src/app/checkout/payment/page.tsx**:
+- Store orderNumber in localStorage as `checkout_order_no`
+- Added after storing `checkout_order_id`
+- Handles missing orderNumber gracefully
+
+**frontend/src/app/checkout/confirmation/page.tsx**:
+- Added `orderNo` state
+- Load from localStorage `checkout_order_no`
+- Display "Order No" (larger, prominent) above "Order ID" (smaller, less prominent)
+- Test ID: `order-no`
+
+**frontend/src/app/admin/orders/page.tsx**:
+- Import orderNumber helper
+- Added "Order #" column as first column (before ID)
+- Compute orderNumber client-side: `orderNumber(r.id, r.createdAt)`
+- Updated empty state colspan from 7 to 8
+
+**frontend/src/app/admin/orders/[id]/page.tsx**:
+- Import orderNumber helper
+- Display "Order No" prominently above "Order ID"
+- Compute client-side: `orderNumber(data.id, data.createdAt)`
+- Test ID: `detail-order-no`
+
+**frontend/src/app/api/admin/orders/export/route.ts**:
+- Import orderNumber helper
+- Updated CSV header: "Order No" as first column
+- Compute orderNumber for each row: `orderNumber(r.id, r.createdAt)`
+- Prepend to row data before escaping
+
+### New Tests
+
+**frontend/tests/e2e/confirmation-shows-ordernumber.spec.ts**:
+- E2E test for confirmation page orderNumber display
+- Complete checkout flow → confirmation
+- Assert `order-no` element is visible
+- Regex match: `/^DX-\d{8}-[A-Z0-9]{4}$/`
+
+**frontend/tests/e2e/admin-orders-export-filters.spec.ts** (Modified):
+- Updated CSV header check to include "Order No"
+- Added regex test for orderNumber pattern in CSV content
+
+## Technical Details
+
+**Order Number Format**:
+- Prefix: `DX-` (Dixis brand)
+- Date: YYYYMMDD (8 digits from createdAt)
+- Suffix: Last 4 characters of ID (uppercased, alphanumeric only)
+- Pattern: `DX-\d{8}-[A-Z0-9]{4}`
+
+**Derivation Logic**:
+```typescript
+function orderNumber(id: string, createdAt?: string | Date): string {
+  const safeId = (id || '').replace(/[^a-z0-9]/gi, '');
+  const suffix = (safeId.slice(-4) || '0000').toUpperCase();
+  const d = createdAt ? new Date(createdAt) : new Date();
+  const y = d.getFullYear();
+  const m = pad(d.getMonth() + 1);
+  const day = pad(d.getDate());
+  return `DX-${y}${m}${day}-${suffix}`;
+}
+```
+
+**Client-Side vs Server-Side**:
+- **Server**: API returns orderNumber on order creation
+- **Client**: Confirmation reads from localStorage
+- **Admin**: Computes client-side from id + createdAt (no API change needed)
+- **CSV**: Computes server-side during export
+
+**No Schema Changes**:
+- Order number is not stored in database
+- Always derived from existing fields (id, createdAt)
+- Can be regenerated anytime from these fields
+
+## Testing
+
+- E2E test verifies DX-YYYYMMDD-#### pattern on confirmation
+- E2E test verifies orderNumber appears in CSV export
+- Admin pages display orderNumber computed from existing data
+- Works with both Prisma and in-memory storage
+
+## Notes
+
+- Non-breaking change (adds new field, doesn't remove old ones)
+- Order ID still visible everywhere for technical reference
+- Order Number more user-friendly for support/tracking
+- No database migration required
+- Backwards compatible with existing orders
+
+---
+
+**Generated**: 2025-10-17 (continued)

--- a/frontend/src/app/admin/orders/[id]/page.tsx
+++ b/frontend/src/app/admin/orders/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React from 'react';
+import { orderNumber } from '../../../../lib/orderNumber';
 
 type Order = {
   id: string;
@@ -49,6 +50,12 @@ export default function AdminOrderDetail({
         <div className="mt-4 text-sm">Φόρτωση…</div>
       ) : (
         <div className="mt-4 text-sm">
+          <div className="mb-2">
+            Order No:{' '}
+            <strong data-testid="detail-order-no">
+              {orderNumber(data.id, data.createdAt)}
+            </strong>
+          </div>
           <div className="mb-2">
             Order ID:{' '}
             <strong data-testid="detail-order-id">{data.id}</strong>

--- a/frontend/src/app/admin/orders/page.tsx
+++ b/frontend/src/app/admin/orders/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React from 'react';
+import { orderNumber } from '../../../lib/orderNumber';
 
 type Row = {
   id: string;
@@ -159,6 +160,7 @@ export default function AdminOrders() {
         <table className="w-full text-sm">
           <thead>
             <tr className="text-left">
+              <th>Order #</th>
               <th>ID</th>
               <th>Ημ/νία</th>
               <th>Τ.Κ.</th>
@@ -171,6 +173,9 @@ export default function AdminOrders() {
           <tbody>
             {rows.map((r) => (
               <tr key={r.id}>
+                <td className="pr-2">
+                  {orderNumber(r.id as any, r.createdAt as any)}
+                </td>
                 <td className="pr-2">
                   <a
                     href={`/admin/orders/${r.id}`}
@@ -196,7 +201,7 @@ export default function AdminOrders() {
             ))}
             {rows.length === 0 && (
               <tr>
-                <td colSpan={7} className="text-neutral-600">
+                <td colSpan={8} className="text-neutral-600">
                   Καμία καταχώρηση.
                 </td>
               </tr>

--- a/frontend/src/app/api/admin/orders/export/route.ts
+++ b/frontend/src/app/api/admin/orders/export/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getPrisma } from '../../../../../lib/prismaSafe';
 import { memOrders } from '../../../../../lib/orderStore';
 import { adminEnabled } from '../../../../../lib/adminGuard';
+import { orderNumber } from '../../../../../lib/orderNumber';
 
 export const dynamic = 'force-dynamic';
 
@@ -120,10 +121,11 @@ export async function GET(req: Request) {
 
   // Generate CSV
   const header =
-    'Order ID,Created At,Postal Code,Method,Weight (g),Subtotal,Shipping Cost,COD Fee,Total,Email,Payment Status,Payment Ref\n';
+    'Order No,Order ID,Created At,Postal Code,Method,Weight (g),Subtotal,Shipping Cost,COD Fee,Total,Email,Payment Status,Payment Ref\n';
 
   const lines = rows.map((r) => {
     return [
+      escapeCSV(orderNumber(r.id, r.createdAt)),
       escapeCSV(r.id),
       escapeCSV(r.createdAt),
       escapeCSV(r.postalCode),

--- a/frontend/src/app/api/orders/route.ts
+++ b/frontend/src/app/api/orders/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getPrisma } from '../../../lib/prismaSafe';
 import { memOrders } from '../../../lib/orderStore';
 import { rateLimit } from '../../../lib/rateLimit';
+import { orderNumber } from '../../../lib/orderNumber';
 
 export const dynamic = 'force-dynamic';
 
@@ -82,7 +83,11 @@ export async function POST(req: Request) {
           }).catch(() => {});
         }
       } catch {}
-      return NextResponse.json({ ok: true, id: created.id }, { status: 201 });
+      const ordNo = orderNumber(created.id, created.createdAt as any);
+      return NextResponse.json(
+        { ok: true, id: created.id, orderNumber: ordNo },
+        { status: 201 }
+      );
     } catch (e) {
       // Fallback to memory if DB fails
       const created = memOrders.create(data);
@@ -105,8 +110,9 @@ export async function POST(req: Request) {
           }).catch(() => {});
         }
       } catch {}
+      const ordNo = orderNumber(created.id, created.createdAt as any);
       return NextResponse.json(
-        { ok: true, id: created.id, mem: true },
+        { ok: true, id: created.id, orderNumber: ordNo, mem: true },
         { status: 201 }
       );
     }
@@ -131,8 +137,9 @@ export async function POST(req: Request) {
         }).catch(() => {});
       }
     } catch {}
+    const ordNo = orderNumber(created.id, created.createdAt as any);
     return NextResponse.json(
-      { ok: true, id: created.id, mem: true },
+      { ok: true, id: created.id, orderNumber: ordNo, mem: true },
       { status: 201 }
     );
   }

--- a/frontend/src/app/checkout/confirmation/page.tsx
+++ b/frontend/src/app/checkout/confirmation/page.tsx
@@ -6,6 +6,7 @@ import { formatEUR } from '../../../lib/money';
 export default function Confirmation() {
   const [json, setJson] = React.useState<any>(null);
   const [orderId, setOrderId] = React.useState<string>('');
+  const [orderNo, setOrderNo] = React.useState<string>('');
 
   React.useEffect(() => {
     try {
@@ -15,6 +16,9 @@ export default function Confirmation() {
     } catch {}
     try {
       setOrderId(localStorage.getItem('checkout_order_id') || '');
+    } catch {}
+    try {
+      setOrderNo(localStorage.getItem('checkout_order_no') || '');
     } catch {}
   }, []);
 
@@ -26,8 +30,13 @@ export default function Confirmation() {
       </p>
       <Card>
         <CardTitle>Σύνοψη</CardTitle>
+        {orderNo && (
+          <div className="mt-1 text-sm text-neutral-800">
+            Order No: <strong data-testid="order-no">{orderNo}</strong>
+          </div>
+        )}
         {orderId && (
-          <div className="mt-1 text-sm text-neutral-700">
+          <div className="mt-1 text-xs text-neutral-600">
             Order ID: <strong data-testid="order-id">{orderId}</strong>
           </div>
         )}

--- a/frontend/src/app/checkout/payment/page.tsx
+++ b/frontend/src/app/checkout/payment/page.tsx
@@ -41,6 +41,14 @@ export default function PaymentPage() {
           try {
             localStorage.setItem('checkout_order_id', String(created.id));
           } catch {}
+          if (created.orderNumber) {
+            try {
+              localStorage.setItem(
+                'checkout_order_no',
+                String(created.orderNumber)
+              );
+            } catch {}
+          }
         }
       } catch {
         // Continue even if order save fails

--- a/frontend/src/lib/orderNumber.ts
+++ b/frontend/src/lib/orderNumber.ts
@@ -1,0 +1,13 @@
+function pad(n: number) {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+export function orderNumber(id: string, createdAt?: string | Date): string {
+  const safeId = (id || '').replace(/[^a-z0-9]/gi, '');
+  const suffix = (safeId.slice(-4) || '0000').toUpperCase();
+  const d = createdAt ? new Date(createdAt) : new Date();
+  const y = d.getFullYear();
+  const m = pad(d.getMonth() + 1);
+  const day = pad(d.getDate());
+  return `DX-${y}${m}${day}-${suffix}`;
+}

--- a/frontend/tests/e2e/admin-orders-export-filters.spec.ts
+++ b/frontend/tests/e2e/admin-orders-export-filters.spec.ts
@@ -38,7 +38,10 @@ test('CSV export contains header and order data', async ({ page }) => {
   const csv = fs.readFileSync(path as string, 'utf-8');
 
   // Έλεγχος header
-  expect(csv).toContain('Order ID,Created At,Postal Code');
+  expect(csv).toContain('Order No,Order ID,Created At,Postal Code');
+
+  // Έλεγχος ότι περιέχει orderNumber (DX-YYYYMMDD-####)
+  expect(/DX-\d{8}-[A-Z0-9]{4}/.test(csv)).toBeTruthy();
 
   // Έλεγχος ότι περιέχει την παραγγελία μας
   expect(csv).toContain(oid as string);

--- a/frontend/tests/e2e/confirmation-shows-ordernumber.spec.ts
+++ b/frontend/tests/e2e/confirmation-shows-ordernumber.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('Confirmation shows friendly Order No (DX-YYYYMMDD-####)', async ({
+  page,
+}) => {
+  await page
+    .goto('/checkout/flow')
+    .catch(() => test.skip(true, 'flow route not present'));
+  await page.getByLabel('Οδός & αριθμός').fill('Panepistimiou 1');
+  await page.getByLabel('Πόλη').fill('Athens');
+  await page.getByLabel('Τ.Κ.').fill('10431');
+  await page.getByTestId('flow-method').selectOption('COURIER');
+  await page.getByTestId('flow-weight').fill('500');
+  await page.getByTestId('flow-subtotal').fill('42');
+  await page.getByTestId('flow-proceed').click();
+  await expect(page.getByText('Πληρωμή')).toBeVisible();
+  await page.getByTestId('pay-now').click();
+  await expect(page.getByText('Επιβεβαίωση παραγγελίας')).toBeVisible();
+
+  const el = page.getByTestId('order-no');
+  await expect(el).toBeVisible();
+  const text = (await el.textContent())?.trim() || '';
+  expect(text).toMatch(/^DX-\d{8}-[A-Z0-9]{4}$/);
+});


### PR DESCRIPTION
## Summary

Adds human-friendly order numbers (DX-YYYYMMDD-####) derived from createdAt + id across the entire system.

**Changes**:
- ✅ Helper function orderNumber(id, createdAt) in src/lib/orderNumber.ts
- ✅ API returns { id, orderNumber } on order creation
- ✅ Confirmation shows Order No (prominent) + Order ID (smaller)
- ✅ Admin list displays Order # as first column
- ✅ Admin detail shows Order No above Order ID
- ✅ CSV export includes orderNumber as first column
- ✅ E2E test: Confirmation shows DX-YYYYMMDD-#### pattern
- ✅ E2E test: CSV contains orderNumber

## Test Plan

- [x] Order creation returns orderNumber in API response
- [x] Confirmation page displays Order No with pattern DX-YYYYMMDD-####
- [x] Order ID still visible (smaller, for technical reference)
- [x] Admin list shows Order # column (client-computed)
- [x] Admin detail shows Order No prominently
- [x] CSV export includes orderNumber as first column
- [x] E2E test validates pattern on confirmation
- [x] E2E test validates orderNumber in CSV
- [x] Works with both Prisma and in-memory storage
- [x] No database migration required (derived field)

## Technical Details

**Order Number Format** (frontend/src/lib/orderNumber.ts:6):
- Pattern: `DX-{YYYY}{MM}{DD}-{last 4 chars of ID}`
- Example: `DX-20251017-A1B2`
- Derived from: createdAt (date) + id (suffix)

**API Integration** (frontend/src/app/api/orders/route.ts:86):
- Returns orderNumber on order creation
- Applied to all code paths (Prisma success, fallback, in-memory)

**UI Display** (frontend/src/app/checkout/confirmation/page.tsx:33):
- Order No: prominent (text-neutral-800)
- Order ID: smaller (text-neutral-600, text-xs)

**Admin Integration**:
- List (frontend/src/app/admin/orders/page.tsx:177): Client-side computation
- Detail (frontend/src/app/admin/orders/[id]/page.tsx:54): Client-side computation

**CSV Export** (frontend/src/app/api/admin/orders/export/route.ts:128):
- First column in CSV
- Server-side computation during export

**E2E Tests**:
- confirmation-shows-ordernumber.spec.ts: Pattern validation
- admin-orders-export-filters.spec.ts: CSV content validation

## Notes

- No database schema changes (purely derived field)
- Backwards compatible with existing orders
- Order ID remains visible for technical reference
- Non-breaking change (adds new field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)