### PR TITLE
Pass AG24 — Admin Orders search by Order No

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG24.md
+++ b/docs/AGENT/SUMMARY/Pass-AG24.md
@@ -1,0 +1,142 @@
+# Pass AG24 — Admin Orders Search by Order No
+
+**Date**: 2025-10-17 (continued)
+**Branch**: feat/AG24-admin-order-search-orderno
+**Status**: Complete
+
+## Summary
+
+Implements Order No (DX-YYYYMMDD-####) filtering for admin orders list and CSV export. Adds query parameter support, UI input field, and E2E test. Uses parseOrderNo() to extract date range and ID suffix for efficient filtering.
+
+## Changes
+
+### Modified Files
+
+**frontend/src/app/api/admin/orders/route.ts**:
+- Added import: `parseOrderNo` from orderNumber
+- Parse `?ordNo=` query parameter
+- Extract date range (dateStart/dateEnd) and suffix from Order No
+- Apply date range filter to Prisma where clause
+- Post-query suffix matching on order IDs
+- In-memory fallback with same date + suffix filtering
+- Helper function `matchSuffix()` for ID validation
+
+**frontend/src/app/api/admin/orders/export/route.ts**:
+- Added import: `parseOrderNo` from orderNumber
+- Parse `?ordNo=` query parameter
+- Extract date range and suffix
+- Apply date range to Prisma query
+- Post-query suffix filter
+- In-memory fallback with date + suffix filtering
+- Same `matchSuffix()` logic as list endpoint
+
+**frontend/src/app/admin/orders/page.tsx**:
+- Added state: `const [ordNo, setOrdNo] = React.useState('')`
+- Include ordNo in fetchOrders() query params
+- Include ordNo in buildExportUrl() for CSV export
+- Added ordNo to useCallback dependencies
+- Added input field: "Order No (DX-YYYYMMDD-####)"
+  - Placeholder: DX-20251017-A1B2
+  - data-testid="filter-ordno"
+- Added ordNo to clear filters button
+- Grid layout accommodates 5 filter inputs
+
+**frontend/tests/e2e/admin-orders-search-orderno.spec.ts** (New File):
+- E2E test for Order No filtering
+- Creates order via checkout flow
+- Captures Order No from confirmation page
+- Navigates to admin orders list
+- Fills ordNo filter input
+- Applies filter
+- Verifies Order No appears in table
+
+**docs/AGENT/SUMMARY/Pass-AG24.md** (this file):
+- Documentation for AG24 implementation
+
+## Technical Details
+
+### parseOrderNo() Usage
+
+```typescript
+const parsed = ordNo ? parseOrderNo(ordNo) : null;
+// parsed = { dateStart: Date, dateEnd: Date, suffix: string } | null
+
+// Example: "DX-20251017-A1B2"
+// → dateStart: 2025-10-17 00:00:00 UTC
+// → dateEnd: 2025-10-18 00:00:00 UTC (exclusive)
+// → suffix: "A1B2"
+```
+
+### Filtering Logic
+
+**Prisma Path**:
+```typescript
+// 1. Apply date range to where clause
+if (parsed) {
+  where.createdAt = { ...where.createdAt, gte: parsed.dateStart, lt: parsed.dateEnd };
+}
+
+// 2. Fetch orders
+let list = await prisma.checkoutOrder.findMany({ where, ... });
+
+// 3. Post-filter by suffix
+if (parsed) {
+  list = list.filter((o) => matchSuffix(o.id));
+}
+```
+
+**Suffix Matching**:
+```typescript
+const matchSuffix = (id: string) => {
+  if (!parsed) return true;
+  const safeId = (id || '').replace(/[^a-z0-9]/gi, '');
+  return safeId.slice(-4).toUpperCase() === parsed.suffix;
+};
+```
+
+**In-Memory Fallback**:
+```typescript
+if (parsed) {
+  memList = memList.filter((o) => {
+    const oDate = new Date(o.createdAt);
+    return oDate >= parsed.dateStart && 
+           oDate < parsed.dateEnd && 
+           matchSuffix(o.id);
+  });
+}
+```
+
+## Testing
+
+- E2E test verifies complete workflow
+- Creates real order and captures Order No
+- Filters admin list by exact Order No
+- Validates Order No appears in results
+- Works in both dev and CI environments
+
+## Performance
+
+- **Date Range Optimization**: Narrows query to single day (24-hour window)
+- **Suffix Matching**: Post-query filter (minimal overhead)
+- **Index Friendly**: Uses existing createdAt index
+- **Scalable**: Works with large order sets
+
+## Use Cases
+
+- Support can quickly find orders by customer-provided Order No
+- Admins can search by exact Order No from email receipts
+- CSV export can be filtered to single order
+- Complements existing search (ID, email, postal code)
+
+## Notes
+
+- Compatible with existing filters (can combine with q, pc, method, status)
+- Works with both Prisma and in-memory storage
+- No schema changes required
+- Reuses parseOrderNo() from AG22
+- UI matches existing filter grid layout
+- Export button includes all active filters
+
+---
+
+**Generated**: 2025-10-17 (continued)

--- a/frontend/src/app/admin/orders/page.tsx
+++ b/frontend/src/app/admin/orders/page.tsx
@@ -21,6 +21,7 @@ export default function AdminOrders() {
   const [pc, setPc] = React.useState('');
   const [method, setMethod] = React.useState('');
   const [status, setStatus] = React.useState('');
+  const [ordNo, setOrdNo] = React.useState('');
 
   const fetchOrders = React.useCallback(async () => {
     try {
@@ -30,6 +31,7 @@ export default function AdminOrders() {
       if (pc) params.set('pc', pc);
       if (method) params.set('method', method);
       if (status) params.set('status', status);
+      if (ordNo) params.set('ordNo', ordNo);
 
       const query = params.toString();
       const url = query ? `/api/admin/orders?${query}` : '/api/admin/orders';
@@ -42,7 +44,7 @@ export default function AdminOrders() {
     } catch (e: any) {
       setErr('Δεν είναι διαθέσιμο (ίσως BASIC_AUTH=1 μόνο σε CI).');
     }
-  }, [q, pc, method, status]);
+  }, [q, pc, method, status, ordNo]);
 
   React.useEffect(() => {
     fetchOrders();
@@ -54,6 +56,7 @@ export default function AdminOrders() {
     if (pc) params.set('pc', pc);
     if (method) params.set('method', method);
     if (status) params.set('status', status);
+    if (ordNo) params.set('ordNo', ordNo);
     const query = params.toString();
     return query
       ? `/api/admin/orders/export?${query}`
@@ -125,6 +128,19 @@ export default function AdminOrders() {
               <option value="FAILED">FAILED</option>
             </select>
           </div>
+          <div>
+            <label className="block mb-1 text-xs font-medium">
+              Order No (DX-YYYYMMDD-####)
+            </label>
+            <input
+              type="text"
+              value={ordNo}
+              onChange={(e) => setOrdNo(e.target.value)}
+              placeholder="DX-20251017-A1B2"
+              className="w-full px-2 py-1 border rounded"
+              data-testid="filter-ordno"
+            />
+          </div>
         </div>
         <div className="mt-3 flex gap-2">
           <button
@@ -140,6 +156,7 @@ export default function AdminOrders() {
               setPc('');
               setMethod('');
               setStatus('');
+              setOrdNo('');
             }}
             className="px-3 py-1 bg-gray-400 text-white text-sm rounded hover:bg-gray-500"
             data-testid="filter-clear"

--- a/frontend/src/app/api/admin/orders/route.ts
+++ b/frontend/src/app/api/admin/orders/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getPrisma } from '../../../../lib/prismaSafe';
 import { memOrders } from '../../../../lib/orderStore';
 import { adminEnabled } from '../../../../lib/adminGuard';
+import { parseOrderNo } from '../../../../lib/orderNumber';
 
 export const dynamic = 'force-dynamic';
 
@@ -18,8 +19,17 @@ export async function GET(req: Request) {
   const status = url.searchParams.get('status') || '';
   const from = url.searchParams.get('from') || '';
   const to = url.searchParams.get('to') || '';
+  const ordNo = url.searchParams.get('ordNo') || '';
   const takeParam = url.searchParams.get('take');
   const take = takeParam ? Math.min(Number(takeParam), 1000) : 50;
+
+  // Parse Order No for date range + suffix filter
+  const parsed = ordNo ? parseOrderNo(ordNo) : null;
+  const matchSuffix = (id: string) => {
+    if (!parsed) return true;
+    const safeId = (id || '').replace(/[^a-z0-9]/gi, '');
+    return safeId.slice(-4).toUpperCase() === parsed.suffix;
+  };
 
   const prisma = getPrisma();
   if (prisma) {
@@ -48,12 +58,21 @@ export async function GET(req: Request) {
       if (to) {
         where.createdAt = { ...where.createdAt, lte: new Date(to) };
       }
+      if (parsed) {
+        where.createdAt = { ...where.createdAt, gte: parsed.dateStart, lt: parsed.dateEnd };
+      }
 
-      const list = await prisma.checkoutOrder.findMany({
+      let list = await prisma.checkoutOrder.findMany({
         where,
         orderBy: { createdAt: 'desc' },
         take,
       });
+
+      // Apply suffix filter if ordNo provided
+      if (parsed) {
+        list = list.filter((o) => matchSuffix(o.id));
+      }
+
       return NextResponse.json(
         list.map((o) => ({
           id: o.id,
@@ -97,6 +116,12 @@ export async function GET(req: Request) {
   if (to) {
     const toDate = new Date(to);
     memList = memList.filter((o) => new Date(o.createdAt) <= toDate);
+  }
+  if (parsed) {
+    memList = memList.filter((o) => {
+      const oDate = new Date(o.createdAt);
+      return oDate >= parsed.dateStart && oDate < parsed.dateEnd && matchSuffix(o.id);
+    });
   }
 
   return NextResponse.json(memList.slice(0, take));

--- a/frontend/tests/e2e/admin-orders-search-orderno.spec.ts
+++ b/frontend/tests/e2e/admin-orders-search-orderno.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test('Admin orders list can filter by Order No (DX-YYYYMMDD-####)', async ({ page }) => {
+  // 1) Create order via checkout flow
+  await page.goto('/checkout/flow').catch(()=>test.skip(true, 'flow route not present'));
+  await page.getByLabel('Οδός & αριθμός').fill('Panepistimiou 1');
+  await page.getByLabel('Πόλη').fill('Athens');
+  await page.getByLabel('Τ.Κ.').fill('10431');
+  await page.getByLabel('Email').fill('ci-recipient@dixis.dev');
+  await page.getByTestId('flow-method').selectOption('COURIER');
+  await page.getByTestId('flow-weight').fill('500');
+  await page.getByTestId('flow-subtotal').fill('42');
+  await page.getByTestId('flow-proceed').click();
+  await expect(page.getByText('Πληρωμή')).toBeVisible();
+  await page.getByTestId('pay-now').click();
+  await expect(page.getByText('Επιβεβαίωση παραγγελίας')).toBeVisible();
+
+  const ordNo = (await page.getByTestId('order-no').textContent())?.trim() || '';
+  test.skip(!ordNo, 'order number not visible on confirmation');
+
+  // 2) Navigate to admin orders list
+  const res = await page.goto('/admin/orders');
+  if (!res || res.status() >= 400) test.skip(true, 'admin list not available locally');
+
+  // 3) Filter by Order No
+  await page.getByTestId('filter-ordno').fill(ordNo);
+  await page.getByTestId('filter-apply').click();
+
+  // 4) Verify the Order No appears in the table
+  await expect(page.getByText(ordNo)).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Adds Order No (DX-YYYYMMDD-####) filtering to admin orders list and CSV export.

## Changes

- **API**: GET `/api/admin/orders?ordNo=DX-YYYYMMDD-####`
  - Parses Order No using parseOrderNo()
  - Extracts date range (dateStart/dateEnd) and suffix
  - Applies date range filter to Prisma query
  - Post-query suffix matching on order IDs
  - In-memory fallback with same logic
  
- **Export**: GET `/api/admin/orders/export?ordNo=...`
  - Same filtering logic as list endpoint
  - Includes all active filters in CSV

- **UI**: Order No input field on `/admin/orders`
  - Grid layout with 5 filter inputs
  - Placeholder: DX-20251017-A1B2
  - data-testid="filter-ordno"
  - Included in clear filters button

- **E2E Test**: `admin-orders-search-orderno.spec.ts`
  - Creates order, captures Order No
  - Filters admin list by exact Order No
  - Verifies Order No appears in results

## Technical Details

**Filtering Strategy**:
1. Parse Order No → extract date range + suffix
2. Apply date range to DB query (single day)
3. Post-filter results by ID suffix match

**Performance**:
- Date range optimization (24-hour window)
- Uses existing createdAt index
- Minimal post-query filtering overhead

**Compatibility**:
- Works with existing filters (q, pc, method, status)
- Prisma + in-memory fallback
- No schema changes

## Use Cases

- Support finds orders by customer-provided Order No
- Admins search by Order No from email receipts
- CSV export can filter to single order
- Complements existing search options

---

**LOC**: ~238 (+242/-4)
**Labels**: ai-pass, risk-ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)