### PR TITLE
AG130: Clean migration.sql (remove warnings, use ALTER TABLE only)

### DIFF
--- a/frontend/prisma/migrations/20251110000000_ag130_checkout_fields/migration.sql
+++ b/frontend/prisma/migrations/20251110000000_ag130_checkout_fields/migration.sql
@@ -1,242 +1,29 @@
-warn The configuration property `package.json#prisma` is deprecated and will be removed in Prisma 7. Please migrate to a Prisma config file (e.g., `prisma.config.ts`).
-For more information, see: https://pris.ly/prisma-config
+-- AlterTable: Make existing Order fields optional for AG130
+ALTER TABLE "Order" ALTER COLUMN "buyerPhone" DROP NOT NULL;
+ALTER TABLE "Order" ALTER COLUMN "buyerName" DROP NOT NULL;
+ALTER TABLE "Order" ALTER COLUMN "shippingLine1" DROP NOT NULL;
+ALTER TABLE "Order" ALTER COLUMN "shippingCity" DROP NOT NULL;
+ALTER TABLE "Order" ALTER COLUMN "shippingPostal" DROP NOT NULL;
 
-Loaded Prisma config from prisma.config.ts.
+-- AlterTable: Add AG130 checkout fields to Order
+ALTER TABLE "Order" ADD COLUMN "email" TEXT;
+ALTER TABLE "Order" ADD COLUMN "name" TEXT;
+ALTER TABLE "Order" ADD COLUMN "phone" TEXT;
+ALTER TABLE "Order" ADD COLUMN "address" TEXT;
+ALTER TABLE "Order" ADD COLUMN "city" TEXT;
+ALTER TABLE "Order" ADD COLUMN "zip" TEXT;
+ALTER TABLE "Order" ADD COLUMN "zone" TEXT DEFAULT 'mainland';
+ALTER TABLE "Order" ADD COLUMN "subtotal" DECIMAL(10,2);
+ALTER TABLE "Order" ADD COLUMN "shipping" DECIMAL(10,2);
+ALTER TABLE "Order" ADD COLUMN "currency" TEXT DEFAULT 'EUR';
 
-warn The Prisma config file in prisma.config.ts overrides the deprecated `package.json#prisma` property in package.json.
-  For more information, see: https://pris.ly/prisma-config
-
--- CreateEnum
-CREATE TYPE "PaymentStatus" AS ENUM ('PENDING', 'PAID', 'FAILED');
-
--- CreateTable
-CREATE TABLE "Producer" (
-    "id" TEXT NOT NULL,
-    "slug" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "region" TEXT NOT NULL,
-    "category" TEXT NOT NULL,
-    "description" TEXT,
-    "phone" TEXT,
-    "email" TEXT,
-    "products" INTEGER NOT NULL DEFAULT 0,
-    "rating" DOUBLE PRECISION DEFAULT 0,
-    "imageUrl" TEXT,
-    "isActive" BOOLEAN NOT NULL DEFAULT true,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-
-    CONSTRAINT "Producer_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Product" (
-    "id" TEXT NOT NULL,
-    "producerId" TEXT NOT NULL,
-    "title" TEXT NOT NULL,
-    "category" TEXT NOT NULL,
-    "price" DOUBLE PRECISION NOT NULL,
-    "unit" TEXT NOT NULL,
-    "stock" INTEGER NOT NULL DEFAULT 0,
-    "description" TEXT,
-    "imageUrl" TEXT,
-    "isActive" BOOLEAN NOT NULL DEFAULT true,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-
-    CONSTRAINT "Product_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Order" (
-    "id" TEXT NOT NULL,
-    "publicToken" TEXT NOT NULL,
-    "buyerPhone" TEXT,
-    "buyerName" TEXT,
-    "shippingLine1" TEXT,
-    "shippingLine2" TEXT,
-    "shippingCity" TEXT,
-    "shippingPostal" TEXT,
-    "total" DOUBLE PRECISION NOT NULL,
-    "status" TEXT NOT NULL DEFAULT 'pending',
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-    "email" TEXT,
-    "name" TEXT,
-    "phone" TEXT,
-    "address" TEXT,
-    "city" TEXT,
-    "zip" TEXT,
-    "zone" TEXT DEFAULT 'mainland',
-    "subtotal" DECIMAL(10,2),
-    "shipping" DECIMAL(10,2),
-    "currency" TEXT DEFAULT 'EUR',
-
-    CONSTRAINT "Order_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "OrderItem" (
-    "id" TEXT NOT NULL,
-    "orderId" TEXT NOT NULL,
-    "productId" TEXT,
-    "producerId" TEXT,
-    "qty" INTEGER NOT NULL,
-    "price" DOUBLE PRECISION NOT NULL,
-    "titleSnap" TEXT,
-    "priceSnap" DOUBLE PRECISION,
-    "status" TEXT NOT NULL DEFAULT 'pending',
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-    "slug" TEXT,
-    "currency" TEXT DEFAULT 'EUR',
-
-    CONSTRAINT "OrderItem_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Event" (
-    "id" TEXT NOT NULL,
-    "type" TEXT NOT NULL,
-    "payload" JSONB NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "Event_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Notification" (
-    "id" TEXT NOT NULL,
-    "channel" TEXT NOT NULL,
-    "to" TEXT NOT NULL,
-    "template" TEXT NOT NULL,
-    "payload" JSONB NOT NULL,
-    "status" TEXT NOT NULL DEFAULT 'QUEUED',
-    "sentAt" TIMESTAMP(3),
-    "error" TEXT,
-    "attempts" INTEGER NOT NULL DEFAULT 0,
-    "nextAttemptAt" TIMESTAMP(3),
-    "dedupId" VARCHAR(64),
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-
-    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "RateLimit" (
-    "id" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "key" TEXT NOT NULL,
-    "bucket" INTEGER NOT NULL,
-    "count" INTEGER NOT NULL DEFAULT 0,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "RateLimit_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "CheckoutOrder" (
-    "id" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-    "postalCode" TEXT NOT NULL,
-    "method" TEXT NOT NULL,
-    "weightGrams" INTEGER NOT NULL,
-    "subtotal" DECIMAL(10,2) NOT NULL,
-    "shippingCost" DECIMAL(10,2) NOT NULL,
-    "codFee" DECIMAL(10,2),
-    "total" DECIMAL(10,2) NOT NULL,
-    "email" TEXT,
-    "paymentStatus" "PaymentStatus" NOT NULL DEFAULT 'PAID',
-    "paymentRef" TEXT,
-
-    CONSTRAINT "CheckoutOrder_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Waitlist" (
-    "id" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "email" TEXT NOT NULL,
-    "role" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "Waitlist_pkey" PRIMARY KEY ("id")
-);
-
--- CreateIndex
-CREATE UNIQUE INDEX "Producer_slug_key" ON "Producer"("slug");
-
--- CreateIndex
-CREATE INDEX "Producer_region_category_idx" ON "Producer"("region", "category");
-
--- CreateIndex
-CREATE INDEX "Producer_name_idx" ON "Producer"("name");
-
--- CreateIndex
-CREATE INDEX "Product_producerId_createdAt_idx" ON "Product"("producerId", "createdAt");
-
--- CreateIndex
-CREATE INDEX "Product_category_idx" ON "Product"("category");
-
--- CreateIndex
-CREATE INDEX "Product_isActive_idx" ON "Product"("isActive");
-
--- CreateIndex
-CREATE UNIQUE INDEX "Order_publicToken_key" ON "Order"("publicToken");
-
--- CreateIndex
-CREATE INDEX "Order_buyerPhone_createdAt_idx" ON "Order"("buyerPhone", "createdAt");
-
--- CreateIndex
-CREATE INDEX "Order_status_createdAt_idx" ON "Order"("status", "createdAt");
-
--- CreateIndex
-CREATE INDEX "Order_publicToken_idx" ON "Order"("publicToken");
-
--- CreateIndex
+-- CreateIndex: Add email index for Order
 CREATE INDEX "Order_email_idx" ON "Order"("email");
 
--- CreateIndex
-CREATE INDEX "OrderItem_orderId_idx" ON "OrderItem"("orderId");
+-- AlterTable: Make OrderItem productId/producerId optional for AG130
+ALTER TABLE "OrderItem" ALTER COLUMN "productId" DROP NOT NULL;
+ALTER TABLE "OrderItem" ALTER COLUMN "producerId" DROP NOT NULL;
 
--- CreateIndex
-CREATE INDEX "OrderItem_producerId_status_idx" ON "OrderItem"("producerId", "status");
-
--- CreateIndex
-CREATE INDEX "OrderItem_productId_idx" ON "OrderItem"("productId");
-
--- CreateIndex
-CREATE INDEX "Event_type_createdAt_idx" ON "Event"("type", "createdAt");
-
--- CreateIndex
-CREATE INDEX "Notification_channel_status_createdAt_idx" ON "Notification"("channel", "status", "createdAt");
-
--- CreateIndex
-CREATE INDEX "Notification_status_nextAttemptAt_idx" ON "Notification"("status", "nextAttemptAt");
-
--- CreateIndex
-CREATE INDEX "Notification_dedupId_idx" ON "Notification"("dedupId");
-
--- CreateIndex
-CREATE INDEX "RateLimit_name_key_bucket_idx" ON "RateLimit"("name", "key", "bucket");
-
--- CreateIndex
-CREATE UNIQUE INDEX "RateLimit_name_key_bucket_key" ON "RateLimit"("name", "key", "bucket");
-
--- CreateIndex
-CREATE INDEX "Waitlist_email_idx" ON "Waitlist"("email");
-
--- CreateIndex
-CREATE INDEX "Waitlist_createdAt_idx" ON "Waitlist"("createdAt");
-
--- AddForeignKey
-ALTER TABLE "Product" ADD CONSTRAINT "Product_producerId_fkey" FOREIGN KEY ("producerId") REFERENCES "Producer"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
+-- AlterTable: Add AG130 fields to OrderItem
+ALTER TABLE "OrderItem" ADD COLUMN "slug" TEXT;
+ALTER TABLE "OrderItem" ADD COLUMN "currency" TEXT DEFAULT 'EUR';


### PR DESCRIPTION
## Critical Production Migration Fix

**Problem**: Migration.sql contained Prisma warning text and full CREATE TABLE statements instead of ALTER TABLE changes
**Error**:  in production migration

**Solution**: Cleaned migration.sql to contain only AG130-specific ALTER TABLE statements:
- Make Order fields nullable (buyerPhone, buyerName, etc.)
- Add AG130 Order columns (email, name, phone, address, city, zip, zone, subtotal, shipping, currency)
- Add Order email index
- Make OrderItem productId/producerId nullable
- Add OrderItem slug/currency columns

**Impact**: Blocks production checkout endpoint from working

**Next**: Merge immediately → Run Production Migration → Deploy → Verify