### PR TITLE
fix(ci): Pass DATABASE_URL through SSH shell environment (AG117.6)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,7 +41,8 @@ jobs:
 
       - name: Remote deploy (install → migrate → build → pm2)
         run: |
-          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" "export DATABASE_URL='${{ secrets.DATABASE_URL_PROD }}'; bash -lc '
+          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" "DATABASE_URL='${{ secrets.DATABASE_URL_PROD }}' bash -lc '
+            export DATABASE_URL
             set -euo pipefail
             cd /var/www/dixis/current/frontend
 


### PR DESCRIPTION
## Problem

Production deployments to dixis.io failing with **Prisma P1012 error**:
```
Error code: P1012
error: Error validating datasource `db`: You must provide a nonempty URL.
The environment variable `DATABASE_URL` resolved to an empty string.
```

Despite GitHub secret `DATABASE_URL_PROD` being set correctly (visible as `***` in logs).

### Root Cause

The workflow file line 44 had a critical bug:
```yaml
ssh "$SECRETS_VPS_USER@$SECRETS_VPS_HOST" "export DATABASE_URL='$SECRETS_DATABASE_URL_PROD'; bash -lc '
  set -euo pipefail
  cd /var/www/dixis/current/frontend
  ...
  pnpm prisma migrate deploy
'"
```

The issue: `bash -lc` starts a **login shell** that **resets the environment**, so the `DATABASE_URL` exported before it doesn't carry through to the commands inside the shell.

Flow:
1. SSH connects to VPS ✅
2. `export DATABASE_URL='...'` runs in SSH session shell ✅
3. `bash -lc '...'` starts NEW login shell ❌
4. Login shell resets environment, losing DATABASE_URL ❌
5. `pnpm prisma migrate deploy` runs without DATABASE_URL ❌

## Solution

Pass `DATABASE_URL` as an **environment variable TO the bash process**, then export it inside the login shell:

```yaml
ssh "$SECRETS_VPS_USER@$SECRETS_VPS_HOST" "DATABASE_URL='$SECRETS_DATABASE_URL_PROD' bash -lc '
  export DATABASE_URL
  set -euo pipefail
  cd /var/www/dixis/current/frontend
  ...
  pnpm prisma migrate deploy
'"
```

Now DATABASE_URL:
1. Is set in SSH session environment ✅
2. Passed to bash process as environment variable ✅
3. Exported inside login shell ✅
4. Available to all child processes (pnpm, prisma) ✅

## Changes

- `.github/workflows/deploy-prod.yml:44` - Move `DATABASE_URL` from export to bash env variable
- `.github/workflows/deploy-prod.yml:45` - Add `export DATABASE_URL` at beginning of shell script

## Testing Plan

After merge, will deploy to production and verify:
- ✅ `pnpm prisma migrate deploy` succeeds (no P1012)
- ✅ Smoke tests pass (healthz + main page)
- ✅ PM2 restart succeeds
- ✅ Site remains accessible at https://dixis.io

## Related

- **Blocked by**: P1012 error in runs 19151531013, 19161295465, 19162753657
- **Related PR**: #726 (added DATABASE_URL fallback logic)
- **GitHub Secret**: `DATABASE_URL_PROD` correctly set (Neon pooler URL)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
