### PR TITLE
fix(prisma): remove dotenv import for proper env loading

### DIFF
--- a/frontend/prisma.config.ts
+++ b/frontend/prisma.config.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import 'dotenv/config';
 import { defineConfig } from 'prisma/config';
 
 export default defineConfig({


### PR DESCRIPTION
## Problem
Deployment failing with Prisma error:
```
Prisma config detected, skipping environment variable loading.
Error: the URL must start with the protocol `postgresql://` or `postgres://`.
```

## Root Cause
The `prisma.config.ts` file imports `dotenv/config`, causing Prisma to skip loading environment variables from `.env` files and process env.

## Solution
Remove `import 'dotenv/config'` from `prisma.config.ts` to allow Prisma to load `DATABASE_URL` properly from:
- Environment variables set by deployment workflow
- `.env` files written by deployment workflow

## Testing
- ✅ Local build passes
- ⏳ Will verify deployment after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)