### PR TITLE
Pass AG89 — Quick filter chips (tap-to-apply status, UI-only)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG89.md
+++ b/docs/AGENT/SUMMARY/Pass-AG89.md
@@ -1,0 +1,4 @@
+- 2025-10-23 21:26 UTC — Pass AG89: Quick filter chips (tap-to-apply status, UI-only)
+  - Τα πράσινα facet chips γίνονται clickable (apply/clear status στο URL)
+  - E2E: admin-orders-ui-filter-chips.spec.ts
+  - Καμία αλλαγή σε backend/schema/DB.

--- a/docs/reports/2025-10-24/AG89-CODEMAP.md
+++ b/docs/reports/2025-10-24/AG89-CODEMAP.md
@@ -1,0 +1,3 @@
+# AG89 — CODEMAP
+- **frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx** — event delegation + chip attributes
+- **frontend/tests/e2e/admin-orders-ui-filter-chips.spec.ts** — E2E test

--- a/docs/reports/2025-10-24/AG89-RISKS-NEXT.md
+++ b/docs/reports/2025-10-24/AG89-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG89 — RISKS-NEXT
+## Risks
+- Πολύ χαμηλό (UI-only). Αλλαγή URL με reload.
+## Next
+- **AG90 (UX):** Highlight active status chip & μικρό "Καθαρισμός" chip.
+- **AG91 (ops):** Προαιρετικό upgrade pnpm σε 10.x (separate ops pass).

--- a/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
+++ b/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
@@ -351,9 +351,9 @@ export default function AdminOrdersMain() {
 
       {/* Facet totals (ALL filtered results) */}
       {facetTotals && facetTotalAll !== null && (
-        <div data-testid="facet-totals" style={{display:'flex', gap:8, flexWrap:'wrap', margin:'8px 0 4px 0'}}>
+        <div data-testid="facet-totals" style={{display:'flex', gap:8, flexWrap:'wrap', margin:'8px 0 4px 0'}} onClick={(e)=>{ const t=(e.target as HTMLElement).closest("[data-st]") as HTMLElement|null; if(!t) return; const st=t.getAttribute("data-st"); if(!st) return; const u=new URL(window.location.href); const cur=u.searchParams.get("status"); if(cur===st){ u.searchParams.delete("status"); } else { u.searchParams.set("status", st); } window.location.assign(u.toString()); }}>
           {Object.entries(facetTotals).sort((a,b)=> b[1]-a[1] || String(a[0]).localeCompare(String(b[0]))).map(([st,count])=>(
-            <div key={st} style={{display:'inline-flex', alignItems:'center', gap:6, padding:'4px 8px', border:'1px solid #e5e5e5', borderRadius:999}}>
+            <div key={st} data-st={st} data-testid={`facet-chip-${st}`} style={{display:'inline-flex', alignItems:'center', gap:6, padding:'4px 8px', border:'1px solid #e5e5e5', borderRadius:999, cursor:'pointer', userSelect:'none'}}>
               <span style={{width:8, height:8, borderRadius:999, background:'#10b981'}} aria-hidden />
               <span style={{fontSize:12}}>{st}</span>
               <strong style={{fontSize:12}}>{count}</strong>

--- a/frontend/tests/e2e/admin-orders-ui-filter-chips.spec.ts
+++ b/frontend/tests/e2e/admin-orders-ui-filter-chips.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('Orders UI: facet chip applies then clears status filter', async ({ page }) => {
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=1&pageSize=5');
+
+  // Πάρε κάποιο διαθέσιμο chip
+  const firstChip = page.locator('[data-testid^="facet-chip-"]').first();
+  await expect(firstChip).toBeVisible();
+
+  // Εφάρμοσε φίλτρο με tap
+  const before = page.url();
+  await Promise.all([
+    page.waitForURL(/[\?&]status=/),
+    firstChip.click(),
+  ]);
+  const after = page.url();
+  expect(after).not.toBe(before);
+  expect(after).toMatch(/[\?&]status=/);
+
+  // Tap ξανά στο ίδιο chip => καθάρισμα φίλτρου (δεν απαιτείται να είναι ίδιο το URL, αρκεί να φύγει το status)
+  await Promise.all([
+    page.waitForURL((url) => !/[?&]status=/.test(url)),
+    firstChip.click(),
+  ]);
+});


### PR DESCRIPTION
UI-only: κάνουμε τα **facet chips** clickable — με 1 tap εφαρμόζει το φίλτρο status, με 2ο tap το καθαρίζει.

### Reports
- CODEMAP → `docs/reports/2025-10-24/AG89-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-24/AG89-RISKS-NEXT.md`

### Test Summary
- UI-only E2E για apply/clear φίλτρου.