### PR TITLE
AG135 — Public tracking token for orders

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -12,6 +12,7 @@ const buckets = new Map<string, Bucket>(); // in-memory, per-process
 const API_GROUPS: { rx: RegExp; cost: number }[] = [
   { rx: /^\/api\/checkout$/, cost: 5 },         // πιο ακριβή
   { rx: /^\/api\/orders\/lookup$/, cost: 2 },
+  { rx: /^\/api\/orders\/track$/, cost: 2 },    // public tracking
   { rx: /^\/api\/cart(\/.*)?$/, cost: 1 },
 ];
 

--- a/frontend/src/app/api/checkout/route.ts
+++ b/frontend/src/app/api/checkout/route.ts
@@ -79,7 +79,7 @@ export async function POST(req: NextRequest) {
         }))
       }
     },
-    select: { id:true }
+    select: { id:true, publicToken:true }
   });
 
   // Fire-and-forget email receipt (don't block response)
@@ -88,6 +88,7 @@ export async function POST(req: NextRequest) {
       await sendOrderReceipt({
         to: customer.email,
         orderId: order.id,
+        publicToken: order.publicToken,
         total,
         currency: 'EUR',
         items: lines,

--- a/frontend/src/app/api/ops/backfill-public-tokens/route.ts
+++ b/frontend/src/app/api/ops/backfill-public-tokens/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import crypto from 'crypto';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  const ops = process.env.OPS_ADMIN_TOKEN;
+  if (!ops || req.headers.get('x-ops-token') !== ops) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  // Find orders without publicToken and generate UUIDs
+  const ordersToUpdate = await prisma.order.findMany({
+    where: {
+      OR: [
+        { publicToken: null },
+        { publicToken: '' }
+      ]
+    },
+    select: { id: true }
+  });
+
+  let updated = 0;
+  for (const order of ordersToUpdate) {
+    await prisma.order.update({
+      where: { id: order.id },
+      data: { publicToken: crypto.randomUUID() }
+    });
+    updated++;
+  }
+
+  return NextResponse.json({ ok: true, updated });
+}

--- a/frontend/src/app/api/orders/track/route.ts
+++ b/frontend/src/app/api/orders/track/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export const dynamic = 'force-dynamic';
+
+async function handle(bodyOrQuery: any) {
+  const token = String(bodyOrQuery?.token ?? '').trim();
+  if (!token) return NextResponse.json({ error: 'Missing token' }, { status: 400 });
+
+  const ord = await prisma.order.findFirst({
+    where: { publicToken: token },
+    include: { items: true }
+  });
+
+  if (!ord) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  return NextResponse.json({
+    id: ord.id,
+    createdAt: ord.createdAt,
+    email: ord.email,
+    subtotal: Number(ord.subtotal ?? 0),
+    shipping: Number(ord.shipping ?? 0),
+    total: Number(ord.total ?? 0),
+    currency: ord.currency ?? 'EUR',
+    items: ord.items.map(it => ({
+      id: it.id,
+      slug: it.slug,
+      qty: it.qty,
+      price: Number(it.price),
+      currency: it.currency
+    })),
+    token: ord.publicToken,
+  });
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const token = url.searchParams.get('token');
+  return handle({ token });
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  return handle(body);
+}

--- a/frontend/src/app/orders/track/[token]/page.tsx
+++ b/frontend/src/app/orders/track/[token]/page.tsx
@@ -1,7 +1,38 @@
-import { redirect } from 'next/navigation'
+import { notFound } from 'next/navigation';
 
-export default function Page({ params }:{ params:{ token:string } }){
-  redirect(`/track/${params.token}`)
+export const dynamic = 'force-dynamic';
+export const metadata = { robots: { index:false, follow:false } };
+
+async function getOrder(token: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001';
+  const res = await fetch(`${baseUrl}/api/orders/track?token=${encodeURIComponent(token)}`, {
+    cache: 'no-store'
+  });
+  if (!res.ok) return null;
+  return res.json();
 }
 
-export const metadata = { robots: { index:false, follow:false } }
+export default async function TrackPage({ params }: { params: { token: string } }) {
+  const data = await getOrder(params.token);
+  if (!data) notFound();
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-2">Παρακολούθηση Παραγγελίας</h1>
+      <p className="text-sm text-neutral-700">
+        Κωδικός: <strong>{data.id}</strong>
+      </p>
+      <p className="text-sm mt-1">
+        Σύνολο: <strong>{Number(data.total).toFixed(2)} {data.currency}</strong>
+      </p>
+      <h2 className="mt-4 font-semibold">Είδη</h2>
+      <ul className="list-disc ml-5 text-sm">
+        {data.items?.map((it: any) => (
+          <li key={it.id}>
+            {it.slug} × {it.qty} — {Number(it.price).toFixed(2)} {it.currency}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/src/lib/mailer.ts
+++ b/frontend/src/lib/mailer.ts
@@ -15,6 +15,7 @@ export async function sendOrderReceipt(params: {
   orderId: string;
   total: number;
   currency: string;
+  publicToken?: string;
   items: Array<{
     slug: string;
     qty: number;
@@ -25,14 +26,18 @@ export async function sendOrderReceipt(params: {
   const transport = getTransport();
   if (!transport) return { ok: false, reason: 'smtp-missing' };
 
-  const { to, orderId, total, currency, items } = params;
+  const { to, orderId, total, currency, publicToken, items } = params;
   const lines = items
     .map(
       (it) =>
         `• ${it.slug} × ${it.qty} — ${Number(it.price).toFixed(2)} ${it.currency}`
     )
     .join('\n');
-  const receiptUrl = `https://dixis.io/orders/receipt/${encodeURIComponent(orderId)}`;
+
+  // Prefer public tracking URL if token exists, fallback to receipt URL
+  const receiptUrl = publicToken
+    ? `https://dixis.io/orders/track/${publicToken}`
+    : `https://dixis.io/orders/receipt/${encodeURIComponent(orderId)}`;
 
   const text = [
     `Ευχαριστούμε για την παραγγελία σας!`,

--- a/frontend/tests/e2e/order-track.spec.ts
+++ b/frontend/tests/e2e/order-track.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('orders track API returns 400 without token', async ({ request }) => {
+  const r = await request.get('/api/orders/track');
+  expect(r.status()).toBe(400);
+  const body = await r.json();
+  expect(body.error).toBe('Missing token');
+});
+
+test('orders track API returns 404 with invalid token', async ({ request }) => {
+  const r = await request.get('/api/orders/track?token=invalid-token-12345');
+  expect(r.status()).toBe(404);
+});


### PR DESCRIPTION
## What
- Prisma: Order.publicToken already exists with @default(uuid())
- Checkout: select publicToken and pass to mailer
- Mailer: prefer `/orders/track/<token>` link over receipt URL
- Public API: `/api/orders/track` (GET/POST) with token param
- Page: `/orders/track/[token]` displays order details
- Ops endpoint: `/api/ops/backfill-public-tokens` (requires x-ops-token) for existing orders
- Rate limiter: includes `/api/orders/track` in middleware matcher
- E2E tests: order-track.spec.ts

## After merge
- No migration needed - publicToken field already exists with default
- One-off: POST `/api/ops/backfill-public-tokens` with `x-ops-token` header for existing orders without tokens
- Smoke test: open `/orders/track/<token>` from a new order email link

## Testing
```bash
# Build successful
pnpm build

# E2E tests added
npx playwright test tests/e2e/order-track.spec.ts
```

Generated with Claude Code