### PR TITLE
Pass AG74 — Orders Repository abstraction (demo default)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG74.md
+++ b/docs/AGENT/SUMMARY/Pass-AG74.md
@@ -1,0 +1,5 @@
+- 2025-10-22 17:35 UTC — Pass AG74: Orders Repository abstraction (demo default)
+  - Repo layer: `frontend/src/lib/orders/providers/*`
+  - API provider select: `DIXIS_DATA_SRC=demo|pg|sqlite` (default: demo; CI→sqlite stub).
+  - `?demo=1` παραμένει για σταθερά E2E.
+  - Χωρίς schema/DB αλλαγές.

--- a/docs/reports/2025-10-22/AG74-CODEMAP.md
+++ b/docs/reports/2025-10-22/AG74-CODEMAP.md
@@ -1,0 +1,7 @@
+# AG74 — CODEMAP
+- **frontend/src/lib/orders/providers/types.ts**
+- **frontend/src/lib/orders/providers/demo.ts**
+- **frontend/src/lib/orders/providers/sqlite.ts** (stub→demo)
+- **frontend/src/lib/orders/providers/pg.ts** (placeholder)
+- **frontend/src/lib/orders/providers/index.ts**
+- **frontend/src/app/api/admin/orders/route.ts** (provider selection)

--- a/docs/reports/2025-10-22/AG74-RISKS-NEXT.md
+++ b/docs/reports/2025-10-22/AG74-RISKS-NEXT.md
@@ -1,0 +1,5 @@
+# AG74 — RISKS-NEXT
+## Risks
+- Very low: demo remains default; CI uses sqlite stub.
+## Next
+- **AG75**: Implement PG provider (Prisma) & real SQLite provider (CI) + `pg-e2e` gated test.

--- a/frontend/src/app/api/admin/orders/route.ts
+++ b/frontend/src/app/api/admin/orders/route.ts
@@ -1,31 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-type Order = { id: string; customer: string; total: string; status: 'pending'|'paid'|'shipped'|'cancelled'|'refunded' };
-
-const DEMO: Order[] = [
-  { id:'A-2001', customer:'Μαρία',   total:'€42.00',  status:'pending'  },
-  { id:'A-2002', customer:'Γιάννης', total:'€99.90',  status:'paid'     },
-  { id:'A-2003', customer:'Ελένη',   total:'€12.00',  status:'refunded' },
-  { id:'A-2004', customer:'Νίκος',   total:'€59.00',  status:'cancelled'},
-  { id:'A-2005', customer:'Άννα',    total:'€19.50',  status:'shipped'  },
-  { id:'A-2006', customer:'Κώστας',  total:'€31.70',  status:'pending'  },
-];
-
-const ALLOWED = new Set(['pending','paid','shipped','cancelled','refunded']);
+import { getOrdersRepo, type OrderStatus } from '@/lib/orders/providers';
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
-  const demo = url.searchParams.get('demo') === '1' || process.env.DIXIS_DEMO_API === '1';
+  const forceDemo = url.searchParams.get('demo') === '1';
   const status = url.searchParams.get('status');
 
-  if (!demo) {
-    return NextResponse.json({ error: 'Not implemented (enable demo with ?demo=1)' }, { status: 501 });
-  }
-
+  const ALLOWED = new Set(['pending','paid','shipped','cancelled','refunded']);
   if (status && !ALLOWED.has(status)) {
     return NextResponse.json({ error: 'Invalid status' }, { status: 400 });
   }
 
-  const data = status ? DEMO.filter(o => o.status === (status as Order['status'])) : DEMO;
-  return NextResponse.json({ items: data, count: data.length }, { status: 200 });
+  const mode = forceDemo ? 'demo' : (process.env.DIXIS_DATA_SRC || (process.env.CI ? 'sqlite' : 'demo'));
+  const repo = getOrdersRepo(mode);
+
+  try {
+    const data = await repo.list({ status: status as OrderStatus | undefined });
+    return NextResponse.json(data, { status: 200 });
+  } catch (err:any) {
+    if (err?.name === 'NOT_IMPLEMENTED') {
+      return NextResponse.json({ error: 'Not implemented for current mode', mode }, { status: 501 });
+    }
+    console.error('[orders api] unexpected', err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
 }

--- a/frontend/src/lib/orders/providers/demo.ts
+++ b/frontend/src/lib/orders/providers/demo.ts
@@ -1,0 +1,17 @@
+import type { OrdersRepo, Order, OrderStatus } from './types';
+
+const DEMO: Order[] = [
+  { id:'A-2001', customer:'Μαρία',   total:'€42.00',  status:'pending'  },
+  { id:'A-2002', customer:'Γιάννης', total:'€99.90',  status:'paid'     },
+  { id:'A-2003', customer:'Ελένη',   total:'€12.00',  status:'refunded' },
+  { id:'A-2004', customer:'Νίκος',   total:'€59.00',  status:'cancelled'},
+  { id:'A-2005', customer:'Άννα',    total:'€19.50',  status:'shipped'  },
+  { id:'A-2006', customer:'Κώστας',  total:'€31.70',  status:'pending'  },
+];
+
+export const demoRepo: OrdersRepo = {
+  async list(params?: { status?: OrderStatus }) {
+    const items = params?.status ? DEMO.filter(o=>o.status===params.status) : DEMO;
+    return { items, count: items.length };
+  }
+};

--- a/frontend/src/lib/orders/providers/index.ts
+++ b/frontend/src/lib/orders/providers/index.ts
@@ -1,0 +1,14 @@
+import type { OrdersRepo, OrderStatus } from './types';
+import { demoRepo } from './demo';
+import { sqliteRepo } from './sqlite';
+import { pgRepo } from './pg';
+
+export function getOrdersRepo(mode?: string): OrdersRepo {
+  switch ((mode || '').toLowerCase()) {
+    case 'pg': return pgRepo;
+    case 'sqlite': return sqliteRepo;
+    case 'demo':
+    default: return demoRepo;
+  }
+}
+export type { OrdersRepo, OrderStatus };

--- a/frontend/src/lib/orders/providers/pg.ts
+++ b/frontend/src/lib/orders/providers/pg.ts
@@ -1,0 +1,6 @@
+import type { OrdersRepo, OrderStatus } from './types';
+class NotImplemented extends Error { constructor(){ super('PG provider not implemented'); this.name='NOT_IMPLEMENTED'; } }
+// Πραγματική υλοποίηση στο AG75 (Prisma/Postgres)
+export const pgRepo: OrdersRepo = {
+  async list(_params?: { status?: OrderStatus }) { throw new NotImplemented(); }
+};

--- a/frontend/src/lib/orders/providers/sqlite.ts
+++ b/frontend/src/lib/orders/providers/sqlite.ts
@@ -1,0 +1,3 @@
+import type { OrdersRepo } from './types';
+import { demoRepo } from './demo';
+export const sqliteRepo: OrdersRepo = demoRepo; // CI stub — πραγματική υλοποίηση στο AG75

--- a/frontend/src/lib/orders/providers/types.ts
+++ b/frontend/src/lib/orders/providers/types.ts
@@ -1,0 +1,5 @@
+export type OrderStatus = 'pending'|'paid'|'shipped'|'cancelled'|'refunded';
+export type Order = { id: string; customer: string; total: string; status: OrderStatus };
+export interface OrdersRepo {
+  list(params?: { status?: OrderStatus }): Promise<{ items: Order[]; count: number }>;
+}


### PR DESCRIPTION
Adds a provider layer behind **/api/admin/orders** and selects source via `DIXIS_DATA_SRC=demo|pg|sqlite`.

### Reports
- CODEMAP → `docs/reports/2025-10-22/AG74-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-22/AG74-RISKS-NEXT.md`

### Test Summary
- Existing E2E (demo mode) remains valid; no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)