### PR TITLE
fix(ci): AG117.8 — Export DATABASE_URL before bash (not inside)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,8 +41,7 @@ jobs:
 
       - name: Remote deploy (install → migrate → build → pm2)
         run: |
-          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" "DATABASE_URL='${{ secrets.DATABASE_URL_PROD }}' bash -c '
-            export DATABASE_URL
+          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" "export DATABASE_URL='${{ secrets.DATABASE_URL_PROD }}' && bash -c '
             set -euo pipefail
             cd /var/www/dixis/current/frontend
 


### PR DESCRIPTION
## Problem

PR #728 (AG117.7) removed the `-l` flag but deployment **still failed with P1012**. Deployment run 19163322259 reported:
```
grep: prisma/.env: No such file or directory
[ERR] DATABASE_URL empty (secret missing & no prisma/.env).
```

Despite the GitHub secret `DATABASE_URL_PROD` being set correctly (visible as `***` in logs).

### Root Cause - PR #728 Analysis

PR #728 changed to `DATABASE_URL='...' bash -c 'export DATABASE_URL; ...'`, which passes DATABASE_URL as an environment variable to the bash process. However, **this still doesn't work** because:

1. The variable is set in bash's environment (`DATABASE_URL='value' command`)
2. But inside the `bash -c '...'` single-quoted string, the `export DATABASE_URL` command doesn't properly make it available to the script context
3. The script runs but DATABASE_URL is empty, causing the check `[ -n "${DATABASE_URL:-}" ]` to fail

## Solution

**Export DATABASE_URL in the SSH shell BEFORE calling bash**:

```yaml
# Before (PR #728)
ssh "..." "DATABASE_URL='***' bash -c 'export DATABASE_URL; ...'"

# After (This PR)
ssh "..." "export DATABASE_URL='***' && bash -c '...'"
```

Now:
1. DATABASE_URL is exported in the SSH shell environment ✅
2. bash inherits the exported variable automatically ✅
3. All commands inside `bash -c` and child processes see DATABASE_URL ✅
4. pnpm, prisma, and all commands receive DATABASE_URL ✅

## Changes

- `.github/workflows/deploy-prod.yml:44` - Changed `DATABASE_URL='...' bash -c` to `export DATABASE_URL='...' && bash -c`
- `.github/workflows/deploy-prod.yml:45` - Removed redundant `export DATABASE_URL` line inside bash script

Net change: 1 insertion, 2 deletions (cleaner and actually works!)

## Why This Approach Works

When you `export VAR='value'` in a shell, it becomes part of that shell's environment and is automatically inherited by all child processes, including `bash -c '...'`.

The previous approach (`VAR='value' command`) sets the variable only for that specific command invocation but doesn't properly export it to the subshell's script context when combined with `bash -c '...'`.

## Testing Plan

After merge, deploy to production and verify:
- ✅ `pnpm prisma migrate deploy` succeeds (no P1012)
- ✅ Smoke tests pass (healthz + main page)
- ✅ PM2 restart succeeds
- ✅ Site remains accessible at https://dixis.io

## Related

- **PR #728**: Removed `-l` flag (but DATABASE_URL still not accessible)
- **PR #727**: First attempt (failed - login shell reset environment)
- **PR #726**: Added DATABASE_URL fallback logic
- **Deployment Runs**: 19151531013, 19161295465, 19162753657, 19163072540, 19163322259 (all failed with P1012)
- **GitHub Secret**: `DATABASE_URL_PROD` correctly set with Neon pooler URL

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
