### PR TITLE
Pass AG95 — useOrdersFilters (URL source of truth & router sync)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG95.md
+++ b/docs/AGENT/SUMMARY/Pass-AG95.md
@@ -1,0 +1,5 @@
+- 2025-10-24 09:15 UTC — Pass AG95: useOrdersFilters hook (URL source of truth & router sync)
+  - Νέο hook useOrdersFilters με set/clear & URL merge, back/forward-safe
+  - Refactor AdminOrdersMain να χρησιμοποιεί το hook (χωρίς window.assign)
+  - E2E: filters sync (chip apply/back) + q persistence
+  - Καμία αλλαγή σε backend/schema/DB.

--- a/docs/reports/2025-10-24/AG95-CODEMAP.md
+++ b/docs/reports/2025-10-24/AG95-CODEMAP.md
@@ -1,0 +1,4 @@
+# AG95 — CODEMAP
+- **frontend/src/app/admin/orders/_hooks/useOrdersFilters.ts** — client hook με router/searchParams
+- **frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx** — useOrdersFilters integration
+- **frontend/tests/e2e/admin-orders-ui-filters-sync.spec.ts** — E2E για URL/back-forward sync

--- a/docs/reports/2025-10-24/AG95-RISKS-NEXT.md
+++ b/docs/reports/2025-10-24/AG95-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG95 — RISKS-NEXT
+## Risks
+- Χαμηλό (UI-only). Ενδεχόμενες ασυμβατότητες αν υπάρχουν custom routers.
+## Next
+- **AG96 (backend)**: Facet totals via DB aggregation (countByStatus) για performance.
+- **AG90x (UX)**: Debounced search + replace() για μικρότερο history spam.

--- a/frontend/src/app/admin/orders/_hooks/useOrdersFilters.ts
+++ b/frontend/src/app/admin/orders/_hooks/useOrdersFilters.ts
@@ -1,0 +1,87 @@
+'use client';
+import * as React from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export type OrdersFilters = {
+  status?: string;
+  q?: string;
+  fromDate?: string;
+  toDate?: string;
+  sort?: string;
+  page?: number;
+  pageSize?: number;
+};
+
+function parseIntOr(x: string | null, d: number): number | undefined {
+  if (!x) return undefined;
+  const n = Number.parseInt(x, 10);
+  return Number.isFinite(n) ? n : d;
+}
+
+export function useOrdersFilters() {
+  const router = useRouter();
+  const sp = useSearchParams();
+
+  const filters = React.useMemo<OrdersFilters>(() => ({
+    status: sp.get('status') || undefined,
+    q: sp.get('q') || undefined,
+    fromDate: sp.get('fromDate') || undefined,
+    toDate: sp.get('toDate') || undefined,
+    sort: sp.get('sort') || undefined,
+    page: parseIntOr(sp.get('page'), 1),
+    pageSize: parseIntOr(sp.get('pageSize'), 10),
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }), [sp?.toString()]);
+
+  const paramString = React.useMemo(() => {
+    const qs = new URLSearchParams();
+    if (filters.status) qs.set('status', filters.status);
+    if (filters.q) qs.set('q', filters.q);
+    if (filters.fromDate) qs.set('fromDate', filters.fromDate);
+    if (filters.toDate) qs.set('toDate', filters.toDate);
+    if (filters.sort) qs.set('sort', filters.sort);
+    if (filters.page && filters.page > 1) qs.set('page', String(filters.page));
+    if (filters.pageSize && filters.pageSize !== 10) qs.set('pageSize', String(filters.pageSize));
+    return qs.toString();
+  }, [filters]);
+
+  function urlWith(next: Partial<OrdersFilters>) {
+    const u = new URL(window.location.href);
+    const qs = u.searchParams;
+    const merged: OrdersFilters = { ...filters, ...next };
+    // normalize
+    function setOrDel(k: string, v?: string | number) {
+      if (v === undefined || v === null || v === '') qs.delete(k);
+      else qs.set(k, String(v));
+    }
+    setOrDel('status', merged.status);
+    setOrDel('q', merged.q);
+    setOrDel('fromDate', merged.fromDate);
+    setOrDel('toDate', merged.toDate);
+    setOrDel('sort', merged.sort || '-createdAt');
+    setOrDel('page', merged.page && merged.page > 1 ? merged.page : undefined);
+    setOrDel('pageSize', merged.pageSize && merged.pageSize !== 10 ? merged.pageSize : undefined);
+    u.search = qs.toString();
+    return u.toString();
+  }
+
+  const setFilter = React.useCallback((k: keyof OrdersFilters, v?: string | number, opts?: { replace?: boolean }) => {
+    const href = urlWith({ [k]: (v as any) });
+    if (opts?.replace) router.replace(href);
+    else router.push(href);
+  }, [router, urlWith]);
+
+  const clearFilter = React.useCallback((k: keyof OrdersFilters, opts?: { replace?: boolean }) => {
+    const href = urlWith({ [k]: undefined as any });
+    if (opts?.replace) router.replace(href);
+    else router.push(href);
+  }, [router, urlWith]);
+
+  const clearAll = React.useCallback((opts?: { replace?: boolean }) => {
+    const href = urlWith({ status: undefined, q: undefined, fromDate: undefined, toDate: undefined, page: 1 });
+    if (opts?.replace) router.replace(href);
+    else router.push(href);
+  }, [router, urlWith]);
+
+  return { filters, paramString, setFilter, clearFilter, clearAll };
+}

--- a/frontend/tests/e2e/admin-orders-ui-filters-sync.spec.ts
+++ b/frontend/tests/e2e/admin-orders-ui-filters-sync.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+test('Orders UI: facet chip sets status in URL and Back clears it', async ({ page }) => {
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=1&pageSize=5');
+
+  const firstChip = page.locator('[data-testid^="facet-chip-"]').first();
+  await expect(firstChip).toBeVisible();
+
+  // Apply via chip (SPA navigation)
+  const before = page.url();
+  await Promise.all([
+    page.waitForURL(/[\?&]status=/),
+    firstChip.click(),
+  ]);
+  const after = page.url();
+  expect(after).not.toBe(before);
+  await expect(page.locator('[data-active="1"]')).toHaveCount(1);
+
+  // Browser Back should remove the filter & un-highlight
+  await page.goBack();
+  await expect(page).toHaveURL((url) => !/[?&]status=/.test(url));
+  await expect(page.locator('[data-active="1"]')).toHaveCount(0);
+});
+
+test('Orders UI: search q persists in URL and refetches facets', async ({ page }) => {
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=1&pageSize=5');
+  await page.fill('input[placeholder="Αναζήτηση (Order ID ή Πελάτης)"]', 'A-200');
+  await page.getByRole('button', { name: 'Εφαρμογή' }).click();
+
+  await expect(page).toHaveURL(/[\?&]q=A-200/);
+  // facets re-render
+  await expect(page.getByTestId('facet-totals')).toBeVisible();
+});


### PR DESCRIPTION
UI-only: νέο **useOrdersFilters** hook που κάνει το URL single source of truth, με set/clear φίλτρων, SPA navigation και back/forward sync.

### Reports
- CODEMAP → `docs/reports/2025-10-24/AG95-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-24/AG95-RISKS-NEXT.md`

### Test Summary
- E2E: filters sync (chip apply/back), q persistence.