### PR TITLE
fix(db): AG112.2 — Repair migration (inject CREATE TABLE "OrderItem")

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG112.2.md
+++ b/docs/AGENT/SUMMARY/Pass-AG112.2.md
@@ -1,0 +1,4 @@
+- 2025-10-25 07:35 UTC — Pass AG112.2: Repair migration (inject CREATE TABLE "OrderItem")
+  - Η init migration δεν έχει OrderItem table → η 3η migration προσπαθεί ALTER χωρίς CREATE
+  - Inject πλήρες DDL (table + indexes + FKs) στην `20251006000000_add_orderitem_snapshots`
+  - Idempotent (IF NOT EXISTS) για ασφάλεια σε όλα τα περιβάλλοντα

--- a/docs/reports/2025-10-25/AG112.2-CODEMAP.md
+++ b/docs/reports/2025-10-25/AG112.2-CODEMAP.md
@@ -1,0 +1,130 @@
+# AG112.2 — CODEMAP
+
+## Modified File
+
+### frontend/prisma/migrations/20251006000000_add_orderitem_snapshots/migration.sql
+Repaired migration by injecting complete OrderItem table DDL.
+
+**Problem Identified**:
+- **Init migration** (`20251005000000_init`) only creates `Producer` table
+- **OrderItem table** is missing from init migration
+- **3rd migration** (`20251006000000_add_orderitem_snapshots`) tries to `ALTER TABLE "OrderItem"` → fails because table doesn't exist
+
+**Root Cause**:
+The Prisma schema contains OrderItem model, but the init migration was generated when OrderItem didn't exist yet in the schema, or the init migration was manually trimmed/edited.
+
+**Solution Applied**:
+Injected complete CREATE TABLE "OrderItem" DDL into the failing migration:
+
+**Before** (AG112.1 - BROKEN):
+```sql
+-- AlterTable
+ALTER TABLE "OrderItem" ADD COLUMN "titleSnap" TEXT;
+ALTER TABLE "OrderItem" ADD COLUMN "priceSnap" DOUBLE PRECISION;
+```
+❌ Fails with: `ERROR: relation "OrderItem" does not exist`
+
+**After** (AG112.2 - FIXED):
+```sql
+-- CreateTable (injected by AG112.2 - missing from init migration)
+CREATE TABLE IF NOT EXISTS "OrderItem" (
+    "id" TEXT NOT NULL,
+    "orderId" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "producerId" TEXT NOT NULL,
+    "qty" INTEGER NOT NULL,
+    "price" DOUBLE PRECISION NOT NULL,
+    "titleSnap" TEXT,
+    "priceSnap" DOUBLE PRECISION,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "OrderItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex (with IF NOT EXISTS for idempotency)
+CREATE INDEX IF NOT EXISTS "OrderItem_orderId_idx" ON "OrderItem"("orderId");
+CREATE INDEX IF NOT EXISTS "OrderItem_producerId_status_idx" ON "OrderItem"("producerId", "status");
+CREATE INDEX IF NOT EXISTS "OrderItem_productId_idx" ON "OrderItem"("productId");
+
+-- AddForeignKey (with conditional check to prevent duplicates)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'OrderItem_orderId_fkey') THEN
+    ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_orderId_fkey"
+      FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'OrderItem_productId_fkey') THEN
+    ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_productId_fkey"
+      FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AlterTable (original migration - now redundant but kept for history)
+ALTER TABLE "OrderItem" ADD COLUMN IF NOT EXISTS "titleSnap" TEXT;
+ALTER TABLE "OrderItem" ADD COLUMN IF NOT EXISTS "priceSnap" DOUBLE PRECISION;
+```
+
+## Key Design Decisions
+
+### 1. Idempotency
+All DDL statements use `IF NOT EXISTS` / `IF EXISTS` checks:
+- `CREATE TABLE IF NOT EXISTS` - Safe to run multiple times
+- `CREATE INDEX IF NOT EXISTS` - Won't fail if index exists
+- `DO $$ BEGIN ... IF NOT EXISTS ...` - Conditional FK creation
+- `ADD COLUMN IF NOT EXISTS` - Safe column addition
+
+**Why**: Migration might be applied in different environments at different times. Idempotency prevents failures on re-runs.
+
+### 2. Included titleSnap/priceSnap in CREATE TABLE
+The original migration was meant to ADD these columns, but since we're creating the table from scratch, we include them directly with NULL defaults.
+
+**Result**: The ALTER statements become no-ops but are kept for migration history clarity.
+
+### 3. Foreign Keys Reference Order & Product
+Assumes these tables exist from init migration (they should, based on schema dependencies).
+
+**Risk Mitigation**: If they don't exist, this migration will still fail, but that would indicate a deeper schema problem requiring investigation.
+
+## Expected Behavior
+
+### Clean Database (CI)
+1. ✅ Init migration creates Producer table
+2. ✅ Producer image migration adds image column
+3. ✅ **This migration** creates OrderItem table + adds snapshot columns in one step
+4. ✅ Subsequent migrations continue normally
+
+### Existing Database (if any)
+- If OrderItem already exists: All IF NOT EXISTS checks prevent errors
+- If OrderItem partially exists: Idempotent operations fill gaps safely
+- If OrderItem doesn't exist: Creates it properly with all columns
+
+## What This Fixes
+
+**Before AG112.2**:
+```
+Migration deploy sequence:
+1. init → ✅ Creates Producer
+2. add_producer_image → ✅ Adds image column
+3. add_orderitem_snapshots → ❌ Tries to ALTER non-existent OrderItem
+   ERROR: relation "OrderItem" does not exist
+```
+
+**After AG112.2**:
+```
+Migration deploy sequence:
+1. init → ✅ Creates Producer
+2. add_producer_image → ✅ Adds image column
+3. add_orderitem_snapshots → ✅ Creates OrderItem + adds snapshot columns
+4-7. Remaining migrations → ✅ Should proceed normally
+```
+
+## Lessons Learned
+
+**Migration Dependency Management**:
+- Always ensure CREATE TABLE migrations come before ALTER TABLE migrations
+- When regenerating schema migrations, validate that all tables are created before being altered
+- Consider using `prisma migrate reset` + `prisma migrate dev` to regenerate clean migration history
+- For production fixes, inject missing DDL into earliest failing migration rather than creating new "repair" migrations

--- a/docs/reports/2025-10-25/AG112.2-RISKS-NEXT.md
+++ b/docs/reports/2025-10-25/AG112.2-RISKS-NEXT.md
@@ -1,0 +1,151 @@
+# AG112.2 — RISKS-NEXT
+
+## Risks
+- **Χαμηλό**: Τροποποίηση μη-εφαρμοσμένης migration (safe for clean databases)
+  - **Mitigation**: Idempotent DDL (IF NOT EXISTS) prevents issues if migration somehow ran partially
+  - **Validation**: Migration Clinic will test on clean PostgreSQL
+
+- **Foreign Key Dependencies**: Assumes Order & Product tables exist
+  - **Mitigation**: These should be created by init migration
+  - **Monitoring**: If FK creation fails, indicates deeper schema issues
+
+- **Schema Drift**: OrderItem missing from init suggests schema regeneration issues
+  - **Future Risk**: Other tables might have similar issues
+  - **Recommendation**: Full schema audit after AG112.2 passes
+
+## Testing Strategy
+1. **PR CI**: Standard checks + **Migration Clinic** (label `migration-clinic`)
+2. **Expected**: All 7 migrations apply successfully
+3. **Validation Points**:
+   - ✅ Migration 1 (init): Creates Producer
+   - ✅ Migration 2 (add_producer_image): Adds column
+   - ✅ **Migration 3** (add_orderitem_snapshots): Creates OrderItem table
+   - ✅ Migrations 4-7: Apply successfully
+   - ✅ Prisma migrate status: "No pending migrations"
+   - ✅ Prisma db validate: Schema matches database
+
+## Expected Results
+
+### Migration Clinic Run (Clean DB)
+```
+Applying migration `20251005000000_init`
+✅ Created: Producer table
+
+Applying migration `20251005120000_add_producer_image`
+✅ Added: Producer.image column
+
+Applying migration `20251006000000_add_orderitem_snapshots`
+✅ Created: OrderItem table (with indexes & FKs)
+✅ Added: OrderItem.titleSnap, OrderItem.priceSnap (no-ops, already in CREATE)
+
+Applying migration `20251007000412_events_notifications_outbox`
+✅ Created: Event, Notification, RateLimit tables
+
+Applying migration `20251007003019_notifications_sentAt_error`
+✅ Modified: Notification schema
+
+Applying migration `20251007003457_notifications_attempts_backoff_dedup`
+✅ Modified: Notification indexes
+
+Applying migration `20251010000000_add_order_public_token`
+✅ Modified: Order table
+
+All migrations applied successfully ✅
+```
+
+### Artifacts
+- `frontend/prisma/migrations/` folder uploaded
+- All 7 migration folders with SQL files
+- Migration Clinic logs showing successful deployment
+
+## Possible Failure Scenarios
+
+### 1. Order/Product Tables Don't Exist
+**Symptom**: Foreign key creation fails
+**Error**: `ERROR: relation "Order" does not exist` or `relation "Product" does not exist`
+**Diagnosis**: Init migration incomplete or corrupted
+**Fix**: AG112.3 - Audit init migration, add missing tables
+
+### 2. Remaining Migrations Fail
+**Symptom**: Migrations 4-7 fail after OrderItem creation
+**Diagnosis**: Check specific migration error
+**Fix**: AG112.4 - Repair subsequent migrations based on error
+
+### 3. Schema Validation Fails
+**Symptom**: `prisma db validate` fails
+**Error**: Schema doesn't match applied migrations
+**Diagnosis**: Mismatch between schema.prisma and migration files
+**Fix**: AG112.5 - Regenerate migrations from schema or fix schema to match migrations
+
+## Next Steps
+
+### If AG112.2 Passes ✅
+**AG113: Production Migration Runbook**
+- ✅ Migration Clinic validated on clean database
+- Document production migration procedures
+- Create rollback scripts
+- Test on staging environment
+- Schedule production migration window
+- **Monitor**: Watch for OrderItem-related queries in production
+
+### If AG112.2 Fails (FK Errors) ❌
+**AG112.3: Init Migration Audit**
+- Review `20251005000000_init/migration.sql`
+- Identify all missing tables (Order, Product, etc.)
+- Generate complete init migration from current schema
+- Re-run Migration Clinic
+
+### If AG112.2 Fails (Later Migrations) ❌
+**AG112.4: Cascading Migration Repair**
+- Analyze which migration (4-7) failed
+- Apply same repair pattern (inject missing DDL)
+- Re-run Migration Clinic
+
+## Future Enhancements
+
+### Schema Migration Audit Tool
+Create script to validate migration consistency:
+```bash
+# Compare schema.prisma vs applied migrations
+pnpm prisma migrate diff \
+  --from-migrations prisma/migrations \
+  --to-schema-datamodel prisma/schema.prisma \
+  --script > schema-drift.sql
+
+# If output is non-empty → schema drift detected
+```
+
+### Migration Health Check
+Add to Migration Clinic workflow:
+```yaml
+- name: Check for schema drift
+  run: |
+    DRIFT=$(pnpm prisma migrate diff \
+      --from-migrations prisma/migrations \
+      --to-schema-datamodel prisma/schema.prisma \
+      --script)
+    if [ -n "$DRIFT" ]; then
+      echo "⚠️ Schema drift detected:"
+      echo "$DRIFT"
+      exit 1
+    fi
+```
+
+### Pre-commit Migration Validation
+```yaml
+# .husky/pre-commit (for migration changes)
+if git diff --cached --name-only | grep -q "prisma/migrations"; then
+  echo "Migration changes detected, running validation..."
+  cd frontend && pnpm prisma migrate status
+fi
+```
+
+## Monitoring
+
+After merge and Migration Clinic run:
+1. **All 7 migrations apply**: Confirm no errors
+2. **Status check**: "No pending migrations"
+3. **Validation check**: Schema matches database
+4. **Artifacts**: Download and inspect all migration files
+5. **Logs**: Review Prisma output for warnings
+6. **Next**: If all pass → AG113 (Production Runbook)

--- a/frontend/prisma/migrations/20251006000000_add_orderitem_snapshots/migration.sql
+++ b/frontend/prisma/migrations/20251006000000_add_orderitem_snapshots/migration.sql
@@ -1,3 +1,46 @@
--- AlterTable
-ALTER TABLE "OrderItem" ADD COLUMN "titleSnap" TEXT;
-ALTER TABLE "OrderItem" ADD COLUMN "priceSnap" DOUBLE PRECISION;
+-- CreateTable (injected by AG112.2 - missing from init migration)
+CREATE TABLE IF NOT EXISTS "OrderItem" (
+    "id" TEXT NOT NULL,
+    "orderId" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "producerId" TEXT NOT NULL,
+    "qty" INTEGER NOT NULL,
+    "price" DOUBLE PRECISION NOT NULL,
+    "titleSnap" TEXT,
+    "priceSnap" DOUBLE PRECISION,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OrderItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "OrderItem_orderId_idx" ON "OrderItem"("orderId");
+CREATE INDEX IF NOT EXISTS "OrderItem_producerId_status_idx" ON "OrderItem"("producerId", "status");
+CREATE INDEX IF NOT EXISTS "OrderItem_productId_idx" ON "OrderItem"("productId");
+
+-- AddForeignKey (references Order and Product tables which should exist from init)
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'OrderItem_orderId_fkey'
+  ) THEN
+    ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_orderId_fkey"
+      FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'OrderItem_productId_fkey'
+  ) THEN
+    ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_productId_fkey"
+      FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AlterTable (original migration content - add snapshot columns)
+-- These columns are already included in the CREATE TABLE above with NULL defaults
+-- so these ALTER statements become no-ops, but kept for migration history clarity
+ALTER TABLE "OrderItem" ADD COLUMN IF NOT EXISTS "titleSnap" TEXT;
+ALTER TABLE "OrderItem" ADD COLUMN IF NOT EXISTS "priceSnap" DOUBLE PRECISION;


### PR DESCRIPTION
Fixes migration P3018 error by injecting complete OrderItem DDL into add_orderitem_snapshots migration. See commit message for full details.