### PR TITLE
fix(migrations): remove publicToken from Order CREATE TABLE (AG112.4)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-AG112.4.md
+++ b/docs/AGENT/SUMMARY/Pass-AG112.4.md
@@ -1,0 +1,5 @@
+- 2025-10-25 10:00 UTC — Pass AG112.4: Remove publicToken from CREATE TABLE "Order" in migration 3
+  - AG112.3 added Order table WITH publicToken column
+  - Migration 7 (`20251010000000_add_order_public_token`) tries to ADD publicToken → conflict!
+  - Removed publicToken column + indexes from AG112.3's CREATE TABLE "Order"
+  - Let migration 7 add publicToken as originally intended by migration history

--- a/docs/reports/2025-10-25/AG112.4-CODEMAP.md
+++ b/docs/reports/2025-10-25/AG112.4-CODEMAP.md
@@ -1,0 +1,164 @@
+# AG112.4 — CODEMAP
+
+## Modified File
+
+### frontend/prisma/migrations/20251006000000_add_orderitem_snapshots/migration.sql
+Removed publicToken column and related indexes from CREATE TABLE "Order" to prevent conflict with migration 7.
+
+**Problem Evolution**:
+- **AG112.3**: Added CREATE TABLE "Order" with publicToken column based on current schema
+- **AG112.3 Run**: Failed at migration 7 with `ERROR: column "publicToken" of relation "Order" already exists`
+- **AG112.4**: This fix - Removed publicToken from CREATE TABLE, let migration 7 add it
+
+**Migration 7 Intent**:
+Migration `20251010000000_add_order_public_token` is designed to:
+```sql
+ALTER TABLE "Order" ADD COLUMN "publicToken" TEXT NOT NULL DEFAULT gen_random_uuid();
+CREATE UNIQUE INDEX "Order_publicToken_key" ON "Order"("publicToken");
+CREATE INDEX "Order_publicToken_idx" ON "Order"("publicToken");
+```
+
+**Conflict**:
+AG112.3 included publicToken in the initial CREATE TABLE, which meant migration 7's ALTER TABLE would fail.
+
+## Changes Made
+
+### Before AG112.4
+```sql
+-- CreateTable Order (injected by AG112.3 - missing from init migration)
+CREATE TABLE IF NOT EXISTS "Order" (
+    "id" TEXT NOT NULL,
+    "publicToken" TEXT NOT NULL,  -- ❌ Conflicts with migration 7!
+    "buyerPhone" TEXT NOT NULL,
+    "buyerName" TEXT NOT NULL,
+    "shippingLine1" TEXT NOT NULL,
+    "shippingLine2" TEXT,
+    "shippingCity" TEXT NOT NULL,
+    "shippingPostal" TEXT NOT NULL,
+    "total" DOUBLE PRECISION NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Order_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex for Order
+CREATE UNIQUE INDEX IF NOT EXISTS "Order_publicToken_key" ON "Order"("publicToken");  -- ❌
+CREATE INDEX IF NOT EXISTS "Order_buyerPhone_createdAt_idx" ON "Order"("buyerPhone", "createdAt");
+CREATE INDEX IF NOT EXISTS "Order_status_createdAt_idx" ON "Order"("status", "createdAt");
+CREATE INDEX IF NOT EXISTS "Order_publicToken_idx" ON "Order"("publicToken");  -- ❌
+```
+
+**Result**: Migration 7 fails trying to add column that already exists.
+
+### After AG112.4
+```sql
+-- CreateTable Order (injected by AG112.3 - missing from init migration)
+-- Note: publicToken column will be added by migration 20251010000000_add_order_public_token
+CREATE TABLE IF NOT EXISTS "Order" (
+    "id" TEXT NOT NULL,
+    "buyerPhone" TEXT NOT NULL,
+    "buyerName" TEXT NOT NULL,
+    "shippingLine1" TEXT NOT NULL,
+    "shippingLine2" TEXT,
+    "shippingCity" TEXT NOT NULL,
+    "shippingPostal" TEXT NOT NULL,
+    "total" DOUBLE PRECISION NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Order_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex for Order (publicToken indexes will be added by migration 7)
+CREATE INDEX IF NOT EXISTS "Order_buyerPhone_createdAt_idx" ON "Order"("buyerPhone", "createdAt");
+CREATE INDEX IF NOT EXISTS "Order_status_createdAt_idx" ON "Order"("status", "createdAt");
+```
+
+**Result**: Migration 3 creates Order table WITHOUT publicToken, migration 7 adds it successfully.
+
+## Migration Sequence After AG112.4
+
+**Expected Flow**:
+```
+Migration 1 (init): ✅ Producer
+Migration 2 (add_producer_image): ✅ Producer.imageUrl
+Migration 3 (add_orderitem_snapshots): ✅ Product + Order (no publicToken) + OrderItem
+Migration 4 (events_notifications_outbox): ✅ Event, Notification, RateLimit
+Migration 5 (notifications_sentAt_error): ✅ Notification.sentAt, Notification.error
+Migration 6 (notifications_attempts_backoff_dedup): ✅ Notification columns
+Migration 7 (add_order_public_token): ✅ Order.publicToken + indexes
+```
+
+## Why This Approach
+
+### Preserving Migration History Intent
+Each migration file represents a historical point in schema evolution. Migration 7 was created to add publicToken, so we should let it do that job instead of pre-empting it in migration 3.
+
+### Avoiding Future Conflicts
+If we kept publicToken in migration 3, we'd need to either:
+1. Make migration 7 idempotent with `ADD COLUMN IF NOT EXISTS` (modifying historical migration)
+2. Delete migration 7 entirely (breaks migration history)
+3. Remove publicToken from migration 3 (✅ chosen approach - least invasive)
+
+### Clean Separation of Concerns
+- **Migration 3**: Creates core Order table structure
+- **Migration 7**: Adds publicToken feature to existing Order table
+
+## Lessons Learned
+
+**When Injecting Missing Tables**:
+1. **Check ALL later migrations** for columns they might add to this table
+2. **Only include columns that existed BEFORE the earliest ALTER migration**
+3. **Document what's intentionally excluded** and why
+
+**Migration Repair Strategy**:
+```
+1. Identify missing table (e.g., Order)
+2. Find EARLIEST migration that modifies this table (e.g., migration 7 adds publicToken)
+3. Inject CREATE TABLE with columns that existed BEFORE that migration
+4. Let later migrations add their intended columns
+```
+
+**Example**:
+If Order table is missing and migrations 7, 9, 12 all add columns:
+- Migration 3 should create Order with ONLY columns before migration 7
+- Migrations 7, 9, 12 add their columns via ALTER TABLE as intended
+
+## What This Fixes
+
+**Before AG112.4**:
+```
+Migration 7 sequence:
+1. ALTER TABLE "Order" ADD COLUMN "publicToken" ... ❌
+   ERROR: column "publicToken" of relation "Order" already exists
+```
+
+**After AG112.4**:
+```
+Migration 7 sequence:
+1. ALTER TABLE "Order" ADD COLUMN "publicToken" ... ✅
+2. CREATE UNIQUE INDEX "Order_publicToken_key" ... ✅
+3. CREATE INDEX "Order_publicToken_idx" ... ✅
+```
+
+## Expected Next Issue
+
+**Still Unknown**: Whether any migrations after #7 also have similar conflicts. We'll discover this when Migration Clinic runs on AG112.4.
+
+**Migration 7 Status**: We verified from logs that migrations 1-6 passed in AG112.3 run, so migration 7 is the next frontier.
+
+**Remaining Migrations**: If migration 7 passes, there are no more migrations to test (7 total migrations, 1-6 passed, 7 is the final one).
+
+## Strategic Perspective
+
+This is the **fourth iteration** of migration repair:
+- **AG112.2**: Added OrderItem table
+- **AG112.3**: Added Product + Order tables (with publicToken)
+- **AG112.4**: Fixed Order table (removed publicToken)
+
+**Success Criteria for AG112.4**: All 7 migrations pass in Migration Clinic on clean PostgreSQL database.
+
+**If AG112.4 Succeeds**: Migration repair complete! Move to **AG113: Production Runbook**
+
+**If AG112.4 Fails**: Analyze next error and continue iterative repair (likely AG112.5).

--- a/docs/reports/2025-10-25/AG112.4-RISKS-NEXT.md
+++ b/docs/reports/2025-10-25/AG112.4-RISKS-NEXT.md
@@ -1,0 +1,212 @@
+# AG112.4 — RISKS-NEXT
+
+## Risks
+
+- **Χαμηλό**: Same as AG112.3 - only affects clean DB migration runs
+  - **Mitigation**: Idempotent DDL with IF NOT EXISTS
+  - **Validation**: Migration Clinic runs on clean PostgreSQL
+
+- **Migration 7 Final Test**: This is the last migration in the sequence
+  - **Risk**: If migration 7 fails for OTHER reasons, we'll need AG112.5
+  - **Confidence**: HIGH - We've verified migrations 1-6 pass, migration 7 just needed publicToken removed
+
+## Testing Strategy
+
+1. **PR CI**: Standard checks + Migration Clinic (should trigger on label)
+2. **Expected**: ALL 7 migrations should pass
+3. **Validation Points**:
+   - ✅ Migration 1 (init): Creates Producer
+   - ✅ Migration 2 (add_producer_image): Adds image column
+   - ✅ Migration 3 (add_orderitem_snapshots): Creates Product + Order + OrderItem
+   - ✅ Migration 4 (events_notifications_outbox): Creates Event, Notification, RateLimit
+   - ✅ Migration 5 (notifications_sentAt_error): Adds Notification.sentAt, error
+   - ✅ Migration 6 (notifications_attempts_backoff_dedup): Adds Notification columns
+   - ✅ **Migration 7** (add_order_public_token): Adds Order.publicToken + indexes
+
+## Expected Results
+
+### Migration 7 Success (AG112.4 Target) ✅
+```
+Applying migration `20251010000000_add_order_public_token`
+✅ ALTER TABLE "Order" ADD COLUMN "publicToken" TEXT NOT NULL DEFAULT gen_random_uuid();
+✅ CREATE UNIQUE INDEX "Order_publicToken_key" ON "Order"("publicToken");
+✅ CREATE INDEX "Order_publicToken_idx" ON "Order"("publicToken");
+✅ All migrations applied successfully!
+```
+
+### Complete Migration Summary
+```
+7 migrations found in prisma/migrations
+
+Applying migration `20251005000000_init`                                    ✅
+Applying migration `20251005120000_add_producer_image`                      ✅
+Applying migration `20251006000000_add_orderitem_snapshots`                 ✅
+Applying migration `20251007000412_events_notifications_outbox`             ✅
+Applying migration `20251007003019_notifications_sentAt_error`              ✅
+Applying migration `20251007003457_notifications_attempts_backoff_dedup`    ✅
+Applying migration `20251010000000_add_order_public_token`                  ✅
+
+The following migrations have been applied:
+migrations/
+  └─ 20251005000000_init/
+  └─ 20251005120000_add_producer_image/
+  └─ 20251006000000_add_orderitem_snapshots/
+  └─ 20251007000412_events_notifications_outbox/
+  └─ 20251007003019_notifications_sentAt_error/
+  └─ 20251007003457_notifications_attempts_backoff_dedup/
+  └─ 20251010000000_add_order_public_token/
+
+Your database is now in sync with your schema.
+```
+
+## Next Steps
+
+### If AG112.4 Passes ALL 7 Migrations ✅
+**CELEBRATION TIME!** 🎉
+
+Then proceed to:
+- **AG113: Production Migration Runbook**
+  - Document safe production migration process
+  - Create rollback plan
+  - Test on staging environment
+  - Coordinate with ops for production deployment
+
+### If AG112.4 Fails at Migration 7 ❌
+**Unlikely, but possible scenarios:**
+
+**Scenario A**: Migration 7 has internal SQL error
+- → **AG112.5**: Debug and fix migration 7 specific issue
+
+**Scenario B**: Migration 7 passes, but database schema doesn't match Prisma schema
+- → Run `prisma migrate status` to check for drift
+- → May need to generate new migration to sync schema
+
+## Monitoring
+
+After merge and Migration Clinic run:
+1. **All Migrations**: Verify all 7 migrations applied successfully
+2. **Final Schema**: Compare database schema with Prisma schema
+3. **Artifacts**: Download and inspect migration logs
+4. **Validation**: Run `prisma db pull` to verify schema matches
+5. **Celebration**: If all pass, migration repair saga is COMPLETE!
+
+## Migration Repair Journey Summary
+
+### The Journey
+```
+AG112.2 → Fixed OrderItem missing from init
+  ↓
+AG112.3 → Fixed Order & Product missing (OrderItem dependencies)
+  ↓
+AG112.4 → Fixed publicToken conflict (let migration 7 add it)
+  ↓
+AG113 → Production Runbook (if AG112.4 succeeds!)
+```
+
+### Lessons Learned Across AG112.2-AG112.4
+
+1. **Init Migration Catastrophe**: Init migration only created 1 of 8 tables
+2. **Cascade Discovery**: Fixing one table revealed FK dependencies (Order, Product)
+3. **Column Timing**: When injecting tables, check later migrations for columns they add
+4. **Idempotent DDL**: IF NOT EXISTS saved us from re-run errors
+5. **Iterative Repair**: Small, focused fixes > one massive migration rewrite
+
+### Success Metrics
+
+**If AG112.4 Succeeds**:
+- ✅ 7/7 migrations pass on clean database
+- ✅ Database schema matches Prisma schema
+- ✅ Migration history preserved and functional
+- ✅ Production deployment path clear
+
+## Future Enhancements
+
+### Pre-Migration Validation Tool
+```typescript
+// Validate migrations before pushing to main
+async function validateMigrationOrder() {
+  const migrations = await getMigrations();
+  for (const mig of migrations) {
+    const sql = await readMigrationSQL(mig);
+    // Check for ALTER TABLE before corresponding CREATE TABLE
+    const alters = extractAlterTables(sql);
+    const creates = extractCreateTables(sql);
+    for (const alter of alters) {
+      if (!creates.includes(alter.table)) {
+        const priorMigs = migrations.slice(0, migrations.indexOf(mig));
+        const tableCreated = priorMigs.some(m => createsTable(m, alter.table));
+        if (!tableCreated) {
+          console.error(`❌ ${mig}: ALTER TABLE ${alter.table} but table not created!`);
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Health Check
+```bash
+# CI job that runs BEFORE Migration Clinic
+- name: Validate migration history
+  run: |
+    pnpm tsx scripts/validate-migrations.ts
+    # Checks:
+    # 1. All schema models have CREATE TABLE in some migration
+    # 2. No ALTER before CREATE
+    # 3. No column additions that already exist in CREATE
+```
+
+## Strategic Decision Point
+
+**After AG112.4**, we're at a critical junction:
+
+**Option A: Success Path** (Migrations 1-7 all pass)
+- → **AG113**: Production Migration Runbook
+- → Coordinate staging deployment
+- → Production migration plan
+- → Monitor and validate
+
+**Option B: Another Iteration** (Migration 7 fails for different reason)
+- → **AG112.5**: Debug new error
+- → Continue iterative repair
+- → Re-evaluate comprehensive repair option
+
+**Option C: Comprehensive Repair** (If many more issues emerge)
+- → Delete all migrations except init
+- → Regenerate migration history from current schema
+- → Test on clean database
+- → More disruptive but cleaner long-term
+
+## Probability Assessment
+
+**AG112.4 Success Probability**: **90%**
+
+**Why High Confidence**:
+- We've already verified migrations 1-6 pass (from AG112.3 logs)
+- Migration 7 SQL is simple (ADD COLUMN + 2 indexes)
+- The ONLY issue was publicToken duplication, now fixed
+- No other dependencies or complex SQL in migration 7
+
+**What Could Still Fail**:
+- PostgreSQL version incompatibility (unlikely, we use PG 15)
+- Syntax error in migration 7 SQL (unlikely, it's Prisma-generated)
+- Index creation issue (very unlikely)
+
+## Final Validation Checklist
+
+After AG112.4 Migration Clinic run:
+- [ ] All 7 migrations applied successfully
+- [ ] No warnings or errors in logs
+- [ ] `prisma migrate status` shows all migrations applied
+- [ ] Database schema matches Prisma schema.prisma
+- [ ] All foreign keys correctly created
+- [ ] All indexes present
+- [ ] Ready for production deployment planning
+
+## Celebration Plan (When AG112.4 Succeeds)
+
+1. **Document the Victory**: AG112 saga summary showing journey from 1 table to 8 tables
+2. **Update Main**: Ensure AG112.4 merged and running on main
+3. **Notify Team**: Migration repair complete, production path clear
+4. **Plan AG113**: Production migration runbook with rollback plan
+5. **Retrospective**: What we learned from this migration disaster recovery

--- a/frontend/prisma/migrations/20251006000000_add_orderitem_snapshots/migration.sql
+++ b/frontend/prisma/migrations/20251006000000_add_orderitem_snapshots/migration.sql
@@ -32,9 +32,9 @@ DO $$ BEGIN
 END $$;
 
 -- CreateTable Order (injected by AG112.3 - missing from init migration)
+-- Note: publicToken column will be added by migration 20251010000000_add_order_public_token
 CREATE TABLE IF NOT EXISTS "Order" (
     "id" TEXT NOT NULL,
-    "publicToken" TEXT NOT NULL,
     "buyerPhone" TEXT NOT NULL,
     "buyerName" TEXT NOT NULL,
     "shippingLine1" TEXT NOT NULL,
@@ -49,11 +49,9 @@ CREATE TABLE IF NOT EXISTS "Order" (
     CONSTRAINT "Order_pkey" PRIMARY KEY ("id")
 );
 
--- CreateIndex for Order
-CREATE UNIQUE INDEX IF NOT EXISTS "Order_publicToken_key" ON "Order"("publicToken");
+-- CreateIndex for Order (publicToken indexes will be added by migration 7)
 CREATE INDEX IF NOT EXISTS "Order_buyerPhone_createdAt_idx" ON "Order"("buyerPhone", "createdAt");
 CREATE INDEX IF NOT EXISTS "Order_status_createdAt_idx" ON "Order"("status", "createdAt");
-CREATE INDEX IF NOT EXISTS "Order_publicToken_idx" ON "Order"("publicToken");
 
 -- CreateTable OrderItem (injected by AG112.2 - missing from init migration)
 CREATE TABLE IF NOT EXISTS "OrderItem" (


### PR DESCRIPTION
## Summary

Remove publicToken column and indexes from migration 3's CREATE TABLE "Order" to prevent conflict with migration 7 which adds this column via ALTER TABLE.

## Problem Analysis

**AG112.3 Result**: Migration 7 failed with error:
```
ERROR: column "publicToken" of relation "Order" already exists
Migration name: 20251010000000_add_order_public_token
```

**Root Cause**: 
- AG112.3 added CREATE TABLE "Order" with publicToken column (based on current schema)
- Migration 7 (`20251010000000_add_order_public_token`) was designed to ADD publicToken via ALTER TABLE
- Conflict: Migration 7 tries to add column that already exists from AG112.3

## Changes Made

**Migration 3** (`20251006000000_add_orderitem_snapshots/migration.sql`):

### Before (AG112.3)
```sql
CREATE TABLE IF NOT EXISTS "Order" (
    "id" TEXT NOT NULL,
    "publicToken" TEXT NOT NULL,  -- ❌ Conflicts with migration 7
    ...
);
CREATE UNIQUE INDEX IF NOT EXISTS "Order_publicToken_key" ON "Order"("publicToken");
CREATE INDEX IF NOT EXISTS "Order_publicToken_idx" ON "Order"("publicToken");
```

### After (AG112.4)
```sql
-- Note: publicToken column will be added by migration 20251010000000_add_order_public_token
CREATE TABLE IF NOT EXISTS "Order" (
    "id" TEXT NOT NULL,
    -- publicToken removed - migration 7 will add it
    ...
);
-- publicToken indexes removed - migration 7 will add them
```

## Migration Sequence

**Expected Flow After AG112.4**:
```
✅ Migration 1 (init): Producer
✅ Migration 2 (add_producer_image): Producer.imageUrl
✅ Migration 3 (add_orderitem_snapshots): Product + Order (no publicToken) + OrderItem
✅ Migration 4 (events_notifications_outbox): Event, Notification, RateLimit
✅ Migration 5 (notifications_sentAt_error): Notification.sentAt, error
✅ Migration 6 (notifications_attempts_backoff_dedup): Notification columns
✅ Migration 7 (add_order_public_token): Order.publicToken + indexes ⬅️ Now works!
```

## Testing Strategy

**Migration Clinic CI**: Will validate all 7 migrations on clean PostgreSQL database.

**Success Criteria**: All migrations 1-7 pass without errors.

## Context & Evolution

**Migration Repair Journey**:
- **AG112.2**: Added OrderItem table (missing from init)
- **AG112.3**: Added Product + Order tables (OrderItem dependencies)
- **AG112.4**: Fixed publicToken timing (let migration 7 add it) ⬅️ **This PR**
- **AG113**: Production Runbook (if AG112.4 succeeds)

## Lessons Learned

**When Injecting Missing Tables**:
1. Check ALL later migrations for columns they add to this table
2. Only include columns that existed BEFORE the earliest ALTER migration
3. Let historical migrations do their intended job

**Migration Repair Strategy**:
```
1. Find missing table (e.g., Order)
2. Find EARLIEST migration that modifies it (e.g., migration 7 adds publicToken)
3. Create table with ONLY columns before that migration
4. Let later migrations add their columns as intended
```

## Documentation

- **CODEMAP**: `docs/reports/2025-10-25/AG112.4-CODEMAP.md` (164 lines)
- **RISKS-NEXT**: `docs/reports/2025-10-25/AG112.4-RISKS-NEXT.md` (212 lines)
- **Summary**: `docs/AGENT/SUMMARY/Pass-AG112.4.md`

## Files Changed

- `frontend/prisma/migrations/20251006000000_add_orderitem_snapshots/migration.sql` (4 lines changed)
  - Removed publicToken column from CREATE TABLE "Order"
  - Removed 2 publicToken indexes
  - Added explanatory comments

**Total Changes**: 4 files, +383/-4 lines (mostly documentation)

## Risk Assessment

**Risk**: LOW  
**Confidence**: 90% success probability

**Why High Confidence**:
- Migrations 1-6 already verified passing (from AG112.3 logs)
- Migration 7 SQL is simple: ADD COLUMN + 2 indexes
- Only issue was publicToken duplication, now fixed

## Next Steps

**If AG112.4 Passes**: 🎉
- All 7 migrations working on clean database
- → **AG113: Production Migration Runbook**

**If AG112.4 Fails**:
- Analyze new error
- → **AG112.5**: Debug and fix

## Related

- Previous: PR #699 (AG112.3 - added Product + Order tables)
- Previous: PR #698 (AG112.2 - added OrderItem table)
- Context: docs/reports/2025-10-25/AG112.3-RISKS-NEXT.md

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)