### PR TITLE
feat(admin): add orders summary bar (count & revenue) — AG27

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG27.md
+++ b/docs/AGENT/SUMMARY/Pass-AG27.md
@@ -1,0 +1,192 @@
+# Pass-AG27 — Admin Orders summary bar (count & revenue)
+
+**Status**: ✅ COMPLETE
+**Branch**: `feat/AG27-admin-orders-summary`
+**Protocol**: STOP-on-failure | STRICT NO-VISION
+
+---
+
+## 🎯 OBJECTIVE
+
+Add summary bar to Admin Orders list showing total count and revenue for current filters:
+- API: GET /api/admin/orders/summary with same filter support as list
+- UI: Display summary bar above table showing filtered count and total amount
+- E2E: Test filtering by Order No and verify summary shows 1 order
+
+---
+
+## ✅ IMPLEMENTATION
+
+### 1. API: `/api/admin/orders/summary` (NEW)
+
+**Purpose**: Returns aggregate data for orders matching current filters
+
+**Query Parameters** (same as list endpoint):
+- `q`: Search query (ID or email)
+- `pc`: Postal code filter
+- `method`: Delivery method (COURIER/PICKUP)
+- `status`: Payment status (PAID/PENDING/FAILED)
+- `from`: Start date (ISO format)
+- `to`: End date (ISO format)
+- `ordNo`: Order number (DX-YYYYMMDD-####)
+
+**Response**:
+```json
+{
+  "totalCount": 42,
+  "totalAmount": 1234.56
+}
+```
+
+**Implementation Details**:
+```typescript
+// Fetch orders with only id and total for aggregation
+let list = await prisma.checkoutOrder.findMany({
+  where,
+  select: { id: true, total: true },
+  take: 1000, // cap for safety
+});
+
+// Apply suffix filter if ordNo provided
+if (parsed) {
+  list = list.filter((o) => matchSuffix(o.id));
+}
+
+const totalCount = list.length;
+const totalAmount = list.reduce((acc, o) => acc + Number(o.total ?? 0), 0);
+
+return NextResponse.json({ totalCount, totalAmount });
+```
+
+**In-Memory Fallback**: Same filtering logic as list endpoint, limited to 1000 records
+
+### 2. UI Changes (`frontend/src/app/admin/orders/page.tsx`)
+
+**Summary State**:
+```typescript
+const [sumAmount, setSumAmount] = React.useState(0);
+const [sumErr, setSumErr] = React.useState('');
+```
+
+**Filter Params Helper**:
+```typescript
+const buildFilterParams = React.useCallback(() => {
+  const params = new URLSearchParams();
+  if (q) params.set('q', q);
+  if (pc) params.set('pc', pc);
+  if (method) params.set('method', method);
+  if (status) params.set('status', status);
+  if (ordNo) params.set('ordNo', ordNo);
+  if (fromISO) params.set('from', fromISO);
+  if (toISO) params.set('to', toISO);
+  return params;
+}, [q, pc, method, status, ordNo, fromISO, toISO]);
+```
+
+**Summary Fetch Effect** (independent of pagination):
+```typescript
+React.useEffect(() => {
+  const fetchSummary = async () => {
+    try {
+      const params = buildFilterParams();
+      const query = params.toString();
+      const url = query ? `/api/admin/orders/summary?${query}` : '/api/admin/orders/summary';
+
+      const r = await fetch(url, { cache: 'no-store' });
+      if (!r.ok) {
+        setSumErr('⚠️');
+        return;
+      }
+      const j = await r.json();
+      setSumAmount(Number(j.totalAmount ?? 0));
+      setSumErr('');
+    } catch {
+      setSumErr('⚠️');
+    }
+  };
+  fetchSummary();
+}, [buildFilterParams]);
+```
+
+**Summary Bar UI**:
+```tsx
+<div className="mt-2 text-sm text-gray-700" data-testid="orders-summary">
+  Σύνοψη: {total.toLocaleString()} παραγγελίες · Σύνολο €{sumAmount.toFixed(2)}
+  {sumErr && <span className="text-red-600"> {sumErr}</span>}
+</div>
+```
+
+### 3. E2E Test (`frontend/tests/e2e/admin-orders-summary.spec.ts`)
+
+**Test Flow**:
+1. Create order via checkout flow (€42 subtotal)
+2. Capture Order No from confirmation page
+3. Navigate to admin orders list
+4. Filter by Order No
+5. Verify summary bar shows "1 παραγγελίες"
+6. Verify summary shows "Σύνολο €" with numeric value
+
+**Key Assertions**:
+```typescript
+const summary = page.getByTestId('orders-summary');
+await expect(summary).toBeVisible();
+
+const text = (await summary.textContent()) || '';
+expect(text).toMatch(/1\s+παραγγελί/i);
+expect(text).toMatch(/Σύνολο\s*€\d+/);
+```
+
+---
+
+## 🔍 KEY PATTERNS
+
+### Independent Summary Fetching
+- Summary fetch is **independent of pagination** (no skip/take/count params)
+- Reacts to filter changes but NOT to page/pageSize changes
+- Uses same filter logic as list endpoint for consistency
+
+### Code Reusability
+- `buildFilterParams()` helper shared between fetchOrders and fetchSummary
+- Reduces duplication and ensures filter consistency
+- Updated fetchOrders dependencies to use helper: `[buildFilterParams, page, pageSize]`
+
+### Error Handling
+- Summary errors shown as warning icon (⚠️) without disrupting UI
+- Failed summary fetch doesn't break the main orders list
+- Graceful degradation if API unavailable
+
+---
+
+## 📊 FILES MODIFIED
+
+1. `frontend/src/app/api/admin/orders/summary/route.ts` - Summary API endpoint (NEW)
+2. `frontend/src/app/admin/orders/page.tsx` - UI summary bar + fetch logic
+3. `frontend/tests/e2e/admin-orders-summary.spec.ts` - E2E test (NEW)
+4. `docs/AGENT/SUMMARY/Pass-AG27.md` - This documentation (NEW)
+
+---
+
+## ✅ VERIFICATION
+
+**API Endpoint**:
+```bash
+# Get summary for all orders
+curl "/api/admin/orders/summary"
+
+# Get summary with filters
+curl "/api/admin/orders/summary?pc=10431&method=COURIER"
+
+# Get summary for specific Order No
+curl "/api/admin/orders/summary?ordNo=DX-20251017-A1B2"
+```
+
+**E2E Test**:
+```bash
+cd frontend
+npx playwright test admin-orders-summary.spec.ts
+```
+
+---
+
+**Generated-by**: Claude Code (AG27 Protocol)
+**Timestamp**: 2025-10-17

--- a/frontend/src/app/api/admin/orders/summary/route.ts
+++ b/frontend/src/app/api/admin/orders/summary/route.ts
@@ -1,0 +1,126 @@
+import { NextResponse } from 'next/server';
+import { getPrisma } from '../../../../../lib/prismaSafe';
+import { memOrders } from '../../../../../lib/orderStore';
+import { adminEnabled } from '../../../../../lib/adminGuard';
+import { parseOrderNo } from '../../../../../lib/orderNumber';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  if (!adminEnabled()) {
+    return new NextResponse('admin disabled', { status: 404 });
+  }
+
+  // Parse filters from query string (same as list endpoint, but no pagination)
+  const url = new URL(req.url);
+  const q = url.searchParams.get('q') || '';
+  const pc = url.searchParams.get('pc') || '';
+  const method = url.searchParams.get('method') || '';
+  const status = url.searchParams.get('status') || '';
+  const from = url.searchParams.get('from') || '';
+  const to = url.searchParams.get('to') || '';
+  const ordNo = url.searchParams.get('ordNo') || '';
+
+  // Parse Order No for date range + suffix filter
+  const parsed = ordNo ? parseOrderNo(ordNo) : null;
+  const matchSuffix = (id: string) => {
+    if (!parsed) return true;
+    const safeId = (id || '').replace(/[^a-z0-9]/gi, '');
+    return safeId.slice(-4).toUpperCase() === parsed.suffix;
+  };
+
+  const prisma = getPrisma();
+  if (prisma) {
+    try {
+      // Build Prisma where clause
+      const where: any = {};
+
+      if (q) {
+        where.OR = [
+          { id: { contains: q, mode: 'insensitive' } },
+          { email: { contains: q, mode: 'insensitive' } },
+        ];
+      }
+      if (pc) {
+        where.postalCode = { contains: pc };
+      }
+      if (method) {
+        where.method = method;
+      }
+      if (status) {
+        where.paymentStatus = status;
+      }
+      if (from) {
+        where.createdAt = { ...where.createdAt, gte: new Date(from) };
+      }
+      if (to) {
+        where.createdAt = { ...where.createdAt, lte: new Date(to) };
+      }
+      if (parsed) {
+        where.createdAt = { ...where.createdAt, gte: parsed.dateStart, lt: parsed.dateEnd };
+      }
+
+      // Fetch orders with id and total for aggregation
+      let list = await prisma.checkoutOrder.findMany({
+        where,
+        select: { id: true, total: true },
+        take: 1000, // cap for safety
+      });
+
+      // Apply suffix filter if ordNo provided
+      if (parsed) {
+        list = list.filter((o) => matchSuffix(o.id));
+      }
+
+      const totalCount = list.length;
+      const totalAmount = list.reduce((acc, o) => acc + Number(o.total ?? 0), 0);
+
+      return NextResponse.json({ totalCount, totalAmount });
+    } catch {
+      // Fallthrough to memory
+    }
+  }
+
+  // Apply filters to in-memory fallback
+  let memList = memOrders.list();
+
+  if (q) {
+    const qLower = q.toLowerCase();
+    memList = memList.filter(
+      (o) =>
+        o.id.toLowerCase().includes(qLower) ||
+        (o.email && o.email.toLowerCase().includes(qLower))
+    );
+  }
+  if (pc) {
+    memList = memList.filter((o) => o.postalCode.includes(pc));
+  }
+  if (method) {
+    memList = memList.filter((o) => o.method === method);
+  }
+  if (status) {
+    memList = memList.filter((o) => o.paymentStatus === status);
+  }
+  if (from) {
+    const fromDate = new Date(from);
+    memList = memList.filter((o) => new Date(o.createdAt) >= fromDate);
+  }
+  if (to) {
+    const toDate = new Date(to);
+    memList = memList.filter((o) => new Date(o.createdAt) <= toDate);
+  }
+  if (parsed) {
+    memList = memList.filter((o) => {
+      const oDate = new Date(o.createdAt);
+      return oDate >= parsed.dateStart && oDate < parsed.dateEnd && matchSuffix(o.id);
+    });
+  }
+
+  // Apply take limit for safety
+  const limited = memList.slice(0, 1000);
+
+  const totalCount = limited.length;
+  const totalAmount = limited.reduce((acc, o: any) => acc + Number(o.total ?? 0), 0);
+
+  return NextResponse.json({ totalCount, totalAmount });
+}

--- a/frontend/tests/e2e/admin-orders-summary.spec.ts
+++ b/frontend/tests/e2e/admin-orders-summary.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+test('Admin Orders — summary reflects filters (Order No → 1 order)', async ({ page }) => {
+  // 1) Create order via checkout flow
+  await page.goto('/checkout/flow').catch(() => test.skip(true, 'flow route not present'));
+  await page.getByLabel('Οδός & αριθμός').fill('Panepistimiou 1');
+  await page.getByLabel('Πόλη').fill('Athens');
+  await page.getByLabel('Τ.Κ.').fill('10431');
+  await page.getByLabel('Email').fill('ci-summary@dixis.dev');
+  await page.getByTestId('flow-method').selectOption('COURIER');
+  await page.getByTestId('flow-weight').fill('500');
+  await page.getByTestId('flow-subtotal').fill('42');
+  await page.getByTestId('flow-proceed').click();
+  await expect(page.getByText('Πληρωμή')).toBeVisible();
+  await page.getByTestId('pay-now').click();
+  await expect(page.getByText('Επιβεβαίωση παραγγελίας')).toBeVisible();
+
+  const ordNo = (await page.getByTestId('order-no').textContent())?.trim() || '';
+  test.skip(!ordNo, 'order number not visible on confirmation');
+
+  // 2) Navigate to admin orders list
+  const res = await page.goto('/admin/orders');
+  if (!res || res.status() >= 400) test.skip(true, 'admin list not available locally');
+
+  // 3) Filter by Order No
+  await page.getByTestId('filter-ordno').fill(ordNo);
+  await page.getByTestId('filter-apply').click();
+
+  // 4) Verify summary bar is visible and shows 1 order with euro amount
+  const summary = page.getByTestId('orders-summary');
+  await expect(summary).toBeVisible();
+
+  const text = (await summary.textContent()) || '';
+
+  // Should show "1 παραγγελίες" (or similar)
+  expect(text).toMatch(/1\s+παραγγελί/i);
+
+  // Should show "Σύνολο €" with a number
+  expect(text).toMatch(/Σύνολο\s*€\d+/);
+});


### PR DESCRIPTION
## Summary
- Add summary bar to Admin Orders list showing total count and revenue for current filters
- New API endpoint `/api/admin/orders/summary` with same filter support as list
- Summary updates independently of pagination (reflects all filtered orders, not just current page)
- E2E test verifies filtering by Order No shows correct summary

## Acceptance Criteria
- [x] API endpoint `/api/admin/orders/summary` returns `{ totalCount, totalAmount }`
- [x] API accepts same filters as list endpoint (q, pc, method, status, from, to, ordNo)
- [x] UI displays summary bar above table showing count and revenue
- [x] Summary updates when filters change (independent of pagination)
- [x] Summary shows all filtered orders, not just current page
- [x] Error handling shows warning icon without breaking UI
- [x] E2E test verifies summary with Order No filter

## Changes
1. **API** (`frontend/src/app/api/admin/orders/summary/route.ts`) - NEW:
   - GET /api/admin/orders/summary
   - Supports same filters as list endpoint (q, pc, method, status, from, to, ordNo)
   - Returns `{ totalCount, totalAmount }` for filtered orders
   - Prisma primary with in-memory fallback
   - Cap at 1000 orders for safety

2. **UI** (`frontend/src/app/admin/orders/page.tsx`):
   - Add summary state (sumAmount, sumErr)
   - Extract `buildFilterParams()` helper for filter reusability
   - Add summary fetch effect (independent of pagination)
   - Display summary bar above table: "Σύνοψη: N παραγγελίες · Σύνολο €X.YY"
   - Show warning icon (⚠️) on summary fetch errors

3. **E2E Test** (`frontend/tests/e2e/admin-orders-summary.spec.ts`) - NEW:
   - Creates order via checkout flow
   - Filters by Order No
   - Verifies summary shows "1 παραγγελίες" and "Σύνολο €"

## Test Plan
- [x] E2E test passes (`admin-orders-summary.spec.ts`)
- [x] Summary updates when filters change
- [x] Summary independent of pagination (shows all filtered orders)
- [x] API returns correct count and total
- [x] Error handling shows warning without breaking UI
- [x] CI checks pass

## Reports
- **Test Coverage**: E2E test for summary filtering (`admin-orders-summary.spec.ts`)
- **API Route**: `frontend/src/app/api/admin/orders/summary/route.ts`
- **UI Component**: `frontend/src/app/admin/orders/page.tsx:298-302` (summary bar)
- **Documentation**: `docs/AGENT/SUMMARY/Pass-AG27.md`

## Evidence
- API endpoint: `frontend/src/app/api/admin/orders/summary/route.ts`
- UI summary bar: `frontend/src/app/admin/orders/page.tsx:298-302`
- Summary fetch: `frontend/src/app/admin/orders/page.tsx:110-130`
- E2E test: `frontend/tests/e2e/admin-orders-summary.spec.ts`
- Documentation: `docs/AGENT/SUMMARY/Pass-AG27.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)