### PR TITLE
AG133 — API rate limiting (cart/checkout/orders-lookup)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -91,3 +91,9 @@ NEXT_PUBLIC_SHIP_ISLANDS_PERITEM=1.1
 # Ops API token (set only on VPS; not in repo)
 # Use a strong random string. Example: OPS_ADMIN_TOKEN=change-me-in-prod
 OPS_ADMIN_TOKEN=
+
+# API Rate Limiting (middleware)
+# Παράδειγμα: 60 req/60s με μικρό burst
+RL_WINDOW_MS=60000
+RL_MAX=60
+RL_BURST=30

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,8 +1,68 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
+// Rate limiting configuration
+const WINDOW_MS = Number(process.env.RL_WINDOW_MS ?? '60000'); // 60s
+const MAX = Number(process.env.RL_MAX ?? '60');                // 60 req/60s
+const BURST = Number(process.env.RL_BURST ?? '30');            // +30 burst
+
+type Bucket = { tokens: number; last: number };
+const buckets = new Map<string, Bucket>(); // in-memory, per-process
+
+const API_GROUPS: { rx: RegExp; cost: number }[] = [
+  { rx: /^\/api\/checkout$/, cost: 5 },         // πιο ακριβή
+  { rx: /^\/api\/orders\/lookup$/, cost: 2 },
+  { rx: /^\/api\/cart(\/.*)?$/, cost: 1 },
+];
+
+function matchGroup(pathname: string) {
+  return API_GROUPS.find(g => g.rx.test(pathname));
+}
+
+function applyRateLimit(req: NextRequest): NextResponse | null {
+  const { pathname } = new URL(req.url);
+  const group = matchGroup(pathname);
+  if (!group) return null;
+
+  // bypass με ops token (operational scripts)
+  if (req.headers.get('x-ops-token')) return null;
+
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    req.headers.get('x-real-ip') ||
+    'unknown';
+
+  const key = `${ip}:${group.rx.source}`;
+  const now = Date.now();
+  const refillRate = MAX / WINDOW_MS; // tokens per ms
+
+  const bucket = buckets.get(key) ?? { tokens: MAX + BURST, last: now };
+  const elapsed = now - bucket.last;
+  bucket.tokens = Math.min(MAX + BURST, bucket.tokens + elapsed * refillRate);
+  bucket.last = now;
+
+  const cost = group.cost;
+  if (bucket.tokens < cost) {
+    const retryMs = Math.ceil((cost - bucket.tokens) / refillRate);
+    const res = NextResponse.json({ error: 'Too Many Requests' }, { status: 429 });
+    res.headers.set('Retry-After', String(Math.max(1, Math.ceil(retryMs / 1000))));
+    res.headers.set('X-RateLimit-Limit', String(MAX));
+    res.headers.set('X-RateLimit-Remaining', String(Math.max(0, Math.floor(bucket.tokens))));
+    return res;
+  }
+
+  bucket.tokens -= cost;
+  buckets.set(key, bucket);
+  return null;
+}
+
 export function middleware(req: NextRequest) {
   const url = req.nextUrl;
+
+  // Apply rate limiting first
+  const rateLimitResponse = applyRateLimit(req);
+  if (rateLimitResponse) return rateLimitResponse;
+
   const res = NextResponse.next();
 
   // Security headers (lightweight, συμβατά)

--- a/frontend/tests/e2e/rate-limit.spec.ts
+++ b/frontend/tests/e2e/rate-limit.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('orders/lookup hits 429 after many rapid requests', async ({ request }) => {
+  // στείλε γρήγορα αρκετά αιτήματα μέχρι να πάρεις 429 (χωρίς email/orderId valid δεν μας νοιάζει)
+  let got429 = false;
+  for (let i = 0; i < 90; i++) {
+    const r = await request.post('/api/orders/lookup', {
+      data: { email: 'bot@example.com', orderId: 'non-existent' }
+    });
+    if (r.status() === 429) { got429 = true; break; }
+  }
+  expect(got429).toBeTruthy();
+});


### PR DESCRIPTION
## What
- Middleware rate limit για /api/cart, /api/checkout, /api/orders/lookup
- Token bucket algorithm (in-memory per process)
- Cost-based: checkout=5 tokens, lookup=2 tokens, cart=1 token
- 429 JSON response με Retry-After & X-RateLimit-* headers
- Configuration knobs στο `.env.example`: RL_WINDOW_MS, RL_MAX, RL_BURST
- E2E smoke test που επαληθεύει 429 under load

## Implementation Details
- **Algorithm**: Token bucket με refill rate
- **Default limits**: 60 req/60s + 30 burst tokens
- **Per-IP tracking**: Χρησιμοποιεί x-forwarded-for header
- **Bypass**: Requests με x-ops-token header παρακάμπτουν rate limiting
- **Headers**: 
  - `Retry-After`: Seconds until retry allowed
  - `X-RateLimit-Limit`: Total limit
  - `X-RateLimit-Remaining`: Remaining tokens

## Notes
- **In-memory storage**: Σε multi-process/replicas απαιτείται shared store (π.χ. Redis)
- **Current setup**: VPS/PM2 single process - in-memory είναι αρκετό
- **Preserves existing middleware**: Security headers και admin guard διατηρούνται
- **Cost weights**: Checkout είναι πιο "ακριβή" (5×) από cart (1×)

## Test Plan
- [x] Build succeeds
- [x] E2E test επαληθεύει 429 behavior
- [ ] Manual test: rapid requests to /api/orders/lookup → 429
- [ ] Verify Retry-After header present in 429 responses