### PR TITLE
CLEANUP-01 — analysis-only triage scripts

### DIFF
--- a/cleanup-scripts/01-analyze-prs.sh
+++ b/cleanup-scripts/01-analyze-prs.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+echo "🔍 DIXIS PR Analysis Report"
+mkdir -p pr-cleanup-reports
+REPORT_FILE="pr-cleanup-reports/pr-analysis-$(date +%Y%m%d-%H%M%S).md"
+cat > "$REPORT_FILE" << 'EOF'
+# PR Cleanup Analysis Report
+
+## Summary Statistics
+EOF
+TOTAL_PRS=$(gh pr list --state open --limit 200 --json number | jq '. | length')
+echo "- Total Open PRs: $TOTAL_PRS" >> "$REPORT_FILE"
+echo -e "\n## Categories\n" >> "$REPORT_FILE"
+
+echo -e "\n### 🤖 Dependabot Updates\n" >> "$REPORT_FILE"
+gh pr list --state open --author "dependabot[bot]" --limit 100 \
+  --json number,title,createdAt,labels \
+  --jq '.[] | "- PR #\(.number): \(.title) (Created: \(.createdAt | split("T")[0]))"' >> "$REPORT_FILE" || true
+
+CUTOFF_DATE=$(date -d '60 days ago' '+%Y-%m-%d' 2>/dev/null || date -v -60d '+%Y-%m-%d')
+echo -e "\n### 📅 Stale PRs (>60 days old)\n" >> "$REPORT_FILE"
+gh pr list --state open --search "updated:<$CUTOFF_DATE" --limit 100 \
+  --json number,title,author,updatedAt \
+  --jq '.[] | "- PR #\(.number): \(.title) by @\(.author.login) (Last update: \(.updatedAt | split(\"T\")[0]))"' >> "$REPORT_FILE" || true
+
+echo -e "\n### ✅ Approved but Not Merged\n" >> "$REPORT_FILE"
+gh pr list --state open --search "review:approved" --limit 30 \
+  --json number,title \
+  --jq '.[] | "- PR #\(.number): \(.title)"' >> "$REPORT_FILE" || true
+
+echo -e "\n### 📝 Draft PRs\n" >> "$REPORT_FILE"
+gh pr list --state open --draft --limit 50 \
+  --json number,title,author \
+  --jq '.[] | "- PR #\(.number): \(.title) by @\(.author.login)"' >> "$REPORT_FILE" || true
+
+echo -e "\n### ⚠️ PRs with Conflicts\n" >> "$REPORT_FILE"
+gh pr list --state open --limit 200 --json number,title,mergeable \
+  --jq '.[] | select(.mergeable == "CONFLICTING") | "- PR #\(.number): \(.title)"' >> "$REPORT_FILE" || true
+
+cat >> "$REPORT_FILE" << 'EOF'
+
+## 🎯 Recommended Actions
+- Close old Dependabot PRs (>30d)
+- Merge approved PRs with green checks
+- Stale PRs: ping authors or close
+- Conflicts: rebase or close
+
+### Helper Commands
+```bash
+gh pr list --state open --search "review:approved status:success"
+```
+EOF
+
+echo "✅ Saved: $REPORT_FILE"

--- a/cleanup-scripts/04-analyze-issues.sh
+++ b/cleanup-scripts/04-analyze-issues.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+echo "🔍 DIXIS Issue Analysis"
+mkdir -p pr-cleanup-reports
+REPORT_FILE="pr-cleanup-reports/issue-analysis-$(date +%Y%m%d-%H%M%S).md"
+cat > "$REPORT_FILE" << 'EOF'
+# Issue Analysis Report
+
+## Statistics
+EOF
+
+TOTAL_ISSUES=$(gh issue list --state open --limit 200 --json number | jq '. | length')
+echo "- Total Open Issues: $TOTAL_ISSUES" >> "$REPORT_FILE"
+echo -e "\n## By Category\n" >> "$REPORT_FILE"
+
+echo "### 🐛 Bugs" >> "$REPORT_FILE"
+gh issue list --state open --label "bug" --limit 50 \
+  --json number,title,createdAt \
+  --jq '.[] | "- #\(.number): \(.title) (Created: \(.createdAt | split("T")[0]))"' >> "$REPORT_FILE" || true
+
+echo -e "\n### ✨ Feature Requests" >> "$REPORT_FILE"
+gh issue list --state open --label "enhancement" --limit 50 \
+  --json number,title \
+  --jq '.[] | "- #\(.number): \(.title)"' >> "$REPORT_FILE" || true
+
+CUTOFF_90=$(date -d '90 days ago' '+%Y-%m-%d' 2>/dev/null || date -v -90d '+%Y-%m-%d')
+echo -e "\n### 📅 Stale Issues (>90 days)" >> "$REPORT_FILE"
+gh issue list --state open --search "updated:<$CUTOFF_90" --limit 50 \
+  --json number,title,updatedAt \
+  --jq '.[] | "- #\(.number): \(.title) (Last: \(.updatedAt | split("T")[0]))"' >> "$REPORT_FILE" || true
+
+echo -e "\n## 📋 Action Items\n" >> "$REPORT_FILE"
+cat >> "$REPORT_FILE" << 'EOF'
+1. Close stale (>90d) after ping
+2. Label unlabeled (needs-triage)
+3. Prioritize P0/P1/P2
+4. Group in milestones
+EOF
+echo "✅ Saved: $REPORT_FILE"

--- a/cleanup-scripts/06-create-dashboard.sh
+++ b/cleanup-scripts/06-create-dashboard.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+mkdir -p pr-cleanup-reports
+DASH="pr-cleanup-reports/DASHBOARD.md"
+OPEN_PRS=$(gh pr list --state open --json number | jq '. | length')
+OPEN_ISSUES=$(gh issue list --state open --json number | jq '. | length')
+DRAFT_PRS=$(gh pr list --state open --draft --json number | jq '. | length')
+APPROVED_PRS=$(gh pr list --state open --search "review:approved" --json number | jq '. | length')
+DEPENDABOT_PRS=$(gh pr list --state open --author "dependabot[bot]" --json number | jq '. | length')
+STALE_ISSUES=$(gh issue list --state open --search "updated:<$(date -d '90 days ago' '+%Y-%m-%d' 2>/dev/null || date -v -90d '+%Y-%m-%d')" --json number | jq '. | length')
+UNLABELED_ISSUES=$(gh issue list --state open --search "no:label" --json number | jq '. | length')
+
+cat > "$DASH" <<EOF
+# 📊 DIXIS Cleanup Dashboard
+
+Generated: $(date '+%Y-%m-%d %H:%M:%S EET')
+
+## 📈 Current Metrics
+- Open PRs: $OPEN_PRS
+- Open Issues: $OPEN_ISSUES
+- Draft PRs: $DRAFT_PRS
+- Approved PRs: $APPROVED_PRS
+- Dependabot PRs: $DEPENDABOT_PRS
+- Stale Issues (>90d): $STALE_ISSUES
+- Unlabeled Issues: $UNLABELED_ISSUES
+
+## Quick Commands
+
+\`\`\`bash
+gh pr list --state open --search "review:approved"
+gh pr list --state open --author "dependabot[bot]"
+gh issue list --state open --search "no:label"
+\`\`\`
+EOF
+echo "✅ Saved: $DASH"

--- a/docs/OPS/CLEANUP-QUICKSTART.md
+++ b/docs/OPS/CLEANUP-QUICKSTART.md
@@ -1,0 +1,17 @@
+# 🚀 CLEANUP-01 (Analysis Only)
+
+**Prereqs**: `gh` logged in (`gh auth status`), `jq` installed.
+
+## Run
+
+```bash
+bash cleanup-scripts/01-analyze-prs.sh
+bash cleanup-scripts/04-analyze-issues.sh
+bash cleanup-scripts/06-create-dashboard.sh
+```
+
+## Outputs
+
+Outputs in `pr-cleanup-reports/` (Markdown).
+
+⚠️ Δεν κλείνουν/γίνονται merge PRs σε αυτό το pass.


### PR DESCRIPTION
Adds non-destructive PR/Issue analysis scripts and dashboard (outputs in pr-cleanup-reports/).

## Scripts
- : Analyzes open PRs (dependabot, stale, approved, drafts, conflicts)
- : Analyzes issues (bugs, features, stale)  
- : Creates metrics dashboard

## Documentation  
- : Quick-start guide

⚠️ **Analysis only**: No PRs/Issues closed or merged automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)