### PR TITLE
Pass AG100 — Empty state (zero results) + Clear filters (UI-only)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG100.md
+++ b/docs/AGENT/SUMMARY/Pass-AG100.md
@@ -1,0 +1,5 @@
+- 2025-10-24 12:57 UTC — Pass AG100: Empty state (zero results) + Clear filters
+  - Εμφάνιση καθαρού μηνύματος όταν τα φιλτραρισμένα αποτελέσματα είναι 0
+  - Κουμπί "Καθαρισμός φίλτρων" που αφαιρεί q/status και κάνει replace
+  - E2E: admin-orders-ui-empty-state.spec.ts
+  - Καμία αλλαγή σε backend/schema/DB.

--- a/docs/reports/2025-10-24/AG100-CODEMAP.md
+++ b/docs/reports/2025-10-24/AG100-CODEMAP.md
@@ -1,0 +1,3 @@
+# AG100 — CODEMAP
+- **frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx** — Empty state UI + clearAll
+- **frontend/tests/e2e/admin-orders-ui-empty-state.spec.ts** — E2E για εμφάνιση και καθαρισμό

--- a/docs/reports/2025-10-24/AG100-RISKS-NEXT.md
+++ b/docs/reports/2025-10-24/AG100-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG100 — RISKS-NEXT
+## Risks
+- Πολύ χαμηλό (UI-only).
+## Next
+- **AG97 (backend)**: Facet totals μέσω DB aggregation (countByStatus) — θα χρειαστεί label `pg-e2e`.
+- **AG101 (UX)**: Small polish — helper text όταν υπάρχει ενεργό φίλτρο (π.χ. "Φίλτρο: Pending").

--- a/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
+++ b/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
@@ -66,7 +66,7 @@ export default function AdminOrdersMain() {
   }, []);
 
   // AG95: URL source of truth for filters via hook
-  const { filters, paramString, setFilter, clearFilter } = useOrdersFilters();
+  const { filters, paramString, setFilter, clearFilter, clearAll } = useOrdersFilters();
   const activeStatus = filters.status || null;
 
   // AG96: Local input state for debounced search
@@ -434,6 +434,28 @@ export default function AdminOrdersMain() {
         <style>{`/* AG99 shimmer */
           @keyframes ag99-shimmer{ 0%{background-position:0 0} 100%{background-position:-200% 0} }
         `}</style>
+        <style>{`/* AG100 empty-state styles */
+          .empty-wrap{border:1px dashed #e5e5e5;border-radius:12px;padding:18px;display:flex;gap:12px;align-items:flex-start;background:#fafafa}
+          .empty-title{font-weight:600;margin:0 0 6px 0}
+          .empty-desc{margin:0 0 12px 0;color:#666}
+          .empty-btn{border:1px solid #e5e5e5;border-radius:8px;padding:6px 10px;cursor:pointer;background:#fff}
+          .empty-btn:hover{border-color:#dcdcdc}
+        `}</style>
+
+        {/* AG100 — Empty State (zero results) */}
+        {(!isFacetLoading && facetTotalAll === 0) && (
+          <div data-testid="orders-empty-state" className="empty-wrap" role="status" aria-live="polite">
+            <div style={{fontSize:22}}>🗂️</div>
+            <div>
+              <p className="empty-title">Δεν βρέθηκαν αποτελέσματα</p>
+              <p className="empty-desc">Κανένα αποτέλεσμα για τα τρέχοντα φίλτρα. Μπορείς να αλλάξεις τα κριτήρια ή να τα καθαρίσεις.</p>
+              <button type="button" className="empty-btn" data-testid="orders-empty-clear"
+                onClick={()=>{ clearAll?.({ replace:true }); }}>
+                Καθαρισμός φίλτρων
+              </button>
+            </div>
+          </div>
+        )}
 
         <div role="row" style={{display:'grid', gridTemplateColumns:'1.2fr 2fr 1fr 1.2fr', gap:12, fontWeight:600, fontSize:12, color:'#555'}}>
           <div>Order</div><div>Πελάτης</div><div>Σύνολο</div><div>Κατάσταση</div>

--- a/frontend/tests/e2e/admin-orders-ui-empty-state.spec.ts
+++ b/frontend/tests/e2e/admin-orders-ui-empty-state.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Orders UI: empty state shown on zero results and clears filters', async ({ page }) => {
+  // Δώσε query που δεν θα ταιριάζει
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=1&pageSize=5&q=__NO_MATCH__XYZ__');
+  await expect(page.getByTestId('orders-empty-state')).toBeVisible();
+
+  // Πάτα "Καθαρισμός φίλτρων" → καθαρίζει q/status & επανέρχονται τα αποτελέσματα
+  await Promise.all([
+    page.waitForURL((url)=>!/[?&]q=/.test(url)),  // q αφαιρέθηκε
+    page.getByTestId('orders-empty-clear').click(),
+  ]);
+
+  // Βεβαιώσου ότι δεν υπάρχει πια empty state
+  await expect(page.getByTestId('orders-empty-state')).toHaveCount(0);
+});


### PR DESCRIPTION
UI-only: Καθαρό **empty state** όταν τα φιλτραρισμένα αποτελέσματα είναι 0, με κουμπί **Καθαρισμός φίλτρων** (router.replace).

### Reports
- CODEMAP → `docs/reports/2025-10-24/AG100-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-24/AG100-RISKS-NEXT.md`

### Test Summary
- E2E: empty state εμφάνιση & clear.