### PR TITLE
Mail: disable CI-skip in production

### DIFF
--- a/frontend/src/lib/mail.ts
+++ b/frontend/src/lib/mail.ts
@@ -1,7 +1,7 @@
 import nodemailer from "nodemailer";
 
 export async function sendMail(to: string, subject: string, html: string, replyTo?: string) {
-  if (process.env.CI === "true") return { ok: true, id: "ci-skip" }; // avoid real send in CI
+  if (process.env.CI === "true" && process.env.NODE_ENV !== "production") return { ok: true, id: "ci-skip" }; // avoid real send in CI
   const host = process.env.SMTP_HOST!;
   const port = Number(process.env.SMTP_PORT ?? 465);
   const secure = String(process.env.SMTP_SECURE ?? "true") === "true";


### PR DESCRIPTION
## Αλλαγές

Τροποποίηση του CI guard στο `mail.ts` για να επιτρέπει αποστολή πραγματικών email σε production.

### Τεχνικά

**Αρχείο**: `frontend/src/lib/mail.ts:4`

**Πριν**:
```typescript
if (process.env.CI === "true") return { ok: true, id: "ci-skip" };
```

**Μετά**:
```typescript
if (process.env.CI === "true" && process.env.NODE_ENV !== "production") return { ok: true, id: "ci-skip" };
```

### Λειτουργικότητα

- ✅ Tests: Παραλείπουν αποστολή email (CI=true, NODE_ENV=test)
- ✅ Production: Στέλνει πραγματικά emails (NODE_ENV=production)
- ✅ Contact form: Θα λειτουργεί με SMTP στο production

### Evidence

- Build: ✅ 72 routes generated
- Change: frontend/src/lib/mail.ts:4