### PR TITLE
Pass AG97.1 — PG facet provider (Prisma groupBy), NOT wired

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG97.1.md
+++ b/docs/AGENT/SUMMARY/Pass-AG97.1.md
@@ -1,0 +1,4 @@
+- 2025-10-24 17:45 UTC — Pass AG97.1: PG facet provider (Prisma groupBy), NOT wired
+  - Υλοποιήθηκαν: buildWhereClause, transformToFacetTotals, createPgFacetProvider(getPrisma)
+  - Το getFacetProvider() παραμένει DEMO (δεν αλλάζει runtime συμπεριφορά)
+  - Καμία επαφή με API/DB στο runtime — προετοιμασία για AG97.2 wiring & AG97.3 pg-e2e

--- a/docs/reports/2025-10-24/AG97.1-CODEMAP.md
+++ b/docs/reports/2025-10-24/AG97.1-CODEMAP.md
@@ -1,0 +1,6 @@
+# AG97.1 — CODEMAP
+- **frontend/src/app/admin/orders/_server/facets.provider.ts**
+  - buildWhereClause(q) → Prisma where
+  - transformToFacetTotals(grouped, total)
+  - createPgFacetProvider(() => prisma)
+  - getFacetProvider(): DEMO by default (PG wiring έρχεται στο AG97.2)

--- a/docs/reports/2025-10-24/AG97.1-RISKS-NEXT.md
+++ b/docs/reports/2025-10-24/AG97.1-RISKS-NEXT.md
@@ -1,0 +1,6 @@
+# AG97.1 — RISKS-NEXT
+## Risks
+- Μηδενικό (δεν γίνεται runtime wiring).
+## Next
+- **AG97.2:** Wire PG provider στο `/api/admin/orders/facets` (feature-guarded με env).
+- **AG97.3:** `pg-e2e` label + CI seed για πραγματικά aggregations και μετρήσεις.

--- a/frontend/src/app/admin/orders/_server/facets.provider.ts
+++ b/frontend/src/app/admin/orders/_server/facets.provider.ts
@@ -18,6 +18,61 @@ export interface FacetProvider {
   getFacetTotals(q: FacetQuery): Promise<FacetTotals>;
 }
 
+/** Χαρτογράφηση φίλτρων σε Prisma where (τύποι ως any για να μην δεσμευτούμε στο compile-time) */
+export function buildWhereClause(q: FacetQuery): any {
+  const where: any = {};
+  if (q.status) where.status = q.status;
+  if (q.fromDate || q.toDate) {
+    where.createdAt = {};
+    if (q.fromDate) where.createdAt.gte = new Date(q.fromDate);
+    if (q.toDate) where.createdAt.lte = new Date(q.toDate);
+  }
+  if (q.q && q.q.trim()) {
+    const needle = q.q.trim();
+    // Προτάσεις από AG97-prep: id ή buyerName ή buyerPhone
+    where.OR = [
+      { id: needle },
+      { buyerName: { contains: needle, mode: 'insensitive' } },
+      { buyerPhone: { contains: needle, mode: 'insensitive' } },
+    ];
+  }
+  return where;
+}
+
+/** Μετατροπή αποτελεσμάτων groupBy σε FacetTotals */
+export function transformToFacetTotals(grouped: Array<{ status: string; _count: { _all: number } }>, total: number): FacetTotals {
+  const totals: Record<string, number> = {};
+  for (const row of grouped) {
+    totals[row.status ?? 'unknown'] = row._count?._all ?? 0;
+  }
+  return { totals, total };
+}
+
+/**
+ * Δημιουργεί PG provider με dependency injection του Prisma (ώστε να ΜΗΝ γίνεται import εδώ).
+ * Χρήση: const pg = createPgFacetProvider(()=>prisma)
+ * Δεν γίνεται wiring από το getFacetProvider() ακόμα (AG97.2 θα το ενεργοποιήσει).
+ */
+export function createPgFacetProvider(getPrisma: () => any): FacetProvider {
+  return {
+    name: 'pg',
+    async getFacetTotals(q: FacetQuery): Promise<FacetTotals> {
+      const prisma = getPrisma();
+      const where = buildWhereClause(q);
+
+      const grouped = await prisma.order.groupBy({
+        by: ['status'],
+        where,
+        _count: { _all: true },
+      });
+
+      const total = await prisma.order.count({ where });
+
+      return transformToFacetTotals(grouped, total);
+    },
+  };
+}
+
 /**
  * Σκελετός provider. Default: 'demo' (placeholder, μηδενικά).
  * Στο AG97.1 υλοποιούμε 'pg' (Prisma/SQL) και θα γίνει wiring στο API route.
@@ -26,11 +81,12 @@ export function getFacetProvider(): FacetProvider {
   const mode = process.env.DIXIS_AGG_PROVIDER === 'pg' ? 'pg' : 'demo';
 
   if (mode === 'pg') {
-    // AG97.1: θα μπει πραγματική Postgres aggregation (countByStatus)
+    // AG97.1: ο pg provider υπάρχει, αλλά ΔΕΝ γίνεται αυτόματο wiring εδώ.
+    // AG97.2 θα κουμπώσει τον provider στο API route.
     return {
       name: 'pg',
-      async getFacetTotals(_q: FacetQuery): Promise<FacetTotals> {
-        throw new Error('AG97.1 pending: Postgres aggregation not wired yet');
+      async getFacetTotals(_q: FacetQuery) {
+        throw new Error('AG97.2 pending: wire PG provider in API route');
       },
     };
   }


### PR DESCRIPTION
Backend: υλοποιήθηκε ο PG facet provider (Prisma `groupBy` + `count`) με helpers `buildWhereClause` / `transformToFacetTotals`.

- **Δεν** έγινε wiring στο API route (αγγίζουμε αυτό στο AG97.2).
- Καμία αλλαγή σε runtime/DB.

### Implementation Details

- `buildWhereClause(q: FacetQuery)`: Maps AG95 filters to Prisma where clause
- `transformToFacetTotals(grouped, total)`: Transforms Prisma groupBy results
- `createPgFacetProvider(getPrisma)`: Factory function with DI for Prisma client
- `getFacetProvider()`: Still returns DEMO by default (no behavior change)

### Reports
- CODEMAP → `docs/reports/2025-10-24/AG97.1-CODEMAP.md`
- RISKS-NEXT → `docs/reports/2025-10-24/AG97.1-RISKS-NEXT.md`

### Test Summary
- N/A (no runtime wiring)

### Next Steps
- **AG97.2**: Wire to API route with env flag
- **AG97.3**: pg-e2e label + CI seed data testing