### PR TITLE
fix(ci): AG117.9 — Use env command for DATABASE_URL (CRITICAL FIX)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Remote deploy (install → migrate → build → pm2)
         run: |
-          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" "export DATABASE_URL='${{ secrets.DATABASE_URL_PROD }}' && bash -c '
+          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" "env DATABASE_URL='${{ secrets.DATABASE_URL_PROD }}' bash -c '
             set -euo pipefail
             cd /var/www/dixis/current/frontend
 


### PR DESCRIPTION
## CRITICAL FAILURE - AG117.8 DIDN'T WORK

Deployment run 19164446929 **FAILED** with the exact same error as before:
```
[ERR] DATABASE_URL empty (secret missing & no prisma/.env).
```

### Root Cause of AG117.8 Failure

PR #729 (AG117.8) used `export DATABASE_URL='...' && bash -c '...'`, but this **doesn't work** because:
1. `export` only affects the current shell environment
2. The `&&` operator runs bash subprocess **AFTER** export completes
3. The bash subprocess does NOT automatically inherit exported variables from the parent SSH command string
4. export and bash -c are sequential commands, not in a parent-child relationship

### Real Solution (AG117.9)

Use the POSIX-standard `env` command to explicitly pass the environment variable to the bash subprocess:

```yaml
# Before (AG117.8 - FAILED)
ssh "..." "export DATABASE_URL='${{ secrets.DATABASE_URL_PROD }}' && bash -c '...'"

# After (AG117.9 - CORRECT)
ssh "..." "env DATABASE_URL='${{ secrets.DATABASE_URL_PROD }}' bash -c '...'"
```

The `env` command:
1. Sets DATABASE_URL in its own environment
2. Executes bash as a direct child process
3. bash automatically inherits DATABASE_URL from env
4. All commands inside bash -c see DATABASE_URL ✅

## Changes

- `.github/workflows/deploy-prod.yml:44` — Changed `export DATABASE_URL='...' &&` to `env DATABASE_URL='...'`

Net change: Single command replacement (export→env, remove &&)

## Why env Works

`env VAR=value command` is the POSIX-standard way to set environment variables for a subprocess. Unlike `export`, which only affects the current shell, `env` guarantees the variable is available in the specified command's environment.

## Testing Plan

After merge, deploy to production and verify:
- ✅ `pnpm prisma migrate deploy` succeeds (no P1012)
- ✅ Smoke tests pass (healthz + main page)
- ✅ PM2 restart succeeds
- ✅ Site remains accessible at https://dixis.io

## Related

- **Run 19164446929**: AG117.8 deployment FAILED (triggered after PR #729 merged)
- **PR #729**: AG117.8 (merged but didn't fix issue)
- **PR #728**: AG117.7 (removed `-l` flag)
- **PR #727**: AG117.6 (first attempt)
- **Deployment Runs**: 19151531013, 19161295465, 19162753657, 19163072540, 19163322259, 19164446929 (all failed with P1012)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)