### PR TITLE
fix(ci): Remove -l flag - use non-login shell (AG117.7)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Remote deploy (install → migrate → build → pm2)
         run: |
-          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" "DATABASE_URL='${{ secrets.DATABASE_URL_PROD }}' bash -lc '
+          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" "DATABASE_URL='${{ secrets.DATABASE_URL_PROD }}' bash -c '
             export DATABASE_URL
             set -euo pipefail
             cd /var/www/dixis/current/frontend


### PR DESCRIPTION
## Problem

PR #727 (AG117.6) **failed to fix the P1012 error**. Deployment run 19163072540 still reported:
```
[ERR] DATABASE_URL empty (secret missing & no prisma/.env).
```

Despite the GitHub secret `DATABASE_URL_PROD` being set correctly.

### Root Cause - PR #727 Analysis

PR #727 changed from `export DATABASE_URL='...'; bash -lc` to `DATABASE_URL='...' bash -lc`. This was supposed to pass DATABASE_URL as an environment variable to the bash process.

**But it failed because**: The `-l` flag (login shell) sources profile files like `~/.bashrc`, `~/.bash_profile`, etc., which **reset or clear the environment**. Even though DATABASE_URL was passed to the bash process, the login shell initialization cleared it before our commands ran.

## Solution

**Remove the `-l` flag** - use `bash -c` instead of `bash -lc`:

```yaml
# Before (PR #727)
ssh "..." "DATABASE_URL='***' bash -lc 'export DATABASE_URL; ...'"

# After (This PR)
ssh "..." "DATABASE_URL='***' bash -c 'export DATABASE_URL; ...'"
```

Now:
1. DATABASE_URL is passed as env var to bash process ✅
2. bash -c does NOT source login profile files ✅
3. export DATABASE_URL makes it available to child processes ✅
4. pnpm, prisma, and all commands receive DATABASE_URL ✅

## Changes

- `.github/workflows/deploy-prod.yml:44` - Changed `bash -lc` to `bash -c` (one character change: removed `-l`)

## Why We Don't Need Login Shell

Login shells are for interactive sessions where you want your personal environment setup. For deployment scripts:
- We don't need ~/.bashrc or ~/.bash_profile
- We explicitly set all required environment variables
- Non-login shells are faster (no profile sourcing)
- Environment variables propagate correctly

## Testing Plan

After merge, deploy to production and verify:
- ✅ `pnpm prisma migrate deploy` succeeds (no P1012)
- ✅ Smoke tests pass (healthz + main page)
- ✅ PM2 restart succeeds
- ✅ Site remains accessible at https://dixis.io

## Related

- **PR #727**: First attempt (failed - login shell reset environment)
- **PR #726**: Added DATABASE_URL fallback logic
- **Deployment Runs**: 19151531013, 19161295465, 19162753657, 19163072540 (all failed with P1012)
- **GitHub Secret**: `DATABASE_URL_PROD` correctly set with Neon pooler URL

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
