### PR TITLE
Pass AG101 — Filters helper text (UI-only)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG101.md
+++ b/docs/AGENT/SUMMARY/Pass-AG101.md
@@ -1,0 +1,5 @@
+- 2025-10-24 13:59 UTC — Pass AG101: Filters helper text (UI-only)
+  - Εμφανίζει συνοπτικά τα ενεργά φίλτρα (status, q, date, sort) πάνω από τον πίνακα
+  - Κουμπί "Καθαρισμός" που κάνει replace και αφαιρεί όλα τα filters
+  - E2E: admin-orders-ui-filters-helper.spec.ts
+  - Καμία αλλαγή σε backend/schema/DB.

--- a/docs/reports/2025-10-24/AG101-CODEMAP.md
+++ b/docs/reports/2025-10-24/AG101-CODEMAP.md
@@ -1,0 +1,3 @@
+# AG101 — CODEMAP
+- **frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx** — helper block & styles
+- **frontend/tests/e2e/admin-orders-ui-filters-helper.spec.ts** — E2E

--- a/docs/reports/2025-10-24/AG101-RISKS-NEXT.md
+++ b/docs/reports/2025-10-24/AG101-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG101 — RISKS-NEXT
+## Risks
+- Πολύ χαμηλό (UI-only).
+## Next
+- **AG97 (backend)**: Facet totals μέσω DB aggregation (`countByStatus`) με label `pg-e2e`.
+- **AG102 (UX)**: Τooltip/help icons για chips & αναζήτηση.

--- a/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
+++ b/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
@@ -441,6 +441,13 @@ export default function AdminOrdersMain() {
           .empty-btn{border:1px solid #e5e5e5;border-radius:8px;padding:6px 10px;cursor:pointer;background:#fff}
           .empty-btn:hover{border-color:#dcdcdc}
         `}</style>
+        <style>{`/* AG101 filters helper styles */
+          .filters-helper{font-size:12px;color:#6b7280;display:flex;gap:8px;align-items:center;margin:4px 0 8px}
+          .filters-helper strong{color:#374151}
+          .filters-helper .pill{border:1px solid #e5e7eb;border-radius:999px;padding:2px 8px;background:#fff}
+          .filters-helper .clear{border:1px solid #e5e7eb;border-radius:6px;padding:3px 8px;background:#fff;cursor:pointer}
+          .filters-helper .clear:hover{border-color:#d1d5db}
+        `}</style>
 
         {/* AG100 — Empty State (zero results) */}
         {(!isFacetLoading && facetTotalAll === 0) && (
@@ -456,6 +463,28 @@ export default function AdminOrdersMain() {
             </div>
           </div>
         )}
+
+        {/* AG101 — Filters helper */}
+        {(() => {
+          const parts: string[] = [];
+          if (filters.status) parts.push(`Κατάσταση: ${filters.status}`);
+          if (filters.q) parts.push(`Αναζήτηση: "${filters.q}"`);
+          if (filters.fromDate || filters.toDate) {
+            const a = filters.fromDate || '—';
+            const b = filters.toDate || '—';
+            parts.push(`Ημ/νίες: ${a} → ${b}`);
+          }
+          if (filters.sort) parts.push(`Ταξινόμηση: ${filters.sort}`);
+          const hasAny = parts.length > 0;
+          return hasAny ? (
+            <div data-testid="filters-helper" className="filters-helper" aria-live="polite">
+              <strong>Ενεργά φίλτρα:</strong>
+              {parts.map((t, i) => <span className="pill" key={i}>{t}</span>)}
+              <button type="button" className="clear" data-testid="filters-clear-all"
+                onClick={()=> clearAll?.({ replace:true })}>Καθαρισμός</button>
+            </div>
+          ) : null;
+        })()}
 
         <div role="row" style={{display:'grid', gridTemplateColumns:'1.2fr 2fr 1fr 1.2fr', gap:12, fontWeight:600, fontSize:12, color:'#555'}}>
           <div>Order</div><div>Πελάτης</div><div>Σύνολο</div><div>Κατάσταση</div>

--- a/frontend/tests/e2e/admin-orders-ui-filters-helper.spec.ts
+++ b/frontend/tests/e2e/admin-orders-ui-filters-helper.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Orders UI: filters helper shows & clears all', async ({ page }) => {
+  await page.goto('/admin/orders?useApi=1&mode=demo&page=2&pageSize=5&status=pending&q=A-200');
+  const helper = page.getByTestId('filters-helper');
+  await expect(helper).toBeVisible();
+  await expect(helper).toContainText('Ενεργά φίλτρα:');
+  await expect(helper).toContainText('Κατάσταση:');
+  await expect(helper).toContainText('Αναζήτηση:');
+  // Πατάμε καθαρισμό → αφαιρούνται φίλτρα & reset
+  await Promise.all([
+    page.waitForURL((u)=>!/[?&](status|q|fromDate|toDate)=/.test(u)),
+    page.getByTestId('filters-clear-all').click(),
+  ]);
+  await expect(page.getByTestId('filters-helper')).toHaveCount(0);
+});


### PR DESCRIPTION
UI-only: εμφανίζει συνοπτικά τα **ενεργά φίλτρα** (status, q, date, sort) και προσφέρει γρήγορο **Καθαρισμό**.

### Reports
- CODEMAP → `docs/reports/2025-10-24/AG101-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-24/AG101-RISKS-NEXT.md`

### Test Summary
- E2E: helper εμφανίζεται όταν υπάρχουν φίλτρα και καθαρίζει όλα.