### PR TITLE
Pass AG98 — A11y & Keyboard UX (chips + Enter-to-search)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG98.md
+++ b/docs/AGENT/SUMMARY/Pass-AG98.md
@@ -1,0 +1,6 @@
+- 2025-10-24 09:48 UTC — Pass AG98: A11y & Keyboard UX (chips + Enter-to-search)
+  - Facet chips: πλήρης keyboard υποστήριξη (role=button, tabIndex, Enter/Space)
+  - Focus ring για ορατή εστίαση
+  - Enter-to-search: άμεσο router.replace & reset page=1
+  - E2E: keyboard toggle & Enter-to-search
+  - Καμία αλλαγή σε backend/schema/DB.

--- a/docs/reports/2025-10-24/AG98-CODEMAP.md
+++ b/docs/reports/2025-10-24/AG98-CODEMAP.md
@@ -1,0 +1,3 @@
+# AG98 — CODEMAP
+- **frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx** — keyboard handlers, focus ring, Enter-to-search
+- **frontend/tests/e2e/admin-orders-ui-a11y-keyboard.spec.ts** — E2E για keyboard & Enter

--- a/docs/reports/2025-10-24/AG98-RISKS-NEXT.md
+++ b/docs/reports/2025-10-24/AG98-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG98 — RISKS-NEXT
+## Risks
+- Πολύ χαμηλό (UI-only).
+## Next
+- **AG97 (backend)**: Facet totals με DB aggregation (countByStatus) — θα απαιτήσει label `pg-e2e`.
+- **AG99 (UX)**: Loading skeleton κατά το facet refetch (ομαλό perceived performance).

--- a/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
+++ b/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
@@ -287,7 +287,7 @@ export default function AdminOrdersMain() {
       <form onSubmit={onSubmitFilters} style={{display:'flex', gap:12, alignItems:'center', flexWrap:'wrap', margin:'8px 0 12px 0'}}>
         <FilterChips options={options as any} active={active} onChange={onChangeStatus} />
         <input
-          value={qInput} onChange={e=>setQInput(e.target.value)} placeholder="Αναζήτηση (Order ID ή Πελάτης)"
+          value={qInput} onChange={e=>setQInput(e.target.value)} onKeyDown={(e)=>{ if(e.key==='Enter'){ e.preventDefault(); setFilter('q', qInput||undefined, { replace:true }); setFilter('page', 1, { replace:true }); } }} placeholder="Αναζήτηση (Order ID ή Πελάτης)"
           style={{padding:'6px 10px', borderRadius:8, border:'1px solid #ddd', fontSize:12}}
         />
         <label style={{fontSize:12}}>Από:&nbsp;<input type="date" value={fromDate} onChange={e=>setFromDate(e.target.value)} /></label>
@@ -390,10 +390,15 @@ export default function AdminOrdersMain() {
 
       {/* Facet totals (ALL filtered results) */}
       {facetTotals && facetTotalAll !== null && (
-        <div data-testid="facet-totals" style={{display:'flex', gap:8, flexWrap:'wrap', margin:'8px 0 4px 0', position:'sticky', top:0, zIndex:20, background:'#fff', padding:'6px 0', borderBottom:'1px solid #eee'}} onClick={(e)=>{ const t=(e.target as HTMLElement); const clear=t.closest("[data-clear]") as HTMLElement|null; const chip=t.closest("[data-st]") as HTMLElement|null; if(clear){ clearFilter("status"); return; } if(!chip) return; const st=chip.getAttribute("data-st"); if(!st) return; if((filters.status||"")===st){ clearFilter("status"); } else { setFilter("status", st); } }}>
+        <div data-testid="facet-totals" style={{display:'flex', gap:8, flexWrap:'wrap', margin:'8px 0 4px 0', position:'sticky', top:0, zIndex:20, background:'#fff', padding:'6px 0', borderBottom:'1px solid #eee'}}
+          /* AG98 chips keyboard */
+          onKeyDown={(e)=>{ const t=(e.target as HTMLElement).closest('[data-st]') as HTMLElement|null; if(!t) return;
+            if(e.key==='Enter'||e.key===' '){ e.preventDefault(); const st=t.getAttribute('data-st'); if(!st) return;
+              if((filters.status||'')===st){ clearFilter('status'); } else { setFilter('status', st); } }}}
+          onClick={(e)=>{ const t=(e.target as HTMLElement); const clear=t.closest("[data-clear]") as HTMLElement|null; const chip=t.closest("[data-st]") as HTMLElement|null; if(clear){ clearFilter("status"); return; } if(!chip) return; const st=chip.getAttribute("data-st"); if(!st) return; if((filters.status||"")===st){ clearFilter("status"); } else { setFilter("status", st); } }}>
           {Object.entries(facetTotals).sort((a,b)=> b[1]-a[1] || String(a[0]).localeCompare(String(b[0]))).map(([st,count])=>(
-            <div key={st} data-st={st} data-testid={`facet-chip-${st}`} data-active={(activeStatus===st)?'1':'0'} aria-pressed={activeStatus===st}
-          style={{display:'inline-flex', alignItems:'center', gap:6, padding:'4px 8px', border:'1px solid', borderColor:(activeStatus===st)?'#10b981':'#e5e5e5', background:(activeStatus===st)?'#ecfdf5':'#fff', borderRadius:999, cursor:'pointer', userSelect:'none'}}>
+            <div key={st} data-st={st} data-testid={`facet-chip-${st}`} data-active={(activeStatus===st)?'1':'0'} aria-pressed={activeStatus===st} role='button' tabIndex={0}
+          style={{display:'inline-flex', alignItems:'center', gap:6, padding:'4px 8px', outline:'none', border:'1px solid', borderColor:(activeStatus===st)?'#10b981':'#e5e5e5', background:(activeStatus===st)?'#ecfdf5':'#fff', borderRadius:999, cursor:'pointer', userSelect:'none'}}>
               <span style={{width:8, height:8, borderRadius:999, background:'#10b981'}} aria-hidden />
               <span style={{fontSize:12}}>{st}</span>
               <strong style={{fontSize:12}}>{count}</strong>
@@ -417,6 +422,9 @@ export default function AdminOrdersMain() {
         <style>{`
           [data-density="compact"] [role="row"] { font-size: 12px; }
           [data-density="normal"] [role="row"] { font-size: 14px; }
+        `}</style>
+        <style>{`/* AG98 focus ring */
+          [data-st][role='button']:focus{ box-shadow: 0 0 0 3px rgba(16,185,129,0.35); }
         `}</style>
 
         <div role="row" style={{display:'grid', gridTemplateColumns:'1.2fr 2fr 1fr 1.2fr', gap:12, fontWeight:600, fontSize:12, color:'#555'}}>

--- a/frontend/tests/e2e/admin-orders-ui-a11y-keyboard.spec.ts
+++ b/frontend/tests/e2e/admin-orders-ui-a11y-keyboard.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('Facet chip toggles with keyboard (Enter) & reflects in URL/highlight', async ({ page }) => {
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=1&pageSize=5');
+  const chip = page.locator('[data-testid^="facet-chip-"]').first();
+  await expect(chip).toBeVisible();
+  await chip.focus();
+  await Promise.all([ page.waitForURL(/[\?&]status=/), page.keyboard.press('Enter') ]);
+  await expect(chip).toHaveAttribute('data-active','1');
+  await Promise.all([ page.waitForURL((u)=>!/[?&]status=/.test(u)), page.keyboard.press('Enter') ]);
+  await expect(chip).toHaveAttribute('data-active','0');
+});
+
+test('Enter-to-search applies immediately via replace (no debounce wait)', async ({ page }) => {
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=2&pageSize=5'); // page=2 to verify reset→1
+  const input = page.locator('input[placeholder="Αναζήτηση (Order ID ή Πελάτης)"]');
+  await expect(input).toBeVisible();
+  await input.fill('A-300');
+  await Promise.all([
+    page.waitForURL(/[\?&]q=A-300/),
+    page.keyboard.press('Enter'),
+  ]);
+  // page reset to 1
+  await expect(page).toHaveURL(/[\?&]page=1/);
+});


### PR DESCRIPTION
UI-only: keyboard support στα facet chips (role, tabIndex, Enter/Space), ορατή focus ένδειξη και **Enter-to-search** με router.replace.

### Reports
- CODEMAP → `docs/reports/2025-10-24/AG98-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-24/AG98-RISKS-NEXT.md`

### Test Summary
- E2E: keyboard toggle & Enter-to-search.