### PR TITLE
Pass AG86 — Gate PG Smoke (main or pg-e2e label)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -157,10 +157,10 @@ jobs:
 
   test-smoke:
     name: Smoke Tests
+    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pg-e2e')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     continue-on-error: true  # Pass 45: Advisory until E2E fully stabilized in Phase 2
-    if: github.event_name == 'pull_request'
     defaults:
       run:
         working-directory: frontend

--- a/docs/AGENT/SOPs/CI-SMOKE-GATING.md
+++ b/docs/AGENT/SOPs/CI-SMOKE-GATING.md
@@ -1,0 +1,7 @@
+# CI SMOKE GATING — Postgres Smoke
+Τρέχει **μόνο**:
+- σε `push` στο `main`, ή
+- σε PR με label `pg-e2e`.
+
+Στόχος: να αποφύγουμε advisory αποτυχίες PG Smoke σε PRs που δεν αγγίζουν DB. Για PR που αφορά DB/Prisma, πρόσθεσε label `pg-e2e`.
+(Προαιρετική βελτίωση επόμενου pass: path-gating με paths-filter για `prisma/**` και `backend/**`.)

--- a/docs/AGENT/SUMMARY/Pass-AG86.md
+++ b/docs/AGENT/SUMMARY/Pass-AG86.md
@@ -1,0 +1,3 @@
+- 2025-10-23 16:50 UTC — Pass AG86: Gate PG Smoke (main or pg-e2e)
+  - Προστέθηκε job-level if: στο "Smoke Tests"
+  - SOP: docs/AGENT/SOPs/CI-SMOKE-GATING.md

--- a/docs/reports/2025-10-23/AG86-CODEMAP.md
+++ b/docs/reports/2025-10-23/AG86-CODEMAP.md
@@ -1,0 +1,4 @@
+# AG86 — CODEMAP
+- **.github/workflows/pr.yml** — προσθήκη `if:` στο job "Smoke Tests"
+- **docs/AGENT/SOPs/CI-SMOKE-GATING.md** — οδηγίες
+- **docs/AGENT/SUMMARY/Pass-AG86.md** — σύνοψη

--- a/docs/reports/2025-10-23/AG86-RISKS-NEXT.md
+++ b/docs/reports/2025-10-23/AG86-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG86 — RISKS-NEXT
+## Risks
+- Πολύ χαμηλό (YAML-only).
+## Next
+- **AG86.1 (ops):** Προσθήκη path-gating με dorny/paths-filter (prisma/**, backend/**).
+- **AG87 (feature):** Totals per status στην Orders header (UI-only).


### PR DESCRIPTION
CI: Gate **Smoke Tests** (PG) ώστε να τρέχουν μόνο σε `main` ή όταν υπάρχει label `pg-e2e`.

### Reports
- CODEMAP → `docs/reports/2025-10-23/AG86-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-23/AG86-RISKS-NEXT.md`
- SOP → `docs/AGENT/SOPs/CI-SMOKE-GATING.md`

### Test Summary
- N/A (YAML-only)