### PR TITLE
Pass AG25 — Admin Orders quick date filters (Today/7d/30d)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG25.md
+++ b/docs/AGENT/SUMMARY/Pass-AG25.md
@@ -1,0 +1,140 @@
+# Pass AG25 — Admin Orders Quick Date Filters
+
+**Date**: 2025-10-17 (continued)
+**Branch**: feat/AG25-admin-quick-date-filters
+**Status**: Complete
+
+## Summary
+
+Implements quick date filter buttons (Today / 7d / 30d) for admin orders list. Buttons set from/to ISO timestamps in query string, reusing existing API date filtering. Includes Clear Dates button and E2E test.
+
+## Changes
+
+### Modified Files
+
+**frontend/src/app/admin/orders/page.tsx**:
+- Added state: `fromISO`, `toISO` for date range
+- Added helper functions:
+  - `iso(d)` - Convert Date to ISO string
+  - `startOfDay(d)` - Get start of day (00:00:00)
+  - `addDays(d, n)` - Add/subtract days
+  - `setQuickRange(days)` - Set date range based on days back
+- Updated `fetchOrders()` to include from/to in query params
+- Updated `buildExportUrl()` to include from/to for CSV export
+- Added dependencies: fromISO, toISO to useCallback
+- Added UI: Quick date filter button group
+  - Today: Sets range to today (00:00:00 to tomorrow 00:00:00)
+  - 7d: Sets range to last 7 days
+  - 30d: Sets range to last 30 days
+  - Clear Dates: Clears from/to filters
+- Positioned before main filter controls
+- data-testid attributes for E2E testing
+
+**frontend/tests/e2e/admin-orders-quick-filters.spec.ts** (New File):
+- E2E test for Today quick filter
+- Creates order via checkout flow
+- Navigates to admin orders list
+- Clicks "Today" button
+- Verifies newly created order appears in results
+- Uses timeout for table update
+
+**docs/AGENT/SUMMARY/Pass-AG25.md** (this file):
+- Documentation for AG25 implementation
+
+## Technical Details
+
+### Date Range Calculation
+
+**Today**:
+```typescript
+const now = new Date();
+const from = startOfDay(now); // Today 00:00:00
+const to = addDays(startOfDay(now), 1); // Tomorrow 00:00:00 (exclusive)
+```
+
+**7d / 30d**:
+```typescript
+const now = new Date();
+const from = addDays(now, -days); // Current time minus N days
+const to = addDays(startOfDay(now), 1); // Tomorrow 00:00:00 (exclusive)
+```
+
+### Query String Integration
+
+```typescript
+// fetchOrders()
+if (fromISO) params.set('from', fromISO);
+if (toISO) params.set('to', toISO);
+
+// buildExportUrl()
+if (fromISO) params.set('from', fromISO);
+if (toISO) params.set('to', toISO);
+```
+
+### UI Button Group
+
+```tsx
+<div className="mt-4 mb-2 flex gap-2 text-xs">
+  <button onClick={() => setQuickRange(0)} data-testid="quick-range-today">
+    Today
+  </button>
+  <button onClick={() => setQuickRange(7)} data-testid="quick-range-7d">
+    7d
+  </button>
+  <button onClick={() => setQuickRange(30)} data-testid="quick-range-30d">
+    30d
+  </button>
+  <button onClick={() => { setFromISO(''); setToISO(''); }}>
+    Clear Dates
+  </button>
+</div>
+```
+
+## API Compatibility
+
+- **No API changes required** - Reuses existing from/to filters (AG19)
+- **No schema changes** - Client-side only implementation
+- **Export support** - CSV export automatically includes date filters
+- **Combines with other filters** - Works alongside q, pc, method, status, ordNo
+
+## Testing
+
+- E2E test verifies Today filter
+- Creates real order and validates visibility
+- Tests filter button interaction
+- Validates table update after filter application
+
+## Use Cases
+
+- Quick access to today's orders
+- Review recent orders (last 7 days)
+- Monthly order overview (last 30 days)
+- Clear date filters to return to all orders
+- Combine date filters with other search criteria
+
+## Performance
+
+- **Client-side computation** - No server load for date calculation
+- **ISO timestamps** - Standard format for API compatibility
+- **Reactive updates** - Automatic refetch on state change
+- **Export integration** - Date filters apply to CSV export
+
+## UX Highlights
+
+- **Positioned above main filters** - Easy access to common date ranges
+- **Small button group** - Minimal space usage
+- **Hover states** - Visual feedback on interaction
+- **Clear action** - Separate button to reset date filters
+- **Combined with search** - Can use quick dates + text search
+
+## Notes
+
+- Date ranges use exclusive end times (tomorrow 00:00:00)
+- Maintains existing filter state when applying date filters
+- Export CSV respects active date filters
+- No database changes required
+- Works with both Prisma and in-memory storage
+
+---
+
+**Generated**: 2025-10-17 (continued)

--- a/frontend/src/app/admin/orders/page.tsx
+++ b/frontend/src/app/admin/orders/page.tsx
@@ -22,6 +22,28 @@ export default function AdminOrders() {
   const [method, setMethod] = React.useState('');
   const [status, setStatus] = React.useState('');
   const [ordNo, setOrdNo] = React.useState('');
+  const [fromISO, setFromISO] = React.useState<string>('');
+  const [toISO, setToISO] = React.useState<string>('');
+
+  // Helper functions for quick date filters
+  const iso = (d: Date) => d.toISOString();
+  const startOfDay = (d: Date) => {
+    const x = new Date(d);
+    x.setHours(0, 0, 0, 0);
+    return x;
+  };
+  const addDays = (d: Date, n: number) => {
+    const x = new Date(d);
+    x.setDate(x.getDate() + n);
+    return x;
+  };
+  const setQuickRange = (days: number) => {
+    const now = new Date();
+    const from = days === 0 ? startOfDay(now) : addDays(now, -days);
+    const to = addDays(startOfDay(now), 1); // exclusive end (tomorrow 00:00)
+    setFromISO(iso(from));
+    setToISO(iso(to));
+  };
 
   const fetchOrders = React.useCallback(async () => {
     try {
@@ -32,6 +54,8 @@ export default function AdminOrders() {
       if (method) params.set('method', method);
       if (status) params.set('status', status);
       if (ordNo) params.set('ordNo', ordNo);
+      if (fromISO) params.set('from', fromISO);
+      if (toISO) params.set('to', toISO);
 
       const query = params.toString();
       const url = query ? `/api/admin/orders?${query}` : '/api/admin/orders';
@@ -44,7 +68,7 @@ export default function AdminOrders() {
     } catch (e: any) {
       setErr('Δεν είναι διαθέσιμο (ίσως BASIC_AUTH=1 μόνο σε CI).');
     }
-  }, [q, pc, method, status, ordNo]);
+  }, [q, pc, method, status, ordNo, fromISO, toISO]);
 
   React.useEffect(() => {
     fetchOrders();
@@ -57,6 +81,8 @@ export default function AdminOrders() {
     if (method) params.set('method', method);
     if (status) params.set('status', status);
     if (ordNo) params.set('ordNo', ordNo);
+    if (fromISO) params.set('from', fromISO);
+    if (toISO) params.set('to', toISO);
     const query = params.toString();
     return query
       ? `/api/admin/orders/export?${query}`
@@ -71,9 +97,48 @@ export default function AdminOrders() {
       </p>
       {err && <div className="mt-2 text-sm text-red-600">{err}</div>}
 
+      {/* Quick Date Filters */}
+      <div className="mt-4 mb-2 flex gap-2 text-xs">
+        <button
+          type="button"
+          onClick={() => setQuickRange(0)}
+          className="border px-2 h-7 rounded hover:bg-gray-100"
+          data-testid="quick-range-today"
+        >
+          Today
+        </button>
+        <button
+          type="button"
+          onClick={() => setQuickRange(7)}
+          className="border px-2 h-7 rounded hover:bg-gray-100"
+          data-testid="quick-range-7d"
+        >
+          7d
+        </button>
+        <button
+          type="button"
+          onClick={() => setQuickRange(30)}
+          className="border px-2 h-7 rounded hover:bg-gray-100"
+          data-testid="quick-range-30d"
+        >
+          30d
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setFromISO('');
+            setToISO('');
+          }}
+          className="border px-2 h-7 rounded hover:bg-gray-100"
+          data-testid="quick-range-clear"
+        >
+          Clear Dates
+        </button>
+      </div>
+
       {/* Filter Controls */}
       <div
-        className="mt-4 mb-4 p-3 border rounded"
+        className="mb-4 p-3 border rounded"
         style={{ backgroundColor: '#f9fafb' }}
       >
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">

--- a/frontend/tests/e2e/admin-orders-quick-filters.spec.ts
+++ b/frontend/tests/e2e/admin-orders-quick-filters.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+test('Admin Orders — Today quick filter includes a newly created order', async ({ page }) => {
+  // 1) Create order via checkout flow
+  await page.goto('/checkout/flow').catch(()=>test.skip(true, 'flow route not present'));
+  await page.getByLabel('Οδός & αριθμός').fill('Panepistimiou 1');
+  await page.getByLabel('Πόλη').fill('Athens');
+  await page.getByLabel('Τ.Κ.').fill('10431');
+  await page.getByLabel('Email').fill('ci-quickfilter@dixis.dev');
+  await page.getByTestId('flow-method').selectOption('COURIER');
+  await page.getByTestId('flow-weight').fill('500');
+  await page.getByTestId('flow-subtotal').fill('42');
+  await page.getByTestId('flow-proceed').click();
+  await expect(page.getByText('Πληρωμή')).toBeVisible();
+  await page.getByTestId('pay-now').click();
+  await expect(page.getByText('Επιβεβαίωση παραγγελίας')).toBeVisible();
+
+  // 2) Navigate to admin orders list
+  const res = await page.goto('/admin/orders');
+  if (!res || res.status()>=400) test.skip(true, 'admin list not available locally');
+
+  // 3) Click Today quick filter
+  await page.getByTestId('quick-range-today').click();
+
+  // 4) Wait for table to update and verify order appears
+  // Check for either email or postal code from our order
+  await expect(
+    page.locator('td').filter({ hasText: 'ci-quickfilter@dixis.dev' }).or(
+      page.locator('td').filter({ hasText: '10431' })
+    )
+  ).toBeVisible({ timeout: 10000 });
+});


### PR DESCRIPTION
## Summary

Adds quick date filter buttons (Today / 7d / 30d) to admin orders list for easy access to common date ranges.

## Changes

- **UI Button Group**: Quick date filters above main controls
  - **Today**: Shows orders from today (00:00:00 to tomorrow 00:00:00)
  - **7d**: Shows orders from last 7 days
  - **30d**: Shows orders from last 30 days
  - **Clear Dates**: Resets date filters

- **State Management**:
  - Added fromISO, toISO state
  - Helper functions: iso(), startOfDay(), addDays(), setQuickRange()
  - Updated fetchOrders() to include from/to params
  - Updated buildExportUrl() for CSV export

- **E2E Test**: `admin-orders-quick-filters.spec.ts`
  - Creates order via checkout
  - Clicks "Today" button
  - Verifies order appears in filtered results

## Technical Details

**Date Range Logic**:
- Today: Current day 00:00 → Tomorrow 00:00 (exclusive)
- 7d: Now - 7 days → Tomorrow 00:00
- 30d: Now - 30 days → Tomorrow 00:00

**API Integration**:
- Reuses existing from/to filters (AG19)
- No API or schema changes
- Query string: `?from=2025-10-17T00:00:00.000Z&to=2025-10-18T00:00:00.000Z`

**Export Support**:
- CSV export automatically includes date filters
- buildExportUrl() syncs with active filters

## Use Cases

- Quick access to today's orders
- Review recent activity (7/30 days)
- Combine with other filters (search, status, etc.)
- Export filtered date ranges to CSV

## UX

- Positioned above main filter controls
- Small, compact button group
- Hover states for visual feedback
- Separate Clear action for date filters
- Works alongside all other filters

## Compatibility

- No breaking changes
- Works with Prisma + in-memory storage
- Compatible with all existing filters
- Client-side date calculation

---

**LOC**: ~237 (+239/-2)
**Labels**: ai-pass, risk-ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)