### PR TITLE
Pass AG97.0 — Facet Aggregation Provider (skeleton, no behavior change)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG97.0.md
+++ b/docs/AGENT/SUMMARY/Pass-AG97.0.md
@@ -1,0 +1,4 @@
+- 2025-10-24 14:59 UTC — Pass AG97.0: Facet Aggregation Provider (skeleton, no behavior change)
+  - Προστέθηκε σκελετός provider με interface & demo fallback.
+  - Δεν έγινε wiring στο API route ακόμη — καμία αλλαγή σε runtime.
+  - Προετοιμασία για AG97.1 (Postgres aggregations με pg-e2e).

--- a/docs/reports/2025-10-24/AG97.0-CODEMAP.md
+++ b/docs/reports/2025-10-24/AG97.0-CODEMAP.md
@@ -1,0 +1,2 @@
+# AG97.0 — CODEMAP
+- **frontend/src/app/admin/orders/_server/facets.provider.ts** — provider interface + demo/pg stubs

--- a/docs/reports/2025-10-24/AG97.0-RISKS-NEXT.md
+++ b/docs/reports/2025-10-24/AG97.0-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG97.0 — RISKS-NEXT
+## Risks
+- Μηδενικό ρίσκο: προσθήκη αρχείων μόνο, χωρίς αλλαγή ροής/DB.
+## Next
+- **AG97.1 (pg-e2e):** Prisma/SQL aggregation (countByStatus) + wiring στο `/api/admin/orders/facets`.
+- Προσθήκη CI seed route για PG E2E και label `pg-e2e` στο PR.

--- a/frontend/src/app/admin/orders/_server/facets.provider.ts
+++ b/frontend/src/app/admin/orders/_server/facets.provider.ts
@@ -1,0 +1,45 @@
+'use server';
+
+export type FacetQuery = {
+  status?: string;
+  q?: string;
+  fromDate?: string;
+  toDate?: string;
+  sort?: string;
+};
+
+export type FacetTotals = {
+  totals: Record<string, number>;
+  total: number;
+};
+
+export interface FacetProvider {
+  name: 'demo' | 'pg';
+  getFacetTotals(q: FacetQuery): Promise<FacetTotals>;
+}
+
+/**
+ * Σκελετός provider. Default: 'demo' (placeholder, μηδενικά).
+ * Στο AG97.1 υλοποιούμε 'pg' (Prisma/SQL) και θα γίνει wiring στο API route.
+ */
+export function getFacetProvider(): FacetProvider {
+  const mode = process.env.DIXIS_AGG_PROVIDER === 'pg' ? 'pg' : 'demo';
+
+  if (mode === 'pg') {
+    // AG97.1: θα μπει πραγματική Postgres aggregation (countByStatus)
+    return {
+      name: 'pg',
+      async getFacetTotals(_q: FacetQuery): Promise<FacetTotals> {
+        throw new Error('AG97.1 pending: Postgres aggregation not wired yet');
+      },
+    };
+  }
+
+  // Demo fallback: placeholder χωρίς αλλαγή συμπεριφοράς
+  return {
+    name: 'demo',
+    async getFacetTotals(_q: FacetQuery): Promise<FacetTotals> {
+      return { totals: {}, total: 0 };
+    },
+  };
+}


### PR DESCRIPTION
Backend skeleton: προστέθηκε **facets.provider.ts** με interface & demo/pg stubs. Καμία αλλαγή στο runtime — προετοιμασία για AG97.1 (Postgres aggregations + pg-e2e).

### Reports
- CODEMAP → `docs/reports/2025-10-24/AG97.0-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-24/AG97.0-RISKS-NEXT.md`

### Test Summary
- N/A (skeleton-only, no behavior change)