### PR TITLE
AG-OPS-05 — Harden email-order (rate/size/schema) + checkout x-flow header

### DIFF
--- a/frontend/src/app/api/ops/email-order/route.ts
+++ b/frontend/src/app/api/ops/email-order/route.ts
@@ -1,20 +1,100 @@
 import { NextResponse } from 'next/server';
 import { sendMail } from '@/server/mailer';
 
-export async function POST(req: Request){
-  try{
-    const body = await req.json();
-    const to = process.env.ADMIN_EMAIL;
-    if(!to) return NextResponse.json({ ok:false, error:'no-admin-email' }, { status: 500 });
+// Rate limiting: 10 req/min per IP
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 10;
+const _bucket = new Map<string, { c: number; ts: number }>();
 
-    const customer = body?.customer || {};
+function ipOf(req: Request): string {
+  const get = (n: string) => (req.headers.get(n) || '') + '';
+  const xff = (get('x-forwarded-for') || get('cf-connecting-ip') || get('x-real-ip')).split(',')[0].trim();
+  return xff || 'unknown';
+}
+
+function allow(ip: string): boolean {
+  const now = Date.now();
+  const v = _bucket.get(ip);
+  if (!v || now - v.ts > RATE_LIMIT_WINDOW_MS) {
+    _bucket.set(ip, { c: 1, ts: now });
+    return true;
+  }
+  v.c++;
+  v.ts = now;
+  _bucket.set(ip, v);
+  return v.c <= RATE_LIMIT_MAX;
+}
+
+// Field clipping
+function clip(v: any, n = 256): string {
+  return (v ?? '').toString().trim().slice(0, n);
+}
+
+export async function POST(req: Request) {
+  try {
+    // Size guard: 8KB limit
+    const len = Number(req.headers.get('content-length') || '0');
+    if (len > 8192) {
+      return NextResponse.json({ ok: false, error: 'payload-too-large' }, { status: 413 });
+    }
+
+    // Rate limiting
+    const ip = ipOf(req);
+    if (!allow(ip)) {
+      return NextResponse.json({ ok: false, error: 'rate-limited' }, { status: 429 });
+    }
+
+    const body = await req.json();
+
+    // Optional header check (x-flow: checkout)
+    const reqhdr = (req.headers.get('x-flow') || '').toString();
+    if (reqhdr && reqhdr !== 'checkout') {
+      return NextResponse.json({ ok: false, error: 'bad-origin' }, { status: 400 });
+    }
+
+    // Field clipping and validation
+    const customer = {
+      name: clip(body?.customer?.name || body?.customer?.fullName || body?.name),
+      phone: clip(body?.customer?.phone || body?.phone, 32),
+      email: clip(body?.customer?.email || body?.email, 128),
+      address: clip(body?.customer?.address || body?.address, 256),
+      city: clip(body?.customer?.city || body?.city, 128),
+      postcode: clip(body?.customer?.postcode || body?.postcode, 16),
+      notes: clip(body?.customer?.notes || body?.notes, 512),
+    };
+
+    if (!customer.name || !customer.phone) {
+      return NextResponse.json({ ok: false, error: 'missing-fields' }, { status: 400 });
+    }
+
+    const to = process.env.ADMIN_EMAIL;
+    if (!to) {
+      return NextResponse.json({ ok: false, error: 'no-admin-email' }, { status: 500 });
+    }
+
     const items = Array.isArray(body?.items) ? body.items : [];
-    const totals = body?.totals || {};
-    const lines = items.map((it:any)=>`• ${it.title} × ${it.qty} — ${(Number(it.price)*Number(it.qty)).toFixed(2)} ${it.currency||'EUR'}`).join('\n');
-    const text = `ΝΕΑ ΠΑΡΑΓΓΕΛΙΑ (demo)\n\nΠελάτης: ${customer.name}\nΤηλέφωνο: ${customer.phone}\nEmail: ${customer.email||'-'}\nΔιεύθυνση: ${customer.address}, ${customer.city} ${customer.postcode}\nΣημειώσεις: ${customer.notes||'-'}\n\nΕίδη:\n${lines}\n\nΣύνολο: ${Number(totals.grand||totals.items||0).toFixed(2)} EUR\n`;
+    const lines = items.map((it: any) =>
+      `• ${clip(it.title, 80)} × ${Number(it.qty || 1)} — ${(Number(it.price || 0) * Number(it.qty || 1)).toFixed(2)} ${it.currency || 'EUR'}`
+    ).join('\n');
+
+    const text = [
+      'ΝΕΑ ΠΑΡΑΓΓΕΛΙΑ (demo)',
+      '',
+      `Πελάτης: ${customer.name}`,
+      `Τηλέφωνο: ${customer.phone}`,
+      `Email: ${customer.email || '-'}`,
+      `Διεύθυνση: ${customer.address}, ${customer.city} ${customer.postcode}`,
+      `Σημειώσεις: ${customer.notes || '-'}`,
+      '',
+      'Είδη:',
+      lines || '-',
+      '',
+      `Σύνολο: ${Number((body?.totals?.grand ?? body?.totals?.items) || 0).toFixed(2)} EUR`,
+    ].join('\n');
+
     await sendMail({ to, subject: 'Dixis — Νέα παραγγελία (demo)', text });
-    return NextResponse.json({ ok:true }, { status: 200 });
-  }catch(err:any){
-    return NextResponse.json({ ok:false, error: err?.message || 'email-failed' }, { status: 500 });
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err: any) {
+    return NextResponse.json({ ok: false, error: err?.message || 'email-failed' }, { status: 500 });
   }
 }

--- a/frontend/src/components/checkout/CheckoutSummary.tsx
+++ b/frontend/src/components/checkout/CheckoutSummary.tsx
@@ -32,7 +32,7 @@ export default function CheckoutSummary(){
     try {
       sessionStorage.setItem('dixis:last-order', JSON.stringify(payload));
       // Προσπάθεια αποστολής email (δεν μπλοκάρει την ολοκλήρωση)
-      try { fetch('/api/ops/email-order', { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(payload) }); } catch {}
+      try { fetch('/api/ops/email-order', { method:'POST', headers:{'content-type':'application/json','x-flow':'checkout'}, body: JSON.stringify(payload) }); } catch {}
       clear();
       window.location.href = '/checkout/confirmation';
     } catch (e) {


### PR DESCRIPTION
Προσθήκη anti-spam μέτρων στο email-order endpoint:
- Rate limiting: 10 αιτήματα/λεπτό ανά IP (429)
- Size guard: απόρριψη payloads > 8KB (413)
- Field clipping: 256 chars για τα περισσότερα πεδία, 512 για notes
- Origin header check: x-flow: checkout (400 για bad-origin)
- Προσθήκη x-flow: checkout header στο CheckoutSummary component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
