### PR TITLE
feat(orders): customer lookup links (AG29)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG29.md
+++ b/docs/AGENT/SUMMARY/Pass-AG29.md
@@ -1,0 +1,247 @@
+# Pass-AG29 — Customer link in receipt & confirmation + Copy
+
+**Status**: ✅ COMPLETE
+**Branch**: `feat/AG29-customer-lookup-link`
+**Protocol**: STOP-on-failure | STRICT NO-VISION
+
+---
+
+## 🎯 OBJECTIVE
+
+Add customer lookup links to receipt emails, confirmation page, and admin detail:
+- Email: Add `/orders/lookup?ordNo=...` link alongside admin link
+- Confirmation: Display customer link with copy button and "Copied!" feedback
+- Admin Detail: Add "Customer view" helper link
+- E2E: Test email contains customer link, confirmation copy button works
+
+---
+
+## ✅ IMPLEMENTATION
+
+### 1. Email Receipt Changes (`frontend/src/app/api/orders/route.ts`)
+
+**Customer Link Variable**:
+```typescript
+const link = `${origin}/admin/orders/${created.id}`;
+const cust = `${origin}/orders/lookup?ordNo=${ordNo}`;
+const body = `Order ${ordNo}\nΣύνολο: €${(data.total ?? 0).toFixed(
+  2
+)}\nΤ.Κ.: ${data.postalCode}\n\nAdmin: ${link}\nCustomer: ${cust}`;
+```
+
+**Email Structure**:
+- Admin link: `/admin/orders/{id}` (existing, unchanged)
+- Customer link: `/orders/lookup?ordNo=DX-{YYYYMMDD}-{suffix}` (new)
+- Both links displayed in email body
+
+**Applied to**:
+- Prisma path (lines 77-81)
+- Memory fallback (lines 106-110)
+
+### 2. Confirmation Page Changes (`frontend/src/app/checkout/confirmation/page.tsx`)
+
+**Added State**:
+```typescript
+const [copied, setCopied] = React.useState<boolean>(false);
+```
+
+**Customer Link Section**:
+```tsx
+{orderNo && (
+  <div className="mt-4 p-3 border rounded bg-gray-50">
+    <div className="text-sm font-medium text-neutral-800 mb-2">
+      Customer Link
+    </div>
+    <div className="text-xs text-neutral-600 break-all mb-2">
+      <a
+        href={`/orders/lookup?ordNo=${orderNo}`}
+        className="underline"
+        data-testid="customer-link"
+      >
+        {typeof window !== 'undefined'
+          ? `${window.location.origin}/orders/lookup?ordNo=${orderNo}`
+          : `/orders/lookup?ordNo=${orderNo}`}
+      </a>
+    </div>
+    <button
+      onClick={async () => {
+        try {
+          const link =
+            typeof window !== 'undefined'
+              ? `${window.location.origin}/orders/lookup?ordNo=${orderNo}`
+              : `/orders/lookup?ordNo=${orderNo}`;
+          await navigator.clipboard.writeText(link);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        } catch {}
+      }}
+      className="px-3 py-1 bg-blue-600 text-white text-xs rounded hover:bg-blue-700"
+      data-testid="copy-customer-link"
+    >
+      Copy link
+    </button>
+    {copied && (
+      <span
+        className="ml-2 text-xs text-green-600"
+        data-testid="copied-flag"
+      >
+        Copied!
+      </span>
+    )}
+  </div>
+)}
+```
+
+**Key Features**:
+- Full URL display with origin (SSR-safe with `typeof window` check)
+- Copy button using `navigator.clipboard.writeText()`
+- Temporary "Copied!" message (2 second timeout)
+- All elements have testid attributes for E2E testing
+
+### 3. Admin Detail Changes (`frontend/src/app/admin/orders/[id]/page.tsx`)
+
+**Customer View Link**:
+```tsx
+<div className="mb-2">
+  <a
+    href={`/orders/lookup?ordNo=${orderNumber(data.id, data.createdAt)}`}
+    className="text-blue-600 underline text-xs"
+    data-testid="customer-view-link"
+  >
+    Customer view →
+  </a>
+</div>
+```
+
+**Placement**: After Order No and Order ID, before the order details table
+
+### 4. E2E Test Updates
+
+**Email Test** (`frontend/tests/e2e/order-receipt-email.spec.ts`):
+```typescript
+// body contains admin link
+expect(String(found?.text || '')).toContain('/admin/orders/');
+// body contains customer link
+expect(String(found?.text || '')).toContain('/orders/lookup?ordNo=');
+```
+
+**Confirmation Test** (`frontend/tests/e2e/confirmation-customer-link.spec.ts` - NEW):
+```typescript
+test('Confirmation page — customer link + copy button', async ({ page, context }) => {
+  // Grant clipboard permissions
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+  // Create order via checkout flow
+  // ...
+
+  // Verify customer link is visible
+  const customerLink = page.getByTestId('customer-link');
+  await expect(customerLink).toBeVisible();
+
+  // Get order number
+  const orderNo = (await page.getByTestId('order-no').textContent())?.trim() || '';
+  expect(orderNo).toMatch(/^DX-\d{8}-[A-Z0-9]{4}$/);
+
+  // Verify link contains order number
+  const linkText = (await customerLink.textContent())?.trim() || '';
+  expect(linkText).toContain(`/orders/lookup?ordNo=${orderNo}`);
+
+  // Click copy button
+  const copyButton = page.getByTestId('copy-customer-link');
+  await copyButton.click();
+
+  // Verify "Copied!" message appears
+  const copiedFlag = page.getByTestId('copied-flag');
+  await expect(copiedFlag).toBeVisible();
+
+  // Verify clipboard contains the link
+  const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipboardText).toContain(`/orders/lookup?ordNo=${orderNo}`);
+
+  // Wait for "Copied!" to disappear
+  await expect(copiedFlag).not.toBeVisible({ timeout: 3000 });
+});
+```
+
+---
+
+## 🔍 KEY PATTERNS
+
+### SSR-Safe Window Access
+```typescript
+{typeof window !== 'undefined'
+  ? `${window.location.origin}/orders/lookup?ordNo=${orderNo}`
+  : `/orders/lookup?ordNo=${orderNo}`}
+```
+- Prevents hydration errors
+- Fallback to relative path on server
+
+### Clipboard API with Error Handling
+```typescript
+try {
+  await navigator.clipboard.writeText(link);
+  setCopied(true);
+  setTimeout(() => setCopied(false), 2000);
+} catch {}
+```
+- Modern clipboard API (no `document.execCommand`)
+- Graceful failure (empty catch)
+- Temporary feedback message
+
+### Playwright Clipboard Testing
+```typescript
+await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+```
+- Grant permissions at context level
+- Read clipboard via evaluate (runs in browser context)
+
+### Replace All Pattern
+When the same email body text appears in both Prisma and memory fallback paths:
+```typescript
+<invoke name="Edit">
+  <parameter name="replace_all">true</parameter>
+</invoke>
+```
+- Avoids duplicating edits
+- Ensures consistency across code paths
+
+---
+
+## 📊 FILES MODIFIED
+
+1. `frontend/src/app/api/orders/route.ts` - Add customer link to email
+2. `frontend/src/app/checkout/confirmation/page.tsx` - Customer link + copy button
+3. `frontend/src/app/admin/orders/[id]/page.tsx` - Customer view helper link
+4. `frontend/tests/e2e/order-receipt-email.spec.ts` - Assert customer link in email
+5. `frontend/tests/e2e/confirmation-customer-link.spec.ts` - Test copy button (NEW)
+6. `docs/AGENT/SUMMARY/Pass-AG29.md` - This documentation (NEW)
+
+---
+
+## ✅ VERIFICATION
+
+**Email Receipt**:
+```bash
+# Create order and check dev mailbox
+curl /api/orders -X POST -d '{"postalCode":"10431","method":"COURIER","total":42}'
+curl /api/dev/mailbox | jq '.[] | select(.subject | contains("DX-"))'
+# Should contain both Admin: and Customer: links
+```
+
+**Confirmation Page**:
+```bash
+cd frontend
+npx playwright test confirmation-customer-link.spec.ts
+# Tests customer link visibility and copy button functionality
+```
+
+**Admin Detail**:
+- Navigate to `/admin/orders/{id}`
+- Verify "Customer view →" link is present
+- Click link to verify it navigates to `/orders/lookup?ordNo=...`
+
+---
+
+**Generated-by**: Claude Code (AG29 Protocol)
+**Timestamp**: 2025-10-18

--- a/frontend/src/app/admin/orders/[id]/page.tsx
+++ b/frontend/src/app/admin/orders/[id]/page.tsx
@@ -60,6 +60,15 @@ export default function AdminOrderDetail({
             Order ID:{' '}
             <strong data-testid="detail-order-id">{data.id}</strong>
           </div>
+          <div className="mb-2">
+            <a
+              href={`/orders/lookup?ordNo=${orderNumber(data.id, data.createdAt)}`}
+              className="text-blue-600 underline text-xs"
+              data-testid="customer-view-link"
+            >
+              Customer view →
+            </a>
+          </div>
           <table className="text-sm">
             <tbody>
               <tr>

--- a/frontend/src/app/api/orders/route.ts
+++ b/frontend/src/app/api/orders/route.ts
@@ -75,9 +75,10 @@ export async function POST(req: Request) {
             data.total ?? 0
           ).toFixed(2)}`;
           const link = `${origin}/admin/orders/${created.id}`;
+          const cust = `${origin}/orders/lookup?ordNo=${ordNo}`;
           const body = `Order ${ordNo}\nΣύνολο: €${(data.total ?? 0).toFixed(
             2
-          )}\nΤ.Κ.: ${data.postalCode}\n\nΠροβολή: ${link}`;
+          )}\nΤ.Κ.: ${data.postalCode}\n\nAdmin: ${link}\nCustomer: ${cust}`;
           await fetch(`${origin}/api/ci/devmail/send`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -104,9 +105,10 @@ export async function POST(req: Request) {
             data.total ?? 0
           ).toFixed(2)}`;
           const link = `${origin}/admin/orders/${created.id}`;
+          const cust = `${origin}/orders/lookup?ordNo=${ordNo}`;
           const body = `Order ${ordNo}\nΣύνολο: €${(data.total ?? 0).toFixed(
             2
-          )}\nΤ.Κ.: ${data.postalCode}\n\nΠροβολή: ${link}`;
+          )}\nΤ.Κ.: ${data.postalCode}\n\nAdmin: ${link}\nCustomer: ${cust}`;
           await fetch(`${origin}/api/ci/devmail/send`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/app/checkout/confirmation/page.tsx
+++ b/frontend/src/app/checkout/confirmation/page.tsx
@@ -7,6 +7,7 @@ export default function Confirmation() {
   const [json, setJson] = React.useState<any>(null);
   const [orderId, setOrderId] = React.useState<string>('');
   const [orderNo, setOrderNo] = React.useState<string>('');
+  const [copied, setCopied] = React.useState<boolean>(false);
 
   React.useEffect(() => {
     try {
@@ -60,6 +61,49 @@ export default function Confirmation() {
             </ul>
           )}
         </div>
+        {orderNo && (
+          <div className="mt-4 p-3 border rounded bg-gray-50">
+            <div className="text-sm font-medium text-neutral-800 mb-2">
+              Customer Link
+            </div>
+            <div className="text-xs text-neutral-600 break-all mb-2">
+              <a
+                href={`/orders/lookup?ordNo=${orderNo}`}
+                className="underline"
+                data-testid="customer-link"
+              >
+                {typeof window !== 'undefined'
+                  ? `${window.location.origin}/orders/lookup?ordNo=${orderNo}`
+                  : `/orders/lookup?ordNo=${orderNo}`}
+              </a>
+            </div>
+            <button
+              onClick={async () => {
+                try {
+                  const link =
+                    typeof window !== 'undefined'
+                      ? `${window.location.origin}/orders/lookup?ordNo=${orderNo}`
+                      : `/orders/lookup?ordNo=${orderNo}`;
+                  await navigator.clipboard.writeText(link);
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 2000);
+                } catch {}
+              }}
+              className="px-3 py-1 bg-blue-600 text-white text-xs rounded hover:bg-blue-700"
+              data-testid="copy-customer-link"
+            >
+              Copy link
+            </button>
+            {copied && (
+              <span
+                className="ml-2 text-xs text-green-600"
+                data-testid="copied-flag"
+              >
+                Copied!
+              </span>
+            )}
+          </div>
+        )}
       </Card>
     </main>
   );

--- a/frontend/tests/e2e/confirmation-customer-link.spec.ts
+++ b/frontend/tests/e2e/confirmation-customer-link.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+test('Confirmation page — customer link + copy button', async ({ page, context }) => {
+  // Grant clipboard permissions
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+  // 1) Create order via checkout flow
+  await page.goto('/checkout/flow').catch(() => test.skip(true, 'flow route not present'));
+  await page.getByLabel('Οδός & αριθμός').fill('Panepistimiou 1');
+  await page.getByLabel('Πόλη').fill('Athens');
+  await page.getByLabel('Τ.Κ.').fill('10431');
+  await page.getByLabel('Email').fill('copy-test@dixis.dev');
+  await page.getByTestId('flow-method').selectOption('COURIER');
+  await page.getByTestId('flow-weight').fill('500');
+  await page.getByTestId('flow-subtotal').fill('42');
+  await page.getByTestId('flow-proceed').click();
+  await expect(page.getByText('Πληρωμή')).toBeVisible();
+  await page.getByTestId('pay-now').click();
+  await expect(page.getByText('Επιβεβαίωση παραγγελίας')).toBeVisible();
+
+  // 2) Verify customer link is visible
+  const customerLink = page.getByTestId('customer-link');
+  await expect(customerLink).toBeVisible();
+
+  // 3) Get the order number from the page
+  const orderNo = (await page.getByTestId('order-no').textContent())?.trim() || '';
+  expect(orderNo).toMatch(/^DX-\d{8}-[A-Z0-9]{4}$/);
+
+  // 4) Verify the customer link contains the order number
+  const linkText = (await customerLink.textContent())?.trim() || '';
+  expect(linkText).toContain(`/orders/lookup?ordNo=${orderNo}`);
+
+  // 5) Click the copy button
+  const copyButton = page.getByTestId('copy-customer-link');
+  await expect(copyButton).toBeVisible();
+  await copyButton.click();
+
+  // 6) Verify "Copied!" message appears
+  const copiedFlag = page.getByTestId('copied-flag');
+  await expect(copiedFlag).toBeVisible();
+  expect(await copiedFlag.textContent()).toContain('Copied!');
+
+  // 7) Verify clipboard contains the customer link
+  const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipboardText).toContain(`/orders/lookup?ordNo=${orderNo}`);
+  expect(clipboardText).toContain(orderNo);
+
+  // 8) Wait for "Copied!" message to disappear (should take ~2s)
+  await expect(copiedFlag).not.toBeVisible({ timeout: 3000 });
+});

--- a/frontend/tests/e2e/order-receipt-email.spec.ts
+++ b/frontend/tests/e2e/order-receipt-email.spec.ts
@@ -36,4 +36,6 @@ test('Order receipt email is stored in dev mailbox', async ({ page, request }) =
   expect(found, 'receipt email should exist in dev mailbox').toBeTruthy();
   // body contains admin link
   expect(String(found?.text || '')).toContain('/admin/orders/');
+  // body contains customer link
+  expect(String(found?.text || '')).toContain('/orders/lookup?ordNo=');
 });


### PR DESCRIPTION
## Summary

Add customer-facing order lookup links to emails, confirmation page, and admin detail.

**Scope**: Customer experience improvements for order tracking

## Changes

1. **Email Receipt** (`frontend/src/app/api/orders/route.ts`)
   - Add `/orders/lookup?ordNo=...` link alongside existing admin link
   - Applied to both Prisma and memory fallback paths

2. **Confirmation Page** (`frontend/src/app/checkout/confirmation/page.tsx`)
   - Display customer lookup link with full URL
   - "Copy link" button with clipboard API
   - "Copied!" feedback message (2s timeout)
   - SSR-safe window access

3. **Admin Detail** (`frontend/src/app/admin/orders/[id]/page.tsx`)
   - "Customer view →" helper link to lookup page

4. **E2E Tests**
   - Update email test to assert customer link presence
   - New test for confirmation copy button functionality
   - Clipboard permissions and verification

## Acceptance Criteria

- [x] Email receipt contains both admin and customer links
- [x] Confirmation page displays customer link with origin
- [x] Copy button writes full URL to clipboard
- [x] "Copied!" message appears and disappears after 2s
- [x] Admin detail includes customer view link
- [x] E2E test verifies email customer link
- [x] E2E test verifies copy button functionality

## Reports

- **Test Coverage**: 
  - Updated: `frontend/tests/e2e/order-receipt-email.spec.ts`
  - New: `frontend/tests/e2e/confirmation-customer-link.spec.ts`
- **Documentation**: `docs/AGENT/SUMMARY/Pass-AG29.md`
- **API Route**: `frontend/src/app/api/orders/route.ts` (risky path - needs `risk-ok`)
- **Line Count**: +356/-2 (within ≤300 LOC guideline for core changes)

---

**Protocol**: AG29 - STOP-on-failure | STRICT NO-VISION
**Generated-by**: Claude Code
**Evidence**: `docs/AGENT/SUMMARY/Pass-AG29.md`