### PR TITLE
Pass AG88 — Orders facet totals (ALL filtered results)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG88.md
+++ b/docs/AGENT/SUMMARY/Pass-AG88.md
@@ -1,0 +1,5 @@
+- 2025-10-23 19:52 UTC — Pass AG88: Orders facet totals (ALL filtered results)
+  - API: `GET /api/admin/orders/facets` γυρίζει counts ανά status + συνολικό πλήθος
+  - UI: chips "Totals (ALL)" πάνω από τον πίνακα
+  - E2E: API + UI tests
+  - Καμία αλλαγή σε schema/DB.

--- a/docs/reports/2025-10-23/AG88-CODEMAP.md
+++ b/docs/reports/2025-10-23/AG88-CODEMAP.md
@@ -1,0 +1,5 @@
+# AG88 — CODEMAP
+- **frontend/src/app/api/admin/orders/facets/route.ts** — facet counts JSON
+- **frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx** — facet totals UI & effect
+- **frontend/tests/e2e/api-orders-facets.spec.ts** — API E2E
+- **frontend/tests/e2e/admin-orders-ui-facets.spec.ts** — UI E2E

--- a/docs/reports/2025-10-23/AG88-RISKS-NEXT.md
+++ b/docs/reports/2025-10-23/AG88-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG88 — RISKS-NEXT
+## Risks
+- Χαμηλό: pagination loop σε μεγάλα datasets (σε demo/CI είναι μικρά). Μελλοντικά: streaming/aggregation στην πηγή.
+## Next
+- AG89 (feature): Quick filter chips (tap-to-apply status).
+- ή AG89 (ops): Path-filtered fast workflow για καθαρά `frontend/**` PRs.

--- a/frontend/src/app/api/admin/orders/facets/route.ts
+++ b/frontend/src/app/api/admin/orders/facets/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getOrdersRepo } from '@/lib/orders/providers';
+import type { ListParams } from '@/lib/orders/providers';
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const forceDemo = url.searchParams.get('demo') === '1';
+  const status = url.searchParams.get('status') || undefined;
+  const q = url.searchParams.get('q') || undefined;
+  const fromDate = url.searchParams.get('fromDate') || undefined;
+  const toDate = url.searchParams.get('toDate') || undefined;
+  const sort = (url.searchParams.get('sort') || '-createdAt') as ListParams['sort'];
+
+  const mode = forceDemo ? 'demo' : (process.env.DIXIS_DATA_SRC || (process.env.CI ? 'sqlite' : 'demo'));
+  const repo = getOrdersRepo(mode);
+
+  const pageSize = 200;
+  let page = 1;
+  const totals = new Map<string, number>();
+  let total = 0;
+
+  for (;;) {
+    const res = await repo.list({ status: status as any, q, fromDate, toDate, sort, page, pageSize });
+    if (!total) total = res.count || 0;
+    for (const r of res.items) {
+      const st = (r as any).status ?? 'unknown';
+      totals.set(st, (totals.get(st) || 0) + 1);
+    }
+    if (res.items.length < pageSize) break;
+    page += 1;
+    if ((page - 1) * pageSize >= total && total > 0) break;
+    if (page > 10000) break; // safety
+  }
+
+  const obj: Record<string, number> = {};
+  for (const [k, v] of totals.entries()) obj[k] = v;
+
+  return NextResponse.json({ totals: obj, total }, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/frontend/tests/e2e/admin-orders-ui-facets.spec.ts
+++ b/frontend/tests/e2e/admin-orders-ui-facets.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('Orders UI: facet totals appear and react to filtering', async ({ page }) => {
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=1&pageSize=5');
+  await expect(page.getByTestId('facet-totals')).toBeVisible();
+  const totalAllText = await page.getByTestId('facet-total-all').textContent();
+  const totalAll = Number(String(totalAllText).match(/(\d+)/)?.[1] || '0');
+  expect(totalAll).toBeGreaterThan(0);
+
+  // Βάλε φίλτρο αναζήτησης για να μικρύνει το σύνολο
+  await page.fill('input[placeholder="Αναζήτηση (Order ID ή Πελάτης)"]', 'A-200');
+  await page.getByRole('button', { name: 'Εφαρμογή' }).click();
+
+  // Μετά το φιλτράρισμα, τα facets πρέπει να ξαναεμφανιστούν και το σύνολο να αλλάξει
+  await expect(page.getByTestId('facet-totals')).toBeVisible();
+  const totalAllText2 = await page.getByTestId('facet-total-all').textContent();
+  const totalAll2 = Number(String(totalAllText2).match(/(\d+)/)?.[1] || '0');
+  expect(totalAll2).toBeGreaterThanOrEqual(0);
+});

--- a/frontend/tests/e2e/api-orders-facets.spec.ts
+++ b/frontend/tests/e2e/api-orders-facets.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('API: /api/admin/orders/facets returns totals & total', async ({ request }) => {
+  const res = await request.get('/api/admin/orders/facets?demo=1&q=A-2');
+  expect(res.status()).toBe(200);
+  const json = await res.json();
+  expect(json).toHaveProperty('totals');
+  expect(json).toHaveProperty('total');
+  const sum = Object.values<number>(json.totals || {}).reduce((a,b)=>a+b,0);
+  expect(sum).toBeGreaterThan(0);
+  expect(sum).toBeLessThanOrEqual(json.total);
+});


### PR DESCRIPTION
Προσθήκη API `/api/admin/orders/facets` για μετρητές ανά status σε ΟΛΑ τα filtered αποτελέσματα + UI chips.

### Reports
- CODEMAP → `docs/reports/2025-10-23/AG88-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-23/AG88-RISKS-NEXT.md`

### Test Summary
- E2E API+UI passing (demo mode).