### PR TITLE
Pass AG23 — Admin resend receipt

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG23.md
+++ b/docs/AGENT/SUMMARY/Pass-AG23.md
@@ -1,0 +1,113 @@
+# Pass AG23 — Admin Resend Receipt
+
+**Date**: 2025-10-17 (continued)
+**Branch**: feat/AG23-admin-resend-receipt
+**Status**: Complete
+
+## Summary
+
+Implements admin functionality to manually resend order receipt emails via dev mailbox. Adds POST endpoint at /api/admin/orders/[id]/resend with BASIC_AUTH guard, "Resend receipt" button on admin order detail page, and E2E test verifying email delivery.
+
+## Changes
+
+### New Files
+
+**frontend/src/app/api/admin/orders/[id]/resend/route.ts**:
+- POST endpoint for resending order receipt
+- Guard: adminEnabled() (BASIC_AUTH=1)
+- Rate limiting: 30 req/min (prod-only)
+- Fetches order from Prisma or in-memory fallback
+- Generates receipt email with:
+  - Subject: Order No (DX-...) + Total
+  - Body: Order No, Total, Postal Code, Admin link
+- Sends via /api/ci/devmail/send (dev mailbox)
+- Returns { ok: true } on success
+- Error handling: 404 for missing order, 429 for rate limit
+
+**frontend/tests/e2e/admin-resend-receipt.spec.ts**:
+- E2E test covering full flow:
+  1. Create order via checkout
+  2. Navigate to admin order detail
+  3. Click "Resend receipt" button
+  4. Verify email in dev mailbox contains DX- pattern and admin link
+- Uses page.on('dialog') to auto-accept alert
+- Skips if dev mailbox API unavailable
+
+### Modified Files
+
+**frontend/src/app/admin/orders/[id]/page.tsx**:
+- Added "Resend receipt" button before "back to list" link
+- Button fetches /api/admin/orders/${id}/resend via POST
+- Shows alert on success/failure
+- data-testid="resend-receipt" for E2E testing
+
+**docs/AGENT/SUMMARY/Pass-AG23.md** (this file):
+- Documentation for AG23 implementation
+
+## Technical Details
+
+### API Endpoint
+```typescript
+export async function POST(req: Request, ctx: { params: { id: string } }) {
+  if (!adminEnabled()) return new NextResponse('Not Found', { status: 404 });
+  if (!(await rateLimit('admin-resend-receipt', 30))) {
+    return new NextResponse('Too Many Requests', { status: 429 });
+  }
+  
+  // Fetch order from Prisma or in-memory
+  // Generate receipt email
+  // Send via dev mailbox
+  
+  return NextResponse.json({ ok: true });
+}
+```
+
+### Email Format
+Same format as initial receipt (AG21):
+- Subject: `Dixis Order ${ordNo} — Total: €${total}`
+- Body: `Order ${ordNo}\nΣύνολο: €${total}\nΤ.Κ.: ${postalCode}\n\nΠροβολή: ${link}`
+
+### UI Button
+```typescript
+<button
+  data-testid="resend-receipt"
+  onClick={async ()=>{
+    const r = await fetch(`/api/admin/orders/${data?.id}/resend`, { method:'POST' });
+    alert(r.ok ? 'Το email στάλθηκε ξανά.' : 'Αποτυχία αποστολής.');
+  }}
+>Resend receipt</button>
+```
+
+## Testing
+
+- E2E test verifies complete workflow
+- Test creates real order and triggers resend
+- Validates email appears in dev mailbox
+- Checks for DX- pattern in subject
+- Verifies admin link in body
+
+## Use Cases
+
+- Support can manually resend receipts to customers
+- Useful when original email fails or is lost
+- Admin can verify email content before customer contact
+- Works in dev/CI environments with SMTP_DEV_MAILBOX=1
+
+## Security
+
+- BASIC_AUTH guard (adminEnabled())
+- Rate limiting (30 req/min, prod-only)
+- Best-effort email sending (no error thrown on failure)
+- Uses existing originFromReq() helper for proper URL formation
+
+## Notes
+
+- Compatible with Prisma and in-memory order storage
+- Reuses orderNumber() helper from AG20
+- Email format consistent with initial receipt (AG21)
+- Button placement: before "back to list" link on detail page
+- Alert feedback for user confirmation
+
+---
+
+**Generated**: 2025-10-17 (continued)

--- a/frontend/src/app/admin/orders/[id]/page.tsx
+++ b/frontend/src/app/admin/orders/[id]/page.tsx
@@ -110,6 +110,20 @@ export default function AdminOrderDetail({
             </tbody>
           </table>
           <div className="mt-4">
+            <button
+              data-testid="resend-receipt"
+              onClick={async ()=>{
+                try {
+                  const r = await fetch(`/api/admin/orders/${data?.id}/resend`, { method:'POST' });
+                  alert(r.ok ? 'Το email στάλθηκε ξανά.' : 'Αποτυχία αποστολής.');
+                } catch {
+                  alert('Σφάλμα αποστολής.');
+                }
+              }}
+              className="border px-3 py-1 rounded"
+            >Resend receipt</button>
+          </div>
+          <div className="mt-4">
             <a href="/admin/orders" className="underline">
               ← Πίσω στη λίστα
             </a>

--- a/frontend/src/app/api/admin/orders/[id]/resend/route.ts
+++ b/frontend/src/app/api/admin/orders/[id]/resend/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { getPrisma } from '../../../../../../lib/prismaSafe';
+import { memOrders } from '../../../../../../lib/orderStore';
+import { adminEnabled } from '../../../../../../lib/adminGuard';
+import { rateLimit } from '../../../../../../lib/rateLimit';
+import { orderNumber } from '../../../../../../lib/orderNumber';
+
+export const dynamic = 'force-dynamic';
+
+function originFromReq(req: Request): string {
+  try {
+    const o = req.headers.get('origin');
+    if (o) return o;
+  } catch {}
+  return process.env.APP_ORIGIN || 'http://localhost:3000';
+}
+
+export async function POST(req: Request, ctx: { params: { id: string } }) {
+  if (!adminEnabled()) return new NextResponse('Not Found', { status: 404 });
+
+  if (!(await rateLimit('admin-resend-receipt', 30))) {
+    return new NextResponse('Too Many Requests', { status: 429 });
+  }
+
+  const id = ctx?.params?.id;
+  if (!id) return new NextResponse('missing id', { status: 400 });
+
+  const prisma = getPrisma();
+  let o: any = null;
+
+  if (prisma) {
+    try {
+      o = await prisma.checkoutOrder.findUnique({ where: { id } });
+    } catch {}
+  }
+  if (!o) {
+    o = memOrders.get(id);
+  }
+  if (!o) return new NextResponse('not found', { status: 404 });
+
+  const ordNo = orderNumber(o.id, o.createdAt);
+  const origin = originFromReq(req);
+  const to = String(o.email || process.env.DEVMAIL_DEFAULT_TO || 'test@dixis.dev');
+
+  const total = Number(o.total ?? 0);
+  const subject = 'Dixis Order ' + ordNo + ' — Total: €' + total.toFixed(2);
+  const link = origin + '/admin/orders/' + o.id;
+  const text = 'Order ' + ordNo + '\nΣύνολο: €' + total.toFixed(2) + '\nΤ.Κ.: ' + o.postalCode + '\n\nΠροβολή: ' + link;
+
+  try {
+    await fetch(origin + '/api/ci/devmail/send', {
+      method: 'POST',
+      headers: { 'Content-Type':'application/json' },
+      body: JSON.stringify({ to, subject, text })
+    });
+  } catch {}
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/tests/e2e/admin-resend-receipt.spec.ts
+++ b/frontend/tests/e2e/admin-resend-receipt.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test('Admin can resend receipt and it appears in dev mailbox', async ({ page, request }) => {
+  // 1) Create order via checkout flow
+  await page.goto('/checkout/flow').catch(()=>test.skip(true, 'flow route not present'));
+  await page.getByLabel('Οδός & αριθμός').fill('Panepistimiou 1');
+  await page.getByLabel('Πόλη').fill('Athens');
+  await page.getByLabel('Τ.Κ.').fill('10431');
+  await page.getByLabel('Email').fill('ci-recipient@dixis.dev');
+  await page.getByTestId('flow-method').selectOption('COURIER');
+  await page.getByTestId('flow-weight').fill('500');
+  await page.getByTestId('flow-subtotal').fill('42');
+  await page.getByTestId('flow-proceed').click();
+  await expect(page.getByText('Πληρωμή')).toBeVisible();
+  await page.getByTestId('pay-now').click();
+  await expect(page.getByText('Επιβεβαίωση παραγγελίας')).toBeVisible();
+
+  const oid = (await page.getByTestId('order-id').textContent())?.trim() || '';
+  test.skip(!oid, 'orderId not visible on confirmation');
+
+  // 2) Navigate to admin detail and resend
+  await page.goto(`/admin/orders/${oid}`);
+  await expect(page.getByText('Admin · Order Detail')).toBeVisible();
+  const btn = page.getByTestId('resend-receipt');
+  await expect(btn).toBeVisible();
+  
+  // Click and dismiss alert
+  page.on('dialog', dialog => dialog.accept());
+  await btn.click();
+
+  // 3) Verify email in dev mailbox
+  const res = await request.get('/api/dev/mailbox', { failOnStatusCode: false });
+  if (!res.ok()) test.skip(true, 'dev mailbox API not available in this env');
+  const list = await res.json();
+
+  const found = list.find((m: any) =>
+    String(m?.to || '').toLowerCase().includes('ci-recipient@dixis.dev') &&
+    String(m?.subject || '').includes('DX-') &&
+    String(m?.text || '').includes(`/admin/orders/${oid}`)
+  );
+  expect(found, 'resend email should exist in dev mailbox').toBeTruthy();
+});


### PR DESCRIPTION
## Summary

Implements admin functionality to manually resend order receipt emails. Adds endpoint, UI button, and E2E test.

## Changes

- **API Endpoint**: POST `/api/admin/orders/[id]/resend`
  - BASIC_AUTH guarded (adminEnabled())
  - Rate limiting: 30 req/min (prod-only)
  - Fetches order from Prisma or in-memory
  - Sends receipt via dev mailbox
- **UI Button**: "Resend receipt" on admin order detail page
  - Shows alert on success/failure
  - data-testid for E2E testing
- **E2E Test**: `admin-resend-receipt.spec.ts`
  - Creates order, navigates to admin detail
  - Clicks resend button
  - Verifies email in dev mailbox

## Email Format

Same as initial receipt (AG21):
- Subject: `Dixis Order DX-YYYYMMDD-#### — Total: €XX.XX`
- Body: Order No, Total, Postal Code, Admin link

## Use Cases

- Support can manually resend receipts to customers
- Useful when original email fails or is lost
- Admin can verify email content

## Technical Details

- Compatible with Prisma + in-memory fallback
- Reuses orderNumber() helper (AG20)
- originFromReq() for proper URL formation
- Best-effort email sending (no error on failure)

---

**LOC**: ~228 (+228/-0)
**Labels**: ai-pass, risk-ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)