### PR TITLE
AG132.1 — Sentry wiring (errors & perf)

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 import path from "path";
 import createNextIntlPlugin from 'next-intl/plugin';
+import { withSentryConfig } from '@sentry/nextjs';
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
@@ -47,4 +48,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withNextIntl(nextConfig);
+export default withSentryConfig(withNextIntl(nextConfig), { silent: true });

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN,
+  tracesSampleRate: 0.05,
+  enabled: !!(process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN),
+});

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+  tracesSampleRate: 0.15,
+  profilesSampleRate: 0.1,
+  enabled: !!process.env.SENTRY_DSN,
+});

--- a/frontend/src/app/api/cart/route.ts
+++ b/frontend/src/app/api/cart/route.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { NextResponse, NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { cookies } from 'next/headers';

--- a/frontend/src/app/api/checkout/route.ts
+++ b/frontend/src/app/api/checkout/route.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { calcShippingFromSummary, type Zone } from '@/lib/shipping';

--- a/frontend/src/app/api/ops/orders/route.ts
+++ b/frontend/src/app/api/ops/orders/route.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 

--- a/frontend/src/app/api/ops/test-error/route.ts
+++ b/frontend/src/app/api/ops/test-error/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    throw new Error('DIXIS Sentry test error');
+  } catch (e) {
+    try {
+      Sentry.captureException(e);
+    } catch {}
+    return NextResponse.json({ ok: false, sentry: true });
+  }
+}

--- a/frontend/src/app/api/orders/lookup/route.ts
+++ b/frontend/src/app/api/orders/lookup/route.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 
@@ -30,7 +31,10 @@ export async function POST(req: NextRequest) {
         id: it.id, slug: it.slug, qty: it.qty, price: Number(it.price), currency: it.currency
       })),
     });
-  } catch {
+  } catch (e) {
+    try {
+      Sentry.captureException(e);
+    } catch {}
     return NextResponse.json({ error: 'Server error' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## What
- Add @sentry/nextjs dependency
- Create sentry.server.config.ts & sentry.client.config.ts
- Wrap next.config with withSentryConfig (silent mode)
- Add Sentry imports to key API routes (checkout, cart, orders/lookup, ops/orders)
- Hook Sentry.captureException in orders/lookup catch block
- Add ops test route: /api/ops/test-error

## Configuration
- **Server**: 15% traces sample rate, 10% profiling
- **Client**: 5% traces sample rate
- **Enabled**: Only when SENTRY_DSN is set (no-op otherwise)

## After merge
1. Set `SENTRY_DSN` (+ optionally `NEXT_PUBLIC_SENTRY_DSN`) on VPS .env
2. Rebuild & restart
3. Hit `/api/ops/test-error` and confirm event in Sentry

## Testing
- ✅ Build passes locally
- ✅ Sentry configs created (server & client)
- ✅ next.config wrapped with Sentry
- ✅ Test error route created at /api/ops/test-error

🤖 Generated with [Claude Code](https://claude.com/claude-code)