### PR TITLE
AG129b — Shipping Quote API (POST)

### DIFF
--- a/frontend/src/app/api/v1/shipping/quote/route.ts
+++ b/frontend/src/app/api/v1/shipping/quote/route.ts
@@ -1,40 +1,32 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function POST(request: NextRequest) {
+export const dynamic = 'force-dynamic';
+
+// Simple rules (tunable next pass)
+const BASE = 2.5;         // base cost
+const PER_ITEM = 0.9;     // per item
+const MAX_COST = 19.9;    // cap to avoid runaway costs
+
+type Item = { slug: string; qty: number };
+
+function calc(items: Item[]) {
+  const qty = items.reduce((s, i) => s + Math.max(0, Number(i.qty) || 0), 0);
+  const total = Math.min(MAX_COST, Math.max(0, BASE + PER_ITEM * qty));
+  return { total: Number(total.toFixed(2)) };
+}
+
+export async function POST(req: NextRequest) {
   try {
-    const body = await request.json();
-
-    // Forward the request to the Laravel backend
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8001/api/v1'}/shipping/quote`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        // Forward auth headers if present
-        ...(request.headers.get('authorization') && {
-          'Authorization': request.headers.get('authorization')!
-        })
-      },
-      body: JSON.stringify(body)
-    });
-
-    const data = await response.json();
-
-    return NextResponse.json(data, {
-      status: response.status,
-      headers: {
-        'Content-Type': 'application/json',
-      }
-    });
-  } catch (error) {
-    console.error('Shipping quote API error:', error);
-
-    return NextResponse.json(
-      {
-        success: false,
-        message: 'Σφάλμα κατά τον υπολογισμό μεταφορικών'
-      },
-      { status: 500 }
-    );
+    const body = await req.json().catch(() => ({}));
+    const items: Item[] = Array.isArray(body?.items) ? body.items : [];
+    if (!items.length) return NextResponse.json({ total: 0 });
+    return NextResponse.json(calc(items));
+  } catch {
+    return NextResponse.json({ total: 0 });
   }
+}
+
+// Explicitly reject other methods
+export function GET() {
+  return NextResponse.json({ error: 'Method Not Allowed' }, { status: 405 });
 }


### PR DESCRIPTION
## Acceptance Criteria
- POST /api/v1/shipping/quote accepts { items: [{slug, qty}] }
- Returns { total: number }
- Simple calculation: BASE (2.5) + PER_ITEM (0.9) * total quantity
- MAX_COST cap at 19.9 to prevent runaway costs
- Explicit 405 response for GET method

## Test Plan
- ✅ Frontend build passes (TypeScript strict mode)
- ✅ Route registered at /api/v1/shipping/quote
- POST with empty items returns { total: 0 }
- POST with items calculates shipping cost
- GET method returns 405 Method Not Allowed
- Manual verification: curl -X POST with items array

## Reports / Test Summary
- **CODEMAP**: docs/AGENT/SYSTEM/routes.md
- **TEST-REPORT**: https://github.com/lomendor/Project-Dixis/actions/runs/19229900984
- **RISKS-NEXT**: frontend/docs/OPS/STATE.md

## Summary
- Adds `POST /api/v1/shipping/quote` (base 2.5 + 0.9/qty, cap 19.9)
- Explicit 405 for GET, graceful `{ total: 0 }` fallback
- Cart totals (PR #749) already consumes this endpoint

## Notes
- Replaces Laravel backend proxy with simple Next.js calculation
- Constants tunable: BASE, PER_ITEM, MAX_COST
- Graceful fallback to 0 on error
- No database queries, stateless calculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
