### PR TITLE
Pass AG68-Ops — Add gate-required aggregator job to pr.yml

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -491,3 +491,22 @@ jobs:
           # So we accept success, failure, or skipped
           echo "✅ All quality gates evaluated (advisory gates may have warnings)"
           exit 0
+
+  gate-required:
+    name: Gate (required)
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [qa, test-smoke, danger, quality-gates]
+    steps:
+      - name: Evaluate required jobs
+        run: |
+          echo '${{ toJson(needs) }}' > needs.json
+          python3 - <<'PY2'
+          import json, sys
+          needs = json.load(open('needs.json'))
+          bad = [k for k,v in needs.items() if v.get('result') not in ('success','skipped')]
+          if bad:
+              print('❌ Failing jobs:', ', '.join(bad))
+              sys.exit(1)
+          print('✓ All required jobs succeeded or were skipped (fast path).')
+          PY2

--- a/docs/AGENT/SUMMARY/Pass-AG68-Ops.md
+++ b/docs/AGENT/SUMMARY/Pass-AG68-Ops.md
@@ -1,0 +1,4 @@
+- 2025-10-22 07:12 UTC — Pass AG68-Ops: Add `gate-required` aggregator job in pr.yml
+  - New job depends on **all** other jobs in the workflow.
+  - Runs with `always()` and fails only if a dependency failed (ignores skipped).
+  - Goal: simplify branch protection to a single required check.

--- a/docs/reports/2025-10-22/AG68-CODEMAP.md
+++ b/docs/reports/2025-10-22/AG68-CODEMAP.md
@@ -1,0 +1,3 @@
+# AG68-Ops — CODEMAP
+- **.github/workflows/pr.yml**: append `gate-required` job with `needs: [all jobs]`, `if: always()`, JSON-based evaluation of `needs` results
+- **docs/AGENT/SUMMARY/Pass-AG68-Ops.md**

--- a/docs/reports/2025-10-22/AG68-RISKS-NEXT.md
+++ b/docs/reports/2025-10-22/AG68-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG68-Ops — RISKS-NEXT
+## Risks
+- Low: CI-only change; no runtime impact.
+## Next
+- Update Branch Protection to require only **"Gate (required)"** (optional but recommended).
+- AG69 (product): wire `StatusChip` to real order status when API layer is ready.


### PR DESCRIPTION
Adds a final aggregator job that depends on all jobs in the PR workflow and fails only if any dependency failed.

Benefits:
- Simplified branch protection (single required check)
- Fast path compatible (handles skipped jobs correctly)
- Clearer PR merge status

The gate-required job runs with always() and depends on: qa, test-smoke, danger, quality-gates.

Reports:
- CODEMAP docs/reports/2025-10-22/AG68-CODEMAP.md
- RISKS-NEXT docs/reports/2025-10-22/AG68-RISKS-NEXT.md

Test Summary:
- CI-only change, ops-only fast path applies