### PR TITLE
chore(ops): fix build - add prisma generate to build script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "dev:restart": "npm run dev:stop && npm run dev:start",
     "clean": "rimraf .next && rimraf node_modules/.cache || true",
     "dev:clean": "npm run clean:cache && npm run dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "start:ci": "next start -p 3001",
     "mock:api": "node ../scripts/mock-api/lhci-mock.cjs",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -42,6 +42,7 @@
     "**/*.test.ts",
     "**/*.spec.ts",
     "vitest.config*.ts",
+    "prisma/seed.ts",
     // ρητά legacy directories
     "../GitHub-Dixis-Project-1/**",
     "../Dixis-Project-1/**",


### PR DESCRIPTION
Problem:
VPS deployments were failing with "Module '@prisma/client' has no
exported member 'PrismaClient'" because the build process was
type-checking prisma/seed.ts before Prisma Client was generated.

Solution:
1. Add "prisma generate" to the build script in package.json
2. Exclude prisma/seed.ts from TypeScript type-checking in tsconfig.json

This ensures:
- Prisma Client is always generated before Next.js build
- seed.ts is excluded from type-checking to prevent circular issues
- Future deployments will not encounter this build failure

Fixes: VPS deployment build failure after PR #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
