### PR TITLE
Pass AG87 — Orders quick totals (per current page, UI-only)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG87.md
+++ b/docs/AGENT/SUMMARY/Pass-AG87.md
@@ -1,0 +1,4 @@
+- 2025-10-23 17:20 UTC — Pass AG87: Orders quick totals (per current page, UI-only)
+  - Προστέθηκαν μετρητές κατάστασης πάνω από τον πίνακα (υπολογισμός από τα ορατά rows)
+  - E2E: admin-orders-ui-quick-totals.spec.ts
+  - Καμία αλλαγή σε backend/schema/DB/CI.

--- a/docs/reports/2025-10-23/AG87-CODEMAP.md
+++ b/docs/reports/2025-10-23/AG87-CODEMAP.md
@@ -1,0 +1,3 @@
+# AG87 — CODEMAP
+- **frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx** — memoized quick totals + chips UI
+- **frontend/tests/e2e/admin-orders-ui-quick-totals.spec.ts** — E2E test

--- a/docs/reports/2025-10-23/AG87-RISKS-NEXT.md
+++ b/docs/reports/2025-10-23/AG87-RISKS-NEXT.md
@@ -1,0 +1,5 @@
+# AG87 — RISKS-NEXT
+## Risks
+- Πολύ χαμηλό (UI-only). Οι μετρητές αφορούν την **τρέχουσα σελίδα**.
+## Next
+- AG88 (feature): Full-filters totals (όλα τα αποτελέσματα) μέσω API facet counts.

--- a/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
+++ b/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
@@ -54,6 +54,22 @@ export default function AdminOrdersMain() {
 
   const [rows, setRows]   = React.useState<Row[]>(LOCAL_DEMO);
 
+  // Quick totals (per current page)
+  const statusOrder = React.useMemo(() => {
+    const seen = new Map<string, number>();
+    rows.forEach(r => { if (r?.status) seen.set(r.status, (seen.get(r.status)||0) + 1); });
+    // σταθερή διάταξη: φθίνουσα κατά count, αλφαβητικά ως δεύτερο κριτήριο
+    return Array.from(seen.entries()).sort((a,b)=> b[1]-a[1] || String(a[0]).localeCompare(String(b[0]))).map(([k])=>k);
+  }, [rows]);
+
+  const pageTotals = React.useMemo(() => {
+    const acc = new Map<string, number>();
+    rows.forEach(r => acc.set(r.status, (acc.get(r.status)||0) + 1));
+    const total = rows.length;
+    return { acc, total };
+  }, [rows]);
+
+
   // Column visibility (persisted)
   type ColKey = 'id'|'customer'|'total'|'status';
   const DEFAULT_COLS: Record<ColKey, boolean> = { id:true, customer:true, total:true, status:true };
@@ -276,6 +292,21 @@ export default function AdminOrdersMain() {
       </div>
 
       {errNote && <div style={{fontSize:12,color:'#a33',margin:'6px 0'}}>Σημείωση: {errNote} — έγινε fallback.</div>}
+
+
+      {/* Quick totals (τρέχουσα σελίδα) */}
+      {pageTotals.total > 0 && (
+        <div data-testid="quick-totals" style={{display:'flex', gap:8, flexWrap:'wrap', margin:'6px 0 10px 0'}}>
+          {statusOrder.map(st => (
+            <div key={st} data-testid={`total-${st}`} style={{display:'inline-flex', alignItems:'center', gap:6, padding:'4px 8px', border:'1px solid #e5e5e5', borderRadius:999}}>
+              <span style={{width:8, height:8, borderRadius:999, background:'#0ea5e9'}} aria-hidden />
+              <span style={{fontSize:12}}>{st}</span>
+              <strong style={{fontSize:12}}>{pageTotals.acc.get(st) || 0}</strong>
+            </div>
+          ))}
+          <div data-testid="total-all" style={{marginLeft:4, fontSize:12, color:'#555'}}>Σύνολο: <strong>{pageTotals.total}</strong></div>
+        </div>
+      )}
 
       <div role="table" style={{display:'grid', gap:8}}>
         <div role="row" style={{display:'grid', gridTemplateColumns:'1.2fr 2fr 1fr 1.2fr', gap:12, fontWeight:600, fontSize:12, color:'#555'}}>

--- a/frontend/tests/e2e/admin-orders-ui-quick-totals.spec.ts
+++ b/frontend/tests/e2e/admin-orders-ui-quick-totals.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('Orders UI: quick totals per page render and match rows count', async ({ page }) => {
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=1&pageSize=5');
+
+  // εμφανίζεται μετρητής συνόλου και τα chips ανά status
+  await expect(page.getByTestId('quick-totals')).toBeVisible();
+
+  // πάρε το "Σύνολο" από το component και μέτρα και τα rows
+  const totalText = await page.getByTestId('total-all').textContent();
+  const total = Number(String(totalText).match(/(\d+)/)?.[1] || '0');
+
+  // μετράμε τα rows του table
+  const rows = page.locator('[role="row"][data-testid^="row-"]');
+  await expect(rows).toHaveCount(total);
+});
+
+test('Orders UI: quick totals hide when empty results', async ({ page }) => {
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=1&pageSize=5');
+  await page.fill('input[placeholder="Αναζήτηση (Order ID ή Πελάτης)"]', 'ZZZ-NOT-FOUND');
+  await page.getByRole('button', { name: 'Εφαρμογή' }).click();
+  // 0 αποτελέσματα => δεν εμφανίζονται totals
+  await expect(page.getByTestId('quick-totals')).toHaveCount(0);
+});


### PR DESCRIPTION
UI-only: Προστέθηκαν γρήγοροι μετρητές ανά status για την **τρέχουσα σελίδα** orders (memoized από τα rows).

### Reports
- CODEMAP → `docs/reports/2025-10-23/AG87-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-23/AG87-RISKS-NEXT.md`

### Test Summary
- UI-only E2E passing.