### PR TITLE
fix: homepage dynamic fetch (eliminate DYNAMIC_SERVER_USAGE)

### DIFF
--- a/frontend/src/app/Home.tsx
+++ b/frontend/src/app/Home.tsx
@@ -1,11 +1,10 @@
 import { Product } from '@/lib/api';
 import HomeClient from './HomeClient';
 import { getTranslations } from 'next-intl/server';
-import { apiPath } from '@/lib/runtime/urls';
 
 async function getInitialProducts(): Promise<Product[]> {
   try {
-    const url = apiPath('/api/public/products?per_page=20&sort=created_at');
+    const url = '/api/products?pageSize=20';
     const res = await fetch(url, { cache: 'no-store' });
 
     if (!res.ok) {
@@ -14,7 +13,7 @@ async function getInitialProducts(): Promise<Product[]> {
     }
 
     const data = await res.json();
-    return Array.isArray(data?.data) ? data.data : [];
+    return Array.isArray(data?.items) ? data.items : [];
   } catch (error) {
     console.error('Error fetching products:', error);
     return [];

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,6 +3,9 @@ import Home from './Home';
 import LandingPage from './Landing';
 import { LANDING_MODE, shouldNoIndex } from '@/lib/flags';
 
+// Force dynamic rendering to avoid static generation issues
+export const dynamic = 'force-dynamic';
+
 // Use ISR (Incremental Static Regeneration) for data fetching
 export const revalidate = 3600; // Revalidate every hour
 


### PR DESCRIPTION
## Summary
- Add `export const dynamic = 'force-dynamic'` to page.tsx
- Replace backend API call with frontend /api/products route
- Change `apiPath('/api/public/products')` to `/api/products?pageSize=20'`
- Update data extraction from `data.data` to `data.items`
- Remove unused `apiPath` import from Home.tsx

## Problem
VPS builds were failing with DYNAMIC_SERVER_USAGE error:
```
Error fetching products: [Error: Dynamic server usage: Route / couldn't be rendered statically because it used revalidate: 0 fetch http://127.0.0.1:8001/api/public/products?per_page=20&sort=created_at
```

## Solution
The homepage now:
1. Declares itself as dynamic (`export const dynamic = 'force-dynamic'`)
2. Uses the frontend API route `/api/products` instead of calling the backend directly
3. Avoids hardcoded URLs during server-side rendering

## Acceptance Criteria
- [x] Homepage builds without DYNAMIC_SERVER_USAGE error
- [x] Homepage marked as Dynamic (ƒ) in build output
- [x] Local build succeeds
- [x] TypeScript compilation passes
- [ ] All CI checks pass
- [ ] VPS deploy completes without DYNAMIC_SERVER_USAGE error
- [ ] Homepage loads correctly on production

## Evidence
- Local build: ✅ SUCCESS (homepage marked as ƒ Dynamic)
- No DYNAMIC_SERVER_USAGE errors in build output
- CI checks pending

## Test plan
- [x] Create clean PR with only homepage changes
- [ ] CI checks pass (build-and-test, typecheck, E2E)
- [ ] VPS deploy completes without DYNAMIC_SERVER_USAGE error
- [ ] Homepage loads correctly on production

## Reports
- Modified files: `frontend/src/app/page.tsx`, `frontend/src/app/Home.tsx`
- Lines changed: 2 files, 5 insertions(+), 3 deletions(-)
- PR scope: ≤10 LOC (focused homepage fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)