### PR TITLE
AG60-fix-cache — Ensure pnpm uses ~/.pnpm-store & pre-create path

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Prepare pnpm store dir
+        run: mkdir -p ~/.pnpm-store
       - name: Cache pnpm store
         uses: actions/cache@v4
         with:
@@ -59,6 +61,7 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@latest --activate
+          pnpm config set store-dir ~/.pnpm-store
           pnpm install --frozen-lockfile
 
 
@@ -196,6 +199,8 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Prepare pnpm store dir
+        run: mkdir -p ~/.pnpm-store
       - name: Cache pnpm store
         uses: actions/cache@v4
         with:
@@ -209,6 +214,7 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@latest --activate
+          pnpm config set store-dir ~/.pnpm-store
           pnpm install --frozen-lockfile
 
 
@@ -354,6 +360,8 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Prepare pnpm store dir
+        run: mkdir -p ~/.pnpm-store
       - name: Cache pnpm store
         uses: actions/cache@v4
         with:
@@ -367,6 +375,7 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@latest --activate
+          pnpm config set store-dir ~/.pnpm-store
           pnpm install --frozen-lockfile
 
 

--- a/docs/AGENT/SUMMARY/Pass-AG60-fix-cache.md
+++ b/docs/AGENT/SUMMARY/Pass-AG60-fix-cache.md
@@ -1,0 +1,3 @@
+- 2025-10-21 20:35 UTC — Pass AG60-fix-cache: Ensure pnpm uses ~/.pnpm-store and create path pre-cache
+  - Adds a pre-cache step to create ~/.pnpm-store
+  - Sets pnpm store-dir to ~/.pnpm-store before pnpm install

--- a/docs/reports/2025-10-21/AG60-fix-cache-CODEMAP.md
+++ b/docs/reports/2025-10-21/AG60-fix-cache-CODEMAP.md
@@ -1,0 +1,4 @@
+# AG60-fix-cache — CODEMAP
+- **.github/workflows/pr.yml**:
+  - Insert "Prepare pnpm store dir" before "Cache pnpm store"
+  - Ensure `pnpm config set store-dir ~/.pnpm-store` runs before `pnpm install`


### PR DESCRIPTION
## Summary
- **Pass**: AG60-fix-cache
- **Objective**: Fix pnpm cache warnings by ensuring store directory exists and pnpm uses it
- **Type**: CI optimization fix (ops-only)
- **Fixes**: Warning from PR #638 - "Path(s) specified in the action for caching do(es) not exist"

## Changes

1. **Pre-create Store Directory** (before cache step):
   ```yaml
   - name: Prepare pnpm store dir
     run: mkdir -p ~/.pnpm-store
   ```

2. **Configure pnpm Store Location** (after corepack prepare):
   ```yaml
   run: |
     corepack enable
     corepack prepare pnpm@latest --activate
     pnpm config set store-dir ~/.pnpm-store
     pnpm install --frozen-lockfile
   ```

## Problem Fixed

**Previous Behavior** (PR #638):
```
[warning]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

**Root Cause**: 
- pnpm by default uses a different store location
- Cache action tried to cache `~/.pnpm-store` before it existed

**Solution**:
- Pre-create the directory before caching
- Explicitly configure pnpm to use `~/.pnpm-store`

## Evidence
- Prepare step: `.github/workflows/pr.yml:49`
- Config command: `.github/workflows/pr.yml:64`
- Applied to all 3 locations (Frontend CI, Quality Assurance, E2E PostgreSQL)

## Reports
- **CODEMAP** → `docs/reports/2025-10-21/AG60-fix-cache-CODEMAP.md`

## Expected Outcome

**First Run**: 
- Directory created ✅
- pnpm configured to use `~/.pnpm-store` ✅
- Cache saved successfully ✅

**Subsequent Runs**:
- Cache restored from `~/.pnpm-store` ✅
- pnpm install significantly faster ✅
- No cache warnings ✅

## AC (Acceptance Criteria)
- No "Path Validation Error" warnings in logs
- Cache successfully saved after first run
- Cache restored on subsequent runs
- pnpm install time reduced on cache hits

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)