### PR TITLE
Pass AG84 — Preflight typecheck (ops)

### DIFF
--- a/docs/AGENT/SOPs/PRECHECKS.md
+++ b/docs/AGENT/SOPs/PRECHECKS.md
@@ -1,0 +1,16 @@
+# PRECHECKS — Local Preflight πριν από κάθε PR
+
+## Τι τρέχουμε
+```bash
+scripts/preflight.sh
+```
+
+- Ενεργοποιεί corepack/pnpm (frontend)
+- pnpm install --frozen-lockfile
+- pnpm typecheck
+
+## Γιατί
+- Αποφεύγουμε TS λάθη (π.χ. μετονομασίες/διπλές δηλώσεις) πριν το push.
+
+## Πότε
+- Πριν από κάθε AG pass ή χειροκίνητο PR.

--- a/docs/AGENT/SUMMARY/Pass-AG84.md
+++ b/docs/AGENT/SUMMARY/Pass-AG84.md
@@ -1,0 +1,4 @@
+- 2025-10-23 10:24 UTC — Pass AG84: Preflight typecheck (ops)
+  - Προστέθηκε scripts/preflight.sh
+  - SOP: docs/AGENT/SOPs/PRECHECKS.md
+  - Καμία αλλαγή σε schema/UI/CI.

--- a/docs/reports/2025-10-23/AG84-CODEMAP.md
+++ b/docs/reports/2025-10-23/AG84-CODEMAP.md
@@ -1,0 +1,4 @@
+# AG84 — CODEMAP
+- **scripts/preflight.sh** — τοπικός τύπος-έλεγχος pnpm (frontend)
+- **docs/AGENT/SOPs/PRECHECKS.md** — οδηγίες χρήσης
+- **docs/AGENT/SUMMARY/Pass-AG84.md** — συνοπτικό pass

--- a/docs/reports/2025-10-23/AG84-RISKS-NEXT.md
+++ b/docs/reports/2025-10-23/AG84-RISKS-NEXT.md
@@ -1,0 +1,8 @@
+# AG84 — RISKS-NEXT
+
+## Risks
+- Μηδενικό (προσθήκη script/docs μόνο).
+
+## Next
+- AG85 (feature): Full CSV export (όλα τα filtered rows) μέσω API streaming.
+- AG86 (ops): Προαιρετικά path-filtered fast workflow (typecheck-only) για PRs που αλλάζουν μόνο frontend/**.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "↯ Preflight: pnpm typecheck (frontend)"
+if ! command -v corepack >/dev/null 2>&1; then
+  echo "❗ corepack not found"; exit 1
+fi
+
+pushd frontend >/dev/null
+  corepack enable >/dev/null 2>&1 || true
+  corepack prepare pnpm@9.12.0 --activate >/dev/null 2>&1 || true
+  pnpm install --frozen-lockfile
+  pnpm typecheck
+popd >/dev/null
+
+echo "✓ Preflight OK"


### PR DESCRIPTION
Adds scripts/preflight.sh and SOP docs to run local typecheck before PR.

### Reports
- CODEMAP → `docs/reports/2025-10-23/AG84-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-23/AG84-RISKS-NEXT.md`

### Test Summary
- N/A (ops-only).