### PR TITLE
AG130 Hotfix — Checkout hang: shared shipping calc (no self-fetch)

### DIFF
--- a/frontend/src/app/api/v1/shipping/quote/route.ts
+++ b/frontend/src/app/api/v1/shipping/quote/route.ts
@@ -1,71 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '@/lib/prisma';
+import { calcShippingForItems, Zone } from '@/lib/shipping';
 
 export const dynamic = 'force-dynamic';
-
-type Item = { slug: string; qty: number };
-type ZoneKey = 'mainland' | 'islands';
-
-const FREE_TH = Number(process.env.NEXT_PUBLIC_SHIP_FREE_THRESHOLD_EUR ?? '35');
-const MAX_COST = Number(process.env.NEXT_PUBLIC_SHIP_MAX_COST ?? '19.9');
-
-const ZONES: Record<ZoneKey, { base: number; perItem: number }> = {
-  mainland: { base: Number(process.env.NEXT_PUBLIC_SHIP_MAINLAND_BASE ?? '2.5'),
-              perItem: Number(process.env.NEXT_PUBLIC_SHIP_MAINLAND_PERITEM ?? '0.9') },
-  islands:  { base: Number(process.env.NEXT_PUBLIC_SHIP_ISLANDS_BASE ?? '3.5'),
-              perItem: Number(process.env.NEXT_PUBLIC_SHIP_ISLANDS_PERITEM ?? '1.1') },
-};
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json().catch(() => ({}));
-    const items: Item[] = Array.isArray(body?.items) ? body.items : [];
-    const zone: ZoneKey = (body?.zone === 'islands' ? 'islands' : 'mainland');
-
-    if (!items.length) {
-      return NextResponse.json({ total: 0, subtotal: 0, zone, threshold: FREE_TH });
-    }
-
-    // Υπολόγισε subtotal από DB για να κρίνεις threshold
-    const slugs = items.map(i => i.slug);
-    const prods = await prisma.product.findMany({
-      where: { id: { in: slugs } },
-      select: { id: true, price: true }
-    });
-
-    const priceBySlug = new Map<string, number>();
-    for (const p of prods) priceBySlug.set(p.id, Number(p.price ?? 0));
-
-    let subtotal = 0;
-    let qtyTotal = 0;
-    for (const it of items) {
-      const price = priceBySlug.get(it.slug) ?? 0;
-      const q = Math.max(0, Number(it.qty) || 0);
-      subtotal += price * q;
-      qtyTotal += q;
-    }
-
-    // Κανόνες: δωρεάν πάνω από threshold, αλλιώς base + perItem*qty, με cap
-    let total = 0;
-    if (subtotal >= FREE_TH) {
-      total = 0;
-    } else {
-      const { base, perItem } = ZONES[zone];
-      total = Math.min(MAX_COST, Math.max(0, base + perItem * qtyTotal));
-    }
-
-    return NextResponse.json({
-      total: Number(total.toFixed(2)),
-      subtotal: Number(subtotal.toFixed(2)),
-      zone,
-      threshold: FREE_TH
-    });
+    const items = Array.isArray(body?.items) ? body.items : [];
+    const zone: Zone = (body?.zone === 'islands' ? 'islands' : 'mainland');
+    if (!items.length) return NextResponse.json({ total: 0, subtotal: 0, zone, threshold: Number(process.env.NEXT_PUBLIC_SHIP_FREE_THRESHOLD_EUR ?? 35) });
+    const res = await calcShippingForItems(items, zone);
+    return NextResponse.json(res);
   } catch {
-    return NextResponse.json({ total: 0, subtotal: 0, zone: 'mainland', threshold: FREE_TH });
+    return NextResponse.json({ total: 0, subtotal: 0, zone: 'mainland', threshold: Number(process.env.NEXT_PUBLIC_SHIP_FREE_THRESHOLD_EUR ?? 35) });
   }
 }
-
-// Αν κληθεί GET, απάντησε 405 (για καθαρότητα)
-export function GET() {
-  return NextResponse.json({ error: 'Method Not Allowed' }, { status: 405 });
-}
+export function GET(){ return NextResponse.json({ error: 'Method Not Allowed' }, { status: 405 }); }

--- a/frontend/src/lib/shipping.ts
+++ b/frontend/src/lib/shipping.ts
@@ -1,0 +1,39 @@
+import { prisma } from '@/lib/prisma';
+
+export type Zone = 'mainland' | 'islands';
+export type Item = { slug: string; qty: number };
+
+const FREE_TH = Number(process.env.NEXT_PUBLIC_SHIP_FREE_THRESHOLD_EUR ?? '35');
+const MAX_COST = Number(process.env.NEXT_PUBLIC_SHIP_MAX_COST ?? '19.9');
+
+const ZONES: Record<Zone, { base: number; perItem: number }> = {
+  mainland: { base: Number(process.env.NEXT_PUBLIC_SHIP_MAINLAND_BASE ?? '2.5'),
+              perItem: Number(process.env.NEXT_PUBLIC_SHIP_MAINLAND_PERITEM ?? '0.9') },
+  islands:  { base: Number(process.env.NEXT_PUBLIC_SHIP_ISLANDS_BASE ?? '3.5'),
+              perItem: Number(process.env.NEXT_PUBLIC_SHIP_ISLANDS_PERITEM ?? '1.1') },
+};
+
+export function calcShippingFromSummary(subtotal: number, qty: number, zone: Zone) {
+  if (subtotal >= FREE_TH) return { total: 0, subtotal, zone, threshold: FREE_TH };
+  const { base, perItem } = ZONES[zone];
+  const total = Math.min(MAX_COST, Math.max(0, base + perItem * Math.max(0, qty)));
+  return { total: Number(total.toFixed(2)), subtotal: Number(subtotal.toFixed(2)), zone, threshold: FREE_TH };
+}
+
+export async function calcShippingForItems(items: Item[], zone: Zone) {
+  const slugs = items.map(i => i.slug);
+  const prods = await prisma.product.findMany({
+    where: { id: { in: slugs } },
+    select: { id: true, price: true }
+  });
+  const map = new Map<string, number>();
+  for (const p of prods) map.set(p.id, Number(p.price ?? 0));
+
+  let subtotal = 0; let qty = 0;
+  for (const it of items) {
+    const q = Math.max(0, Number(it.qty) || 0);
+    subtotal += (map.get(it.slug) ?? 0) * q;
+    qty += q;
+  }
+  return calcShippingFromSummary(subtotal, qty, zone);
+}


### PR DESCRIPTION
## Why
- POST /api/checkout was hanging due to internal HTTP fetch to own host (self-referencing call)
- The checkout endpoint was calling `computeShipping()` which made an HTTP fetch to `/api/v1/shipping/quote`
- This created a circular dependency that caused the endpoint to hang indefinitely

## What
- **New shared library**: Created `src/lib/shipping.ts` with centralized shipping calculation logic
- **Updated /api/v1/shipping/quote**: Now uses `calcShippingForItems()` from shared lib (removed duplicate logic)
- **Updated /api/checkout**: Now uses `calcShippingFromSummary()` directly (removed internal HTTP fetch)
- **Build verification**: TypeScript compilation passes, all routes functional

## Technical Details
- `calcShippingFromSummary(subtotal, qty, zone)`: Pure calculation function using existing subtotal/qty
- `calcShippingForItems(items, zone)`: Async function that fetches product prices and calculates shipping
- Zone-based pricing: mainland (€2.50 base + €0.90/item) vs islands (€3.50 base + €1.10/item)
- Free shipping threshold: €35 (configurable via env)

## Verify
- ✅ Build OK
- After merge & deploy: `POST /api/checkout` should return JSON response immediately (< 1s)

## Test Command
```bash
curl -sS -X POST -H 'Content-Type: application/json' -H 'x-idempotency-key: hotfix-test' \
  -d '{"customer":{"email":"t@t.io"},"items":[{"slug":"seed-product-fig-sweet","qty":1}],"zone":"mainland"}' \
  https://dixis.io/api/checkout | jq .
```

Expected: Fast response with `{"orderId":"...", "total":..., "shipping":..., "subtotal":...}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)