### PR TITLE
Pass AG83 — Orders CSV export (current view, UI-only)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG83.md
+++ b/docs/AGENT/SUMMARY/Pass-AG83.md
@@ -1,0 +1,5 @@
+- 2025-10-23 09:26 UTC — Pass AG83: Orders CSV export (current view, UI-only)
+  - Προστέθηκε κουμπί "Εξαγωγή CSV" που κατεβάζει το τρέχον αποτέλεσμα (όπως εμφανίζεται στη σελίδα)
+  - CSV headers: Order, Πελάτης, Σύνολο, Κατάσταση
+  - E2E: admin-orders-ui-csv.spec.ts (έλεγχος download ονόματος & περιεχομένου)
+  - Καμία αλλαγή σε schema/DB/CI.

--- a/docs/reports/2025-10-23/AG83-CODEMAP.md
+++ b/docs/reports/2025-10-23/AG83-CODEMAP.md
@@ -1,0 +1,3 @@
+# AG83 — CODEMAP
+- **frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx** — toCSV() + export button
+- **frontend/tests/e2e/admin-orders-ui-csv.spec.ts** — CSV download test

--- a/docs/reports/2025-10-23/AG83-RISKS-NEXT.md
+++ b/docs/reports/2025-10-23/AG83-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG83 — RISKS-NEXT
+## Risks
+- Ελάχιστο (UI-only). Browser download path εξαρτάται από Playwright runner — το test βασίζεται σε suggestedFilename και περιεχόμενο.
+## Next
+- AG84 (ops): Προ-τύπωση τοπικού typecheck πριν το push για να αποφεύγουμε TS λάθη (π.χ. AG82 TS2451).
+- AG85 (feature): Full export (όλα τα filtered rows) μέσω API endpoint με streaming CSV.

--- a/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
+++ b/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
@@ -16,6 +16,18 @@ const LOCAL_DEMO: Row[] = [
 ];
 
 export default function AdminOrdersMain() {
+  const toCSV = (rows: Row[]) => {
+    const esc = (v: any) => `"${String(v).replace(/"/g, '""')}"`;
+    const head = ['Order','Πελάτης','Σύνολο','Κατάσταση'];
+    const lines = [head, ...rows.map(r => [r.id, r.customer, r.total, r.status])].map(r => r.map(esc).join(','));
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const ts = new Date().toISOString().slice(0,10);
+    const a = document.createElement('a');
+    a.href = url; a.download = `orders_${ts}.csv`;
+    document.body.appendChild(a); a.click(); a.remove();
+    setTimeout(()=>URL.revokeObjectURL(url), 1000);
+  };
   const options = [
     { key:'pending',   label:'Σε αναμονή' },
     { key:'paid',      label:'Πληρωμή'    },
@@ -204,6 +216,11 @@ export default function AdminOrdersMain() {
         <button type="button" onClick={toggleSort} data-testid="toggle-sort"
           style={{padding:'6px 10px', borderRadius:8, border:'1px solid #ddd', background:'#fff', cursor:'pointer', fontSize:12, fontWeight:600}}>
           Ταξινόμηση: {sort==='-createdAt' ? 'Νεότερα πρώτα' : 'Παλαιότερα πρώτα'}
+        </button>
+        
+        <button type="button" onClick={()=>toCSV(rows)} data-testid="export-csv"
+          style={{padding:'6px 10px', borderRadius:8, border:'1px solid #ddd', background:'#fff', cursor:'pointer', fontSize:12, fontWeight:600}}>
+          Εξαγωγή CSV
         </button>
         <label style={{fontSize:12}}>
           Page size:&nbsp;

--- a/frontend/tests/e2e/admin-orders-ui-csv.spec.ts
+++ b/frontend/tests/e2e/admin-orders-ui-csv.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('Orders UI: CSV export downloads current view', async ({ page }) => {
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=1&pageSize=3');
+  await expect(page.getByTestId('results-count')).toBeVisible();
+
+  const [ download ] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByTestId('export-csv').click(),
+  ]);
+
+  const fname = download.suggestedFilename();
+  expect(fname).toMatch(/orders_\d{4}-\d{2}-\d{2}\.csv$/);
+
+  const content = await download.createReadStream();
+  let buf = Buffer.alloc(0);
+  for await (const chunk of content!) { buf = Buffer.concat([buf, chunk as Buffer]); }
+  const text = buf.toString('utf8');
+
+  expect(text).toContain('Order');
+  expect(text).toContain('Πελάτης');
+  expect(text).toContain('Σύνολο');
+  expect(text).toContain('Κατάσταση');
+});


### PR DESCRIPTION
UI-only: Προστέθηκε "Εξαγωγή CSV" που κατεβάζει τα εμφανιζόμενα rows (τρέχουσα σελίδα/φίλτρα). Περιλαμβάνει E2E.

### Reports
- CODEMAP → `docs/reports/2025-10-23/AG83-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-23/AG83-RISKS-NEXT.md`

### Test Summary
- UI-only E2E για CSV download.