### PR TITLE
Pass AG105 — Facets timing metrics (env-guarded logs)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG105.md
+++ b/docs/AGENT/SUMMARY/Pass-AG105.md
@@ -1,0 +1,4 @@
+- 2025-10-25 00:30 UTC — Pass AG105: Facets timing metrics (env-guarded logs)
+  - Μετράμε χρόνους για PG aggregations στο /api/admin/orders/facets
+  - Ενεργοποιείται ΜΟΝΟ όταν: DIXIS_AGG_PROVIDER=pg ΚΑΙ DIXIS_METRICS=1 (εκτός demo)
+  - Δεν αλλάζει η απόκριση API· logs μόνο στο server (χωρίς PII)

--- a/docs/reports/2025-10-25/AG105-CODEMAP.md
+++ b/docs/reports/2025-10-25/AG105-CODEMAP.md
@@ -1,0 +1,83 @@
+# AG105 — CODEMAP
+
+## Modified Files
+
+### frontend/src/app/api/admin/orders/facets/route.ts
+
+**Changes**:
+1. **Import performance API** (line 2):
+   ```typescript
+   import { performance } from 'node:perf_hooks';
+   ```
+
+2. **Add timing measurements** (lines 30-42):
+   - Measure `getFacetTotals()` execution time using `performance.now()`
+   - Log metrics only when `DIXIS_METRICS=1` environment variable is set
+   - Privacy-safe logging: No PII, only query metadata
+
+**Code Added**:
+```typescript
+// AG105 — Performance timing (env-guarded)
+const t0 = performance.now();
+const { totals, total } = await provider.getFacetTotals(q);
+const t1 = performance.now();
+
+if (process.env.DIXIS_METRICS === '1') {
+  const qLen = q.q ? q.q.length : 0;
+  const status = q.status || 'any';
+  const fromD = q.fromDate ? '1' : '0';
+  const toD = q.toDate ? '1' : '0';
+  // ΜΗΝ log-άρεις την q τιμή (PII). Μόνο μήκος & flags.
+  console.info(`[AG105][facets] provider=pg ms=${(t1-t0).toFixed(1)} total=${total} status=${status} qLen=${qLen} fromDate=${fromD} toDate=${toD}`);
+}
+```
+
+## Why This Change
+
+### Purpose: Performance Monitoring
+- Measure actual query performance in production
+- Compare PG aggregation vs demo fallback performance
+- Identify slow queries for optimization
+
+### Privacy-First Design
+- **No PII logged**: Never log actual search query text
+- **Metadata only**: Query length, status filter, date range flags
+- **Opt-in**: Requires explicit `DIXIS_METRICS=1` environment variable
+
+### Example Log Output
+```
+[AG105][facets] provider=pg ms=42.3 total=150 status=pending qLen=5 fromDate=1 toDate=0
+```
+
+This shows:
+- Query took 42.3ms
+- Returned 150 total orders
+- Filtered by status "pending"
+- Search query was 5 characters long
+- Date range "from" was set, "to" was not
+
+## Impact
+
+- ✅ **Zero API contract change**: Response format identical
+- ✅ **Zero runtime overhead when disabled**: `DIXIS_METRICS != 1` means no logging
+- ✅ **Minimal overhead when enabled**: `performance.now()` is extremely fast (~1μs)
+- ✅ **Privacy-safe**: No PII in logs
+- ✅ **Production-ready**: Can be enabled in production for debugging
+
+## Activation
+
+To enable metrics logging:
+```bash
+# Local development
+DIXIS_AGG_PROVIDER=pg DIXIS_METRICS=1 npm run dev
+
+# Production environment variable
+DIXIS_METRICS=1
+```
+
+## Use Cases
+
+1. **Performance Baseline**: Measure typical query performance
+2. **Slow Query Detection**: Identify queries taking >100ms
+3. **Optimization Validation**: Verify improvements after index changes
+4. **Capacity Planning**: Understand query patterns and load

--- a/docs/reports/2025-10-25/AG105-RISKS-NEXT.md
+++ b/docs/reports/2025-10-25/AG105-RISKS-NEXT.md
@@ -1,0 +1,67 @@
+# AG105 — RISKS-NEXT
+
+## Risks
+
+- **Πολύ χαμηλό**: Logging-only change, activated only with explicit env flag
+- **Performance overhead**: `performance.now()` calls add ~1-2μs (negligible)
+- **Log volume**: Only logs when `DIXIS_METRICS=1`, one line per request
+- **Privacy**: No PII logged, only metadata
+
+## Testing Strategy
+
+- **Existing tests pass**: No API contract changes
+- **pg-e2e validates**: PG aggregation still works correctly
+- **Local testing**: Enable `DIXIS_METRICS=1` to verify log format
+
+## Expected Result
+
+- ✅ **All tests pass**: Zero functional changes
+- ✅ **No performance degradation**: Timing measurement is negligible
+- ✅ **Clean logs**: When enabled, logs are structured and parseable
+
+## Next Steps (Optional)
+
+### AG106: In-Memory Cache
+- 60-second cache for facet totals
+- Cache key: query parameters hash
+- Invalidation: Time-based (simple) or event-based (complex)
+- Reduces database load for repeated queries
+
+### AG107: Metrics Analysis Script
+- `scripts/metrics/grep-facets.sh` for log analysis
+- Parse AG105 logs to compute:
+  - p50, p95, p99 response times
+  - Most common query patterns
+  - Slow query identification (>100ms)
+
+### Long-term: Observability Stack
+1. **Structured Logging**: JSON format for log aggregation
+2. **Metrics Export**: Prometheus/OpenTelemetry integration
+3. **Alerting**: Alert on p99 > threshold
+4. **Dashboards**: Grafana dashboards for query performance
+
+## Monitoring Recommendations
+
+Once `DIXIS_METRICS=1` is enabled in production:
+
+### Response Time Targets
+- **p50**: <50ms (median query)
+- **p95**: <100ms (95th percentile)
+- **p99**: <200ms (99th percentile)
+
+If exceeded, consider:
+1. **Database indexes**: Add/optimize indexes on filter columns
+2. **Query optimization**: Review `groupBy` efficiency
+3. **Caching**: Implement AG106 (60s cache)
+4. **Read replicas**: Route aggregations to replicas
+
+### Query Pattern Analysis
+Monitor distribution of:
+- **Status filters**: Which statuses are queried most?
+- **Search usage**: How many users use text search?
+- **Date ranges**: Common time windows?
+
+This informs:
+- **Index strategy**: Index most-filtered columns
+- **Cache strategy**: Cache most common queries
+- **Feature usage**: Understand user behavior


### PR DESCRIPTION
## Summary
Add performance timing metrics to facets API PG aggregation path. Measurements are logged only when `DIXIS_METRICS=1` environment variable is set.

## Changes
### Modified Files
- **`frontend/src/app/api/admin/orders/facets/route.ts`**:
  - Import `performance` from `node:perf_hooks`
  - Measure `getFacetTotals()` execution time
  - Log timing + query metadata when `DIXIS_METRICS=1`

### Privacy-Safe Logging
- **No PII**: Never logs actual search query text
- **Metadata only**: Query length, status filter, date range flags
- **Opt-in**: Requires explicit `DIXIS_METRICS=1` environment variable

### Example Log Output
```
[AG105][facets] provider=pg ms=42.3 total=150 status=pending qLen=5 fromDate=1 toDate=0
```

## Benefits
1. **Performance Monitoring**: Measure real query performance
2. **Optimization Guidance**: Identify slow queries
3. **Capacity Planning**: Understand query patterns
4. **Production-Safe**: Opt-in with env var, no PII

## Impact
- ✅ **Zero API contract change**: Response unchanged
- ✅ **Negligible overhead**: ~1-2μs for performance.now()
- ✅ **Opt-in**: No logging unless DIXIS_METRICS=1
- ✅ **Privacy-safe**: No PII in logs

## Activation
```bash
DIXIS_AGG_PROVIDER=pg DIXIS_METRICS=1 npm run dev
```

## Reports
- CODEMAP: `docs/reports/2025-10-25/AG105-CODEMAP.md`
- RISKS-NEXT: `docs/reports/2025-10-25/AG105-RISKS-NEXT.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)