### PR TITLE
Pass AG60-Ops — Cache pnpm store in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,6 +46,13 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Install minimal deps for fast path (ui-only | ops-only)
         if: \${{ contains(join(github.event.pull_request.labels.*.name, ','), 'ui-only') || contains(join(github.event.pull_request.labels.*.name, ','), 'ops-only') }}
         working-directory: frontend
@@ -189,6 +196,13 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Install minimal deps for fast path (ui-only | ops-only)
         if: \${{ contains(join(github.event.pull_request.labels.*.name, ','), 'ui-only') || contains(join(github.event.pull_request.labels.*.name, ','), 'ops-only') }}
         working-directory: frontend
@@ -340,6 +354,13 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Install minimal deps for fast path (ui-only | ops-only)
         if: \${{ contains(join(github.event.pull_request.labels.*.name, ','), 'ui-only') || contains(join(github.event.pull_request.labels.*.name, ','), 'ops-only') }}
         working-directory: frontend

--- a/docs/AGENT/SUMMARY/Pass-AG60-Ops.md
+++ b/docs/AGENT/SUMMARY/Pass-AG60-Ops.md
@@ -1,0 +1,3 @@
+- 2025-10-21 20:02 UTC — Pass AG60-Ops: Cache pnpm store in CI
+  - Adds actions/cache@v4 for ~/.pnpm-store keyed by **/pnpm-lock.yaml
+  - Speeds up both fast-path and full-path jobs.

--- a/docs/reports/2025-10-21/AG60-CODEMAP.md
+++ b/docs/reports/2025-10-21/AG60-CODEMAP.md
@@ -1,0 +1,3 @@
+# AG60-Ops — CODEMAP
+- **.github/workflows/pr.yml**: insert "Cache pnpm store" step before any "pnpm install"
+- **docs/AGENT/SUMMARY/Pass-AG60-Ops.md**

--- a/docs/reports/2025-10-21/AG60-RISKS-NEXT.md
+++ b/docs/reports/2025-10-21/AG60-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG60-Ops — RISKS-NEXT
+## Risks
+- Low: CI-only caching; no runtime/product code.
+## Next
+- AG61 (product): Admin orders empty-state (UI-only).
+- AG62 (backend): Fix Prisma Postgres migrations (OrderItem) for full PG E2E.

--- a/docs/reports/2025-10-21/AG60-TEST-REPORT.md
+++ b/docs/reports/2025-10-21/AG60-TEST-REPORT.md
@@ -1,0 +1,3 @@
+# AG60-Ops — TEST-REPORT
+- Expect ~15–25s faster on fast path (ui/ops-only).
+- Expect ~40–60s faster on full path when pnpm install runs.


### PR DESCRIPTION
## Summary
- **Pass**: AG60-Ops
- **Objective**: Add pnpm store caching to CI workflow to speed up dependency installation
- **Type**: CI optimization (ops-only)

## Changes
Added `actions/cache@v4` step before all `pnpm install` commands in `.github/workflows/pr.yml`:

1. **Cache Configuration**:
   - Path: `~/.pnpm-store`
   - Key: `${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}`
   - Restore keys: `${{ runner.os }}-pnpm-store-`

2. **Applied to 3 Locations**:
   - Frontend CI job (fast path)
   - Quality Assurance job (Smoke Tests)
   - E2E PostgreSQL job

## Performance Impact

**Expected Improvements:**
- Fast path (ui-only/ops-only): **~15-25s faster** 
- Full path (PostgreSQL E2E): **~40-60s faster**

**Cache Behavior:**
- First run: No cache, normal install time
- Subsequent runs: Cache hit, significantly faster installs
- Cache invalidated: When `pnpm-lock.yaml` changes

## Evidence
- Workflow file: `.github/workflows/pr.yml:49` (first cache step)
- Pattern: Cache step added before each `pnpm install`

## Reports
- **CODEMAP** → `docs/reports/2025-10-21/AG60-CODEMAP.md`
- **TEST-REPORT** → `docs/reports/2025-10-21/AG60-TEST-REPORT.md`
- **RISKS-NEXT** → `docs/reports/2025-10-21/AG60-RISKS-NEXT.md`

## Test Summary
- Faster install steps on subsequent CI runs
- No functional changes to tests or code
- Cache benefits both fast path and full path

## AC (Acceptance Criteria)
- Cache step exists before all pnpm install commands
- Cache key uses pnpm-lock.yaml hash
- Subsequent runs show cache restore in logs
- CI time reduced on cache hits

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)