### PR TITLE
Pass AG92 — Sticky summary header (facet/quick totals)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG92.md
+++ b/docs/AGENT/SUMMARY/Pass-AG92.md
@@ -1,0 +1,4 @@
+- 2025-10-24 07:56 UTC — Pass AG92: Sticky summary header (facet/quick totals)
+  - Τα blocks με σύνολα μένουν ορατά στο scroll (position: sticky)
+  - E2E: admin-orders-ui-sticky-summary.spec.ts
+  - Καμία αλλαγή σε backend/schema/DB.

--- a/docs/reports/2025-10-24/AG92-CODEMAP.md
+++ b/docs/reports/2025-10-24/AG92-CODEMAP.md
@@ -1,0 +1,3 @@
+# AG92 — CODEMAP
+- **frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx** — sticky styles (facet/quick totals)
+- **frontend/tests/e2e/admin-orders-ui-sticky-summary.spec.ts** — E2E για sticky συμπεριφορά

--- a/docs/reports/2025-10-24/AG92-RISKS-NEXT.md
+++ b/docs/reports/2025-10-24/AG92-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG92 — RISKS-NEXT
+## Risks
+- Πολύ χαμηλό (UI-only). Αν υπάρξει overlap με header, θα ρυθμίσουμε top offset σε επόμενο pass.
+## Next
+- **AG93 (cleanup):** Quiet ESLint warnings στα tests (μη-μπλοκάροντας).
+- **AG91 (ops, προαιρετικό):** pnpm upgrade σε 10.x με lockfile refresh (separate PR).

--- a/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
+++ b/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
@@ -341,7 +341,7 @@ export default function AdminOrdersMain() {
 
       {/* Quick totals (τρέχουσα σελίδα) */}
       {pageTotals.total > 0 && (
-        <div data-testid="quick-totals" style={{display:'flex', gap:8, flexWrap:'wrap', margin:'6px 0 10px 0'}}>
+        <div data-testid="quick-totals" style={{display:'flex', gap:8, flexWrap:'wrap', margin:'6px 0 10px 0', position:'sticky', top:0, zIndex:20, background:'#fff', padding:'6px 0', borderBottom:'1px solid #eee'}}>
           {statusOrder.map(st => (
             <div key={st} data-testid={`total-${st}`} style={{display:'inline-flex', alignItems:'center', gap:6, padding:'4px 8px', border:'1px solid #e5e5e5', borderRadius:999}}>
               <span style={{width:8, height:8, borderRadius:999, background:'#0ea5e9'}} aria-hidden />
@@ -356,7 +356,7 @@ export default function AdminOrdersMain() {
 
       {/* Facet totals (ALL filtered results) */}
       {facetTotals && facetTotalAll !== null && (
-        <div data-testid="facet-totals" style={{display:'flex', gap:8, flexWrap:'wrap', margin:'8px 0 4px 0'}} onClick={(e)=>{ const t=(e.target as HTMLElement).closest("[data-st]") as HTMLElement|null; if(!t) return; const st=t.getAttribute("data-st"); if(!st) return; const u=new URL(window.location.href); const cur=u.searchParams.get("status"); if(cur===st){ u.searchParams.delete("status"); } else { u.searchParams.set("status", st); } window.location.assign(u.toString()); }}>
+        <div data-testid="facet-totals" style={{display:'flex', gap:8, flexWrap:'wrap', margin:'8px 0 4px 0', position:'sticky', top:0, zIndex:20, background:'#fff', padding:'6px 0', borderBottom:'1px solid #eee'}} onClick={(e)=>{ const t=(e.target as HTMLElement).closest("[data-st]") as HTMLElement|null; if(!t) return; const st=t.getAttribute("data-st"); if(!st) return; const u=new URL(window.location.href); const cur=u.searchParams.get("status"); if(cur===st){ u.searchParams.delete("status"); } else { u.searchParams.set("status", st); } window.location.assign(u.toString()); }}>
           {Object.entries(facetTotals).sort((a,b)=> b[1]-a[1] || String(a[0]).localeCompare(String(b[0]))).map(([st,count])=>(
             <div key={st} data-st={st} data-testid={`facet-chip-${st}`} data-active={(activeStatus===st)?'1':'0'} aria-pressed={activeStatus===st}
           style={{display:'inline-flex', alignItems:'center', gap:6, padding:'4px 8px', border:'1px solid', borderColor:(activeStatus===st)?'#10b981':'#e5e5e5', background:(activeStatus===st)?'#ecfdf5':'#fff', borderRadius:999, cursor:'pointer', userSelect:'none'}}>

--- a/frontend/tests/e2e/admin-orders-ui-sticky-summary.spec.ts
+++ b/frontend/tests/e2e/admin-orders-ui-sticky-summary.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('Orders UI: facet/quick totals stay visible while scrolling', async ({ page }) => {
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=1&pageSize=20');
+
+  // διάλεξε προτεραιότητα στο facet-totals, αλλιώς quick-totals
+  const sticky = (await page.getByTestId('facet-totals').count()) > 0
+    ? page.getByTestId('facet-totals')
+    : page.getByTestId('quick-totals');
+
+  await expect(sticky).toBeVisible();
+
+  // scroll αρκετά
+  await page.evaluate(() => window.scrollTo({ top: 1200, behavior: 'instant' }));
+  await page.waitForTimeout(200);
+
+  // εξακολουθεί να είναι ορατό και κοντά στο πάνω μέρος του viewport
+  const box = await sticky.boundingBox();
+  expect(box).not.toBeNull();
+  if (box) {
+    expect(box.y).toBeGreaterThanOrEqual(0);
+    expect(box.y).toBeLessThan(80);
+  }
+});


### PR DESCRIPTION
UI-only: Τα σύνολα (facet/quick totals) μένουν ορατά στο scroll με **position: sticky**.

### Reports
- CODEMAP → `docs/reports/2025-10-24/AG92-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-24/AG92-RISKS-NEXT.md`

### Test Summary
- UI-only E2E για sticky συμπεριφορά.