### PR TITLE
AG200.1 — Strip quotes from DATABASE_URL secrets (Prisma P1012 final fix)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -56,7 +56,9 @@ jobs:
 
             # --- DATABASE_URL guard (raw/unpooled for migrations)
             if [ -n \"${DBURL:-}\" ]; then
-              export DATABASE_URL=\"${DBURL}\"
+              # Strip quotes from secret value (Prisma P1012 fix)
+              DB_CLEAN=\"${DBURL}\"; DB_CLEAN=\"\${DB_CLEAN%\"\"}\"; DB_CLEAN=\"\${DB_CLEAN#\"\"}\"
+              export DATABASE_URL=\"\$DB_CLEAN\"
             elif [ -f prisma/.env ]; then
               DB_LINE=\$(grep -E \"^DATABASE_URL=\" prisma/.env || true)
               DB_VAL=\"\${DB_LINE#DATABASE_URL=}\"; DB_VAL=\"\${DB_VAL%\"\"}\"; DB_VAL=\"\${DB_VAL#\"\"}\"
@@ -66,7 +68,9 @@ jobs:
 
             # --- RUNTIME_DBURL (can be pooled, fallback to raw)
             if [ -n \"${RUNTIME_DBURL:-}\" ]; then
-              export RUNTIME_DATABASE_URL=\"${RUNTIME_DBURL}\"
+              # Strip quotes from secret value
+              RT_CLEAN=\"${RUNTIME_DBURL}\"; RT_CLEAN=\"\${RT_CLEAN%\"\"}\"; RT_CLEAN=\"\${RT_CLEAN#\"\"}\"
+              export RUNTIME_DATABASE_URL=\"\$RT_CLEAN\"
             else
               export RUNTIME_DATABASE_URL=\"\$DATABASE_URL\"
             fi


### PR DESCRIPTION
## Why
Prisma P1012 error persisted because GitHub secrets may contain quotes. When prisma.config.ts is present, Prisma skips .env files and reads from environment variables directly.

## What
- Strip leading/trailing quotes from DBURL secret before export
- Strip quotes from RUNTIME_DBURL secret before export
- Ensures DATABASE_URL environment variable is clean for Prisma

## Root Cause
`prisma.config.ts` presence causes Prisma to skip .env file loading and read DATABASE_URL directly from shell environment. If the GitHub secret contains quotes, they become part of the environment variable value, causing P1012 validation error.