### PR TITLE
AG124b: Fix Production Seed workflow

### DIFF
--- a/.github/workflows/prod-seed.yml
+++ b/.github/workflows/prod-seed.yml
@@ -17,6 +17,7 @@ jobs:
     if: github.event.inputs.confirm == 'DIXIS-PROD-SEED'
     env:
       DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+      CI: 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,6 +26,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: 'frontend/pnpm-lock.yaml'
 
       - name: Enable corepack
         working-directory: frontend
@@ -33,6 +36,10 @@ jobs:
       - name: Install dependencies
         working-directory: frontend
         run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma Client
+        working-directory: frontend
+        run: pnpm prisma generate
 
       - name: Run seed
         working-directory: frontend


### PR DESCRIPTION
## What
- Add missing prisma generate step before seed
- Set CI=true for non-interactive mode
- Enable pnpm cache for faster installs

## Why
Production Seed workflow was failing because:
1. Missing `prisma generate` step - Prisma client wasn't generated before seed
2. No CI environment variable - pnpm could ask interactive prompts  
3. No pnpm caching - slower installs

## After merge
- Ensure repo secret `PROD_DATABASE_URL` is set (Settings → Secrets → Actions)
- Run **Production Seed** workflow via Actions tab with confirm='DIXIS-PROD-SEED'
- Verify /api/products returns data (total >= 1)

Ref: AG128 cart smoke test requires seeded products