### PR TITLE
docs(ci): AG97.7 — Trigger pg-e2e validation (docs-only)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG97.7.md
+++ b/docs/AGENT/SUMMARY/Pass-AG97.7.md
@@ -1,0 +1,5 @@
+- 2025-10-24 20:45 UTC — Pass AG97.7: Trigger pg-e2e validation (docs-only)
+  - Σκοπός: να εκτελεστεί το job **pg-e2e** μετά τις διορθώσεις AG97.3–97.6
+  - Καμία αλλαγή σε runtime/DB. Μόνο validation.
+  - Test: `admin-orders-facets-aggregation.pg-e2e.spec.ts`
+  - Expected: Green pg-e2e job validates full PG aggregation flow


### PR DESCRIPTION
Docs-only change που **εκκινεί το job pg-e2e** για να επιβεβαιώσουμε ότι το admin-orders PG aggregation E2E τρέχει πράσινο μετά τα AG97.3–97.6.

## Summary
Validation run for complete AG97 series (AG97.0-97.6). No code changes, docs-only to trigger pg-e2e workflow.

## Test Summary
- **Test file**: `tests/e2e/admin-orders-facets-aggregation.pg-e2e.spec.ts`
- **Workflow**: pg-e2e (label-gated)
- **Validates**: Full PG aggregation flow
  1. CI seed creates 10 orders
  2. API `/api/admin/orders/facets` uses PG provider
  3. Test validates `provider: 'pg'` and exact counts

## AG97 Series Validation
This completes validation of:
- ✅ AG97.0: Facet provider skeleton
- ✅ AG97.1: PG provider (Prisma groupBy)
- ✅ AG97.2: API wiring (env-guarded)
- ✅ AG97.3: CI seed + E2E test
- ✅ AG97.4: Prisma db push
- ✅ AG97.5: ESM __dirname fix
- ✅ AG97.6: Test path + testMatch fix

## Expected Result
✅ pg-e2e job passes, validating end-to-end PG aggregation

🤖 Generated with [Claude Code](https://claude.com/claude-code)