### PR TITLE
AG58-fix5 — Smoke fast path: export DATABASE_URL before Prisma

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -234,6 +234,7 @@ jobs:
           cat > .env.ci <<'ENV'
           DATABASE_URL="file:./tmp/smoke.db"
           ENV
+          export DATABASE_URL="file:./tmp/smoke.db"
           npx prisma generate --schema prisma/schema.ci.prisma
           npx prisma db push --schema prisma/schema.ci.prisma --force-reset
           echo "DATABASE_URL=file:./tmp/smoke.db" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- **Pass**: AG58-fix5
- **Objective**: Fix Smoke test failures on ui-only/ops-only PRs by exporting DATABASE_URL before Prisma commands
- **Fixes**: PR #635 Smoke test failure (Environment variable not found: DATABASE_URL)

## Changes
Added `export DATABASE_URL="file:./tmp/smoke.db"` before Prisma commands in the "Prepare SQLite schema" step.

**Before**:
```bash
mkdir -p tmp
cat > .env.ci <<'ENV'
DATABASE_URL="file:./tmp/smoke.db"
ENV
npx prisma generate --schema prisma/schema.ci.prisma  # ❌ Fails - no env var
```

**After**:
```bash
mkdir -p tmp
cat > .env.ci <<'ENV'
DATABASE_URL="file:./tmp/smoke.db"
ENV
export DATABASE_URL="file:./tmp/smoke.db"  # ✅ Export before Prisma
npx prisma generate --schema prisma/schema.ci.prisma
npx prisma db push --schema prisma/schema.ci.prisma --force-reset
echo "DATABASE_URL=file:./tmp/smoke.db" >> $GITHUB_ENV
```

## Evidence
- Workflow file: `.github/workflows/pr.yml:237`
- Root cause: Prisma requires DATABASE_URL in environment, not just in .env file

## Test Plan
- [x] Smoke tests should now PASS for ui-only/ops-only PRs
- [x] SQLite schema preparation completes without error
- [x] No impact on full test path (PostgreSQL)

## Reports
- **CODEMAP** → `.github/workflows/pr.yml`
- **TEST-REPORT** → CI checks attached
- **RISKS-NEXT** → Low (CI-only fix, no functional changes)

## AC (Acceptance Criteria)
- Smoke tests pass on ui-only/ops-only PRs
- No Prisma validation errors
- Fast path completes in <2 minutes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)