### PR TITLE
ci(cd): envfix for prod deploy (DATABASE_URL)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -24,12 +24,6 @@ jobs:
         with:
           version: 9
 
-      - name: Build (optional, artifact not used)
-        working-directory: frontend
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm --version || true
-
       - name: Add SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -40,12 +34,16 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan -H "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts
 
-      - name: Rsync code to VPS (frontend only)
+      - name: Rsync (preserve env files)
         run: |
-          rsync -az --delete --exclude node_modules --exclude .next \
+          rsync -az --delete \
+            --exclude node_modules --exclude .next \
+            --exclude ".env" --exclude ".env.production" --exclude "prisma/.env" \
             ./frontend/ "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/var/www/dixis/current/frontend/"
 
-      - name: Remote deploy (inline install → migrate → build → pm2)
+      - name: Remote deploy (install → migrate → build → pm2)
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
         run: |
           ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" 'bash -lc "
             set -euo pipefail
@@ -53,11 +51,23 @@ jobs:
             corepack enable >/dev/null 2>&1 || true
             corepack prepare pnpm@9.15.9 --activate
             export CI=true
-            grep -q ^DATABASE_URL= prisma/.env && grep -q ^DATABASE_URL= .env && grep -q ^DATABASE_URL= .env.production
+
+            # 1) Γράψε/διατήρησε env αρχεία από το secret (χωρίς echo της τιμής)
+            mkdir -p prisma
+            for f in prisma/.env .env .env.production; do
+              if [ ! -f \"\$f\" ] || ! grep -q \"^DATABASE_URL=\" \"\$f\"; then
+                install -m 600 -D /dev/null \"\$f\"
+                printf '"'DATABASE_URL=\"%s\"\n'"' \"${DATABASE_URL}\" > \"\$f\"
+              fi
+            done
+
+            # 2) Install + Prisma + build + restart
             pnpm install --frozen-lockfile
             pnpm prisma migrate deploy
             pnpm build
             pm2 restart dixis-frontend --update-env
+
+            # 3) Τοπικό health
             curl -sI http://127.0.0.1:3000/api/healthz | head -n1 || true
           "'
 


### PR DESCRIPTION
## Τι διορθώνει
- **Preserve env files**: Rsync excludes .env files (διατηρεί υπάρχοντα)
- **Auto-create env files**: Γράφει env files από DATABASE_URL_PROD secret
- **Fixes P1012**: Stop Prisma "Environment variable not found: DATABASE_URL"

## Evidence
- Run 19133854460 failed με P1012 (prisma/.env missing)
- DATABASE_URL_PROD secret υπάρχει (set 2025-11-06)

## Πλάνο
- CI pass → Merge
- Trigger workflow από main
- Smoke tests (external + internal healthz)

🤖 Generated by Claude Code