### PR TITLE
ci(cd): DB URL guard for Prisma (fix P1012)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -45,20 +45,28 @@ jobs:
             set -euo pipefail
             cd /var/www/dixis/current/frontend
 
+            # Αν το secret είναι κενό, πάρε τιμή από prisma/.env (αν υπάρχει)
+            if [ -z \"${DATABASE_URL:-}\" ]; then
+              if [ -f prisma/.env ]; then
+                DB_LINE=$(grep -E \"^DATABASE_URL=\" prisma/.env || true)
+                DB_VAL=\"${DB_LINE#DATABASE_URL=}\"
+                DB_VAL=\"${DB_VAL%\"}\"; DB_VAL=\"${DB_VAL#\"}\"
+                export DATABASE_URL=\"$DB_VAL\"
+              fi
+            fi
+            [ -n \"${DATABASE_URL:-}\" ] || { echo \"[ERR] DATABASE_URL empty (secret missing & no prisma/.env).\"; exit 1; }
+
             corepack enable >/dev/null 2>&1 || true
             corepack prepare pnpm@9.15.9 --activate
             export CI=true
 
-            # Γράψε env αρχεία από το process env (χωρίς echo τιμών)
+            # Γράψε env αρχεία για runtime (ο Prisma θα διαβάσει από process env)
             mkdir -p prisma
             install -m 600 -D /dev/null prisma/.env
             printf \"DATABASE_URL=\\\"%s\\\"\\n\" \"$DATABASE_URL\" > prisma/.env
             install -m 600 -D /dev/null .env
             install -m 600 -D /dev/null .env.production
             printf \"DATABASE_URL=\\\"%s\\\"\\n\" \"$DATABASE_URL\" | tee .env > .env.production >/dev/null
-
-            # Prisma CLI ΔΕΝ φορτώνει .env λόγω prisma.config.ts → θέλει process env
-            export DATABASE_URL=\"$DATABASE_URL\"
 
             pnpm install --frozen-lockfile
             pnpm prisma migrate deploy


### PR DESCRIPTION
Pass DATABASE_URL into remote shell; fallback to prisma/.env; migrate/build/restart; smoke.