### PR TITLE
AG115 — Fix Production Migration (Neon reachability)

### DIFF
--- a/.github/workflows/prod-migration.yml
+++ b/.github/workflows/prod-migration.yml
@@ -56,6 +56,23 @@ jobs:
           PRISMA_HIDE_UPDATE_MESSAGE: 1
         run: pnpm prisma generate
 
+      - name: Sanity (print host/db)
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+        run: |
+          node -e "const u=new URL(process.env.DATABASE_URL); console.log('Host='+u.hostname,'DB='+u.pathname.slice(1),'sslmode='+u.searchParams.get('sslmode'))"
+
+      - name: Wait for Neon (prod)
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+        run: |
+          for i in {1..24}; do
+            echo "SELECT 1;" | pnpm prisma db execute --stdin --url "$DATABASE_URL" && exit 0
+            echo "Neon not ready yet ($i/24); retrying in 5s..."
+            sleep 5
+          done
+          echo "Neon didn't respond in time"; exit 1
+
       - name: Prisma migrate deploy (PRODUCTION)
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}


### PR DESCRIPTION
Adds Sanity check + Wait-for-Neon steps to production migration workflow.

## Changes
- **Sanity check**: Prints host/db/sslmode before migration
- **Wait loop**: Retries Neon connection up to 24 times (2 minutes total)
- **Error handling**: Fails gracefully if Neon doesn't respond

## Why
- Prevents P3005 errors from Neon cold start delays
- Validates DATABASE_URL_PROD is correctly configured
- Provides diagnostic info in logs

## Safety
- Only affects workflow, not database schema
- Idempotent operations
- Same pattern as AG114 staging workflow

## Testing
- Will test on production after merge and manual trigger