### PR TITLE
fix: Use correct host in checkout success redirect

### DIFF
--- a/frontend/src/app/checkout/success/route.ts
+++ b/frontend/src/app/checkout/success/route.ts
@@ -3,6 +3,11 @@ import { NextRequest, NextResponse } from 'next/server';
 export async function GET(req: NextRequest) {
   const u = new URL(req.url);
   const id = u.searchParams.get('orderId') || u.searchParams.get('order') || '';
-  const to = new URL(`/checkout/confirmation${id ? `?orderId=${encodeURIComponent(id)}` : ''}`, u.origin);
+
+  // Use NEXT_PUBLIC_BASE_URL if set, otherwise use host from request headers
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ||
+    `${u.protocol}//${req.headers.get('host') || u.host}`;
+
+  const to = new URL(`/checkout/confirmation${id ? `?orderId=${encodeURIComponent(id)}` : ''}`, baseUrl);
   return NextResponse.redirect(to, { status: 307 });
 }


### PR DESCRIPTION
## Problem
The `/checkout/success` redirect was using `req.url` origin which returned `localhost:3000` when behind Nginx proxy, resulting in redirect Location headers pointing to localhost instead of the public domain (dixis.io).

## Solution
- Updated redirect route to use `NEXT_PUBLIC_BASE_URL` environment variable
- Falls back to `Host` header from request if env var not available
- Ensures redirect Location header uses correct public domain

## Changes
- Modified `frontend/src/app/checkout/success/route.ts`
- Added logic to prefer NEXT_PUBLIC_BASE_URL over req.url origin
- Fallback to Host header for cases where env var not set

## Testing
- [ ] Build passes
- [ ] Redirect uses https://dixis.io in Location header (not localhost:3000)
- [ ] 307 status code maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)