### PR TITLE
AG200.2 — Remove prisma.config.ts to fix P1012 error

### DIFF
--- a/frontend/prisma.config.ts
+++ b/frontend/prisma.config.ts
@@ -1,8 +1,0 @@
-import path from 'node:path';
-import { defineConfig } from 'prisma/config';
-
-export default defineConfig({
-  // paths are relative to this file
-  schema: path.join('prisma', 'schema.prisma'),
-  migrations: { path: path.join('prisma', 'migrations') },
-});


### PR DESCRIPTION
## Why
prisma.config.ts causes Prisma to skip .env file loading, which breaks deployment when DATABASE_URL needs to come from prisma/.env file.

## What
- Delete frontend/prisma.config.ts
- Restores default Prisma behavior: reads from .env files
- Fixes P1012 error in deploy workflow

## Root Cause
When prisma.config.ts exists, Prisma logs "Prisma config detected, skipping environment variable loading" and only reads from process.env, not from .env files. This breaks our deploy workflow which writes DATABASE_URL to prisma/.env file.