### PR TITLE
AG-API-URL-01 — Fix Invalid URL for server /api calls

### DIFF
--- a/frontend/src/app/Home.tsx
+++ b/frontend/src/app/Home.tsx
@@ -1,10 +1,11 @@
 import { Product } from '@/lib/api';
 import HomeClient from './HomeClient';
 import { getTranslations } from 'next-intl/server';
+import { abs } from '@/lib/url';
 
 async function getInitialProducts(): Promise<Product[]> {
   try {
-    const url = '/api/products?pageSize=20';
+    const url = abs('/api/products?pageSize=20');
     const res = await fetch(url, { cache: 'no-store' });
 
     if (!res.ok) {

--- a/frontend/src/lib/url.ts
+++ b/frontend/src/lib/url.ts
@@ -1,0 +1,8 @@
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://dixis.io';
+
+export function abs(path: string): string {
+  if (!path) return SITE_URL;
+  // ensure path starts with /
+  const p = path.startsWith('/') ? path : `/${path}`;
+  return new URL(p, SITE_URL).toString();
+}


### PR DESCRIPTION
## 🎯 Problem

Production logs showed `ERR_INVALID_URL` errors from server-side fetch() calls:
```
TypeError: Invalid URL
  code: 'ERR_INVALID_URL',
  input: '/api/products?pageSize=20'
```

Next.js server components cannot use relative URLs with `new URL()` in Node.js runtime.

## ✅ Solution

Created centralized URL helper that constructs absolute URLs:

**New file: `src/lib/url.ts`**
- Exports `abs()` function that prepends `NEXT_PUBLIC_SITE_URL` to paths
- Defaults to `https://dixis.io` in production
- Handles paths with/without leading slash

**Updated: `src/app/Home.tsx`**
- Changed `/api/products?pageSize=20` to `abs('/api/products?pageSize=20')`
- Fixes server-side fetch() calls

## 🧪 Test Evidence

- ✅ Build passed successfully
- ✅ All TypeScript checks passed
- ✅ No breaking changes to API

## 📊 Impact

- Fixes ERR_INVALID_URL crashes on production homepage
- Enables proper server-side data fetching
- No changes to client-side behavior

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)