### PR TITLE
ops: cleanup scripts suite (no reports)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ junit-*.xml
 # Dixis Skill artifacts (local-only)
 .dixis-skill/
 dixis-skill_v*.zip
+pr-cleanup-reports/

--- a/cleanup-scripts/01-analyze-prs.sh
+++ b/cleanup-scripts/01-analyze-prs.sh
@@ -21,7 +21,7 @@ CUTOFF_DATE=$(date -d '60 days ago' '+%Y-%m-%d' 2>/dev/null || date -v -60d '+%Y
 echo -e "\n### 📅 Stale PRs (>60 days old)\n" >> "$REPORT_FILE"
 gh pr list --state open --search "updated:<$CUTOFF_DATE" --limit 100 \
   --json number,title,author,updatedAt \
-  --jq '.[] | "- PR #\(.number): \(.title) by @\(.author.login) (Last update: \(.updatedAt | split(\"T\")[0]))"' >> "$REPORT_FILE" || true
+  --jq '.[] | "- PR #\(.number): \(.title) by @\(.author.login) (Last update: \(.updatedAt | split("T")[0]))"' >> "$REPORT_FILE" || true
 
 echo -e "\n### ✅ Approved but Not Merged\n" >> "$REPORT_FILE"
 gh pr list --state open --search "review:approved" --limit 30 \

--- a/cleanup-scripts/06-create-dashboard.sh
+++ b/cleanup-scripts/06-create-dashboard.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 mkdir -p pr-cleanup-reports
 DASH="pr-cleanup-reports/DASHBOARD.md"
-OPEN_PRS=$(gh pr list --state open --json number | jq '. | length')
-OPEN_ISSUES=$(gh issue list --state open --json number | jq '. | length')
-DRAFT_PRS=$(gh pr list --state open --draft --json number | jq '. | length')
-APPROVED_PRS=$(gh pr list --state open --search "review:approved" --json number | jq '. | length')
-DEPENDABOT_PRS=$(gh pr list --state open --author "dependabot[bot]" --json number | jq '. | length')
+OPEN_PRS=$(gh pr list --state open --limit 200 --json number | jq '. | length')
+OPEN_ISSUES=$(gh issue list --state open --limit 200 --json number | jq '. | length')
+DRAFT_PRS=$(gh pr list --state open --draft --limit 200 --json number | jq '. | length')
+APPROVED_PRS=$(gh pr list --state open --search "review:approved" --limit 200 --json number | jq '. | length')
+DEPENDABOT_PRS=$(gh pr list --state open --author "dependabot[bot]" --limit 200 --json number | jq '. | length')
 STALE_ISSUES=$(gh issue list --state open --search "updated:<$(date -d '90 days ago' '+%Y-%m-%d' 2>/dev/null || date -v -90d '+%Y-%m-%d')" --json number | jq '. | length')
 UNLABELED_ISSUES=$(gh issue list --state open --search "no:label" --json number | jq '. | length')
 

--- a/cleanup-scripts/aggressive-45d.sh
+++ b/cleanup-scripts/aggressive-45d.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -euo pipefail
+cd "/Users/panagiotiskourkoutis/Dixis Project 2/Project-Dixis"
+export GH_REPO="lomendor/Project-Dixis"
+mkdir -p pr-cleanup-reports
+
+echo "=== Aggressive pass: needs-rebase >45d, drafts >30d, merge approved+green, nudge clean PRs ==="
+REPORT="pr-cleanup-reports/auto-close-45d-$(date +%Y%m%d-%H%M%S).md"
+echo "# Auto-Close (>45d & needs-rebase) + Drafts >30d + Batch Merge + Nudge" > "$REPORT"
+echo "" >> "$REPORT"
+
+# macOS cutoffs
+C45="$(date -v -45d +%Y-%m-%d)"
+C30="$(date -v -30d +%Y-%m-%d)"
+PROTECTED='-label:wip -label:do-not-merge -label:keep-open -label:security -label:breaking-change -label:release'
+
+# Ensure labels exist
+gh label create "auto-closed-stale" --color "CFD3D7" --description "Auto-closed due to staleness" --force >/dev/null 2>&1 || true
+gh label create "maintainer-note"   --color "E0F3F8" --description "Maintainer maintenance note" --force >/dev/null 2>&1 || true
+
+echo "=== A) Close needs-rebase >45d (exclude protected) ===" | tee -a "$REPORT"
+TOCLOSE_45=$(gh pr list --state open --search "label:needs-rebase updated:<$C45 $PROTECTED" \
+  --limit 200 --json number,title,updatedAt,url \
+  --jq '.[] | "\(.number)|\(.title)|\(.updatedAt)|\(.url)"')
+
+if [ -n "${TOCLOSE_45}" ]; then
+  echo "$TOCLOSE_45" | while IFS='|' read -r num title upd url; do
+    echo "- #$num (last: ${upd%%T*}) $url — $title" | tee -a "$REPORT"
+    gh pr comment "$num" -b "Auto-close: PR με conflicts (needs-rebase) και χωρίς δραστηριότητα >45 ημέρες. **Κάνε rebase** και ξανά-άνοιξέ το όποτε θες. 😊" || true
+    gh pr edit "$num" --add-label "auto-closed-stale" || true
+    gh pr close "$num" -c "Auto-close: stale conflicting PR (>45d)." || true
+  done
+else
+  echo "No PRs matched >45d & needs-rebase." | tee -a "$REPORT"
+fi
+
+echo -e "\n=== B) Close abandoned drafts >30d ===" | tee -a "$REPORT"
+DRAFTS_30=$(gh pr list --state open --draft --search "updated:<$C30 $PROTECTED" \
+  --limit 200 --json number,title,updatedAt,url \
+  --jq '.[] | "\(.number)|\(.title)|\(.updatedAt)|\(.url)"')
+
+if [ -n "${DRAFTS_30}" ]; then
+  echo "$DRAFTS_30" | while IFS='|' read -r num title upd url; do
+    echo "- #$num (last: ${upd%%T*}) $url — $title" | tee -a "$REPORT"
+    gh pr comment "$num" -b "Auto-close: draft χωρίς ενημέρωση >30 ημέρες. Αν συνεχίζει να σε ενδιαφέρει, βγάλ'το από draft/κάνε rebase και ξανά-άνοιξέ το." || true
+    gh pr edit "$num" --add-label "auto-closed-stale" || true
+    gh pr close "$num" -c "Auto-close: abandoned draft (>30d)." || true
+  done
+else
+  echo "No stale drafts >30d." | tee -a "$REPORT"
+fi
+
+echo -e "\n=== C) Batch merge (approved + checks green) ===" | tee -a "$REPORT"
+APPROVED_OK=$(gh pr list --state open --search "review:approved status:success -label:wip -label:do-not-merge" \
+  --limit 200 --json number,title,url \
+  --jq '.[] | "\(.number)|\(.title)|\(.url)"')
+
+if [ -n "${APPROVED_OK}" ]; then
+  echo "$APPROVED_OK" | while IFS='|' read -r num title url; do
+    echo "• Merging #$num — $title ($url)" | tee -a "$REPORT"
+    gh pr merge "$num" --merge --delete-branch || echo "  ↳ merge failed, check manually" | tee -a "$REPORT"
+  done
+else
+  echo "No approved+green PRs to merge." | tee -a "$REPORT"
+fi
+
+echo -e "\n=== D) Nudge clean (non-conflicting) PRs without approval ===" | tee -a "$REPORT"
+CLEAN_NOAPP=$(gh pr list --state open --limit 200 \
+  --json number,title,mergeable,url \
+  --jq '.[] | select(.mergeable=="MERGEABLE") | "\(.number)|\(.title)|\(.url)"')
+
+if [ -n "${CLEAN_NOAPP}" ]; then
+  echo "$CLEAN_NOAPP" | while IFS='|' read -r num title url; do
+    # Skip ones that are approved already (we tried merge above)
+    IS_APPROVED=$(gh pr view "$num" --json reviews --jq '.reviews | map(select(.state=="APPROVED")) | length')
+    if [ "${IS_APPROVED}" -eq 0 ]; then
+      echo "• Nudge #$num — $title" | tee -a "$REPORT"
+      gh pr comment "$num" -b "Σύντομη ενημέρωση: Χωρίς approvals ακόμα. Αν θες να προχωρήσει, ζήτα review ή πρόσθεσε tests. **Πολιτική**: αν μείνει ανενεργό, θα κλείσει αυτόματα στο επόμενο cleanup. 🙏" || true
+      gh pr edit "$num" --add-label "maintainer-note" || true
+    fi
+  done
+else
+  echo "No clean PRs found to nudge." | tee -a "$REPORT"
+fi
+
+echo -e "\n=== E) Refresh dashboard ==="
+bash cleanup-scripts/06-create-dashboard.sh
+sed -n '1,40p' pr-cleanup-reports/DASHBOARD.md
+
+echo -e "\n✅ Report saved: $REPORT"

--- a/cleanup-scripts/aggressive-close.sh
+++ b/cleanup-scripts/aggressive-close.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+cd "/Users/panagiotiskourkoutis/Dixis Project 2/Project-Dixis"
+export GH_REPO="lomendor/Project-Dixis"
+mkdir -p pr-cleanup-reports
+
+echo "=== Aggressive close: PRs με conflicts (needs-rebase) & >90 ημέρες ==="
+REPORT="pr-cleanup-reports/auto-close-aggressive-$(date +%Y%m%d-%H%M%S).md"
+echo "# Aggressive Auto-Close (needs-rebase & >90d)" > "$REPORT"
+echo "" >> "$REPORT"
+
+C90="$(date -v -90d +%Y-%m-%d)"
+PROTECTED='-label:wip -label:do-not-merge -label:keep-open -label:security -label:breaking-change -label:release'
+TOCLOSE=$(gh pr list --state open --search "label:needs-rebase updated:<$C90 $PROTECTED" \
+  --limit 200 --json number,title,updatedAt,url \
+  --jq '.[] | "\(.number)|\(.title)|\(.updatedAt)|\(.url)"')
+
+if [ -n "$TOCLOSE" ]; then
+  echo "$TOCLOSE" | while IFS='|' read -r num title upd url; do
+    echo "- #$num (last: ${upd%%T*}) $url — $title" >> "$REPORT"
+    gh pr close "$num" -c "Auto-close: stale (>90d) & conflicting (needs-rebase). Reopen if still relevant." || true
+  done
+else
+  echo "No PRs match aggressive rule." | tee -a "$REPORT"
+fi
+
+echo "" >> "$REPORT"
+echo "— Dependabot >30d safety pass" | tee -a "$REPORT"
+C30="$(date -v -30d +%Y-%m-%d)"
+gh pr list --state open --author "dependabot[bot]" --search "updated:<$C30" --limit 200 \
+  --json number,title,updatedAt,url --jq '.[] | "\(.number)|\(.title)|\(.updatedAt)|\(.url)"' \
+| while IFS='|' read -r num title upd url; do
+    echo "- #$num (last: ${upd%%T*}) $url — $title" >> "$REPORT"
+    gh pr close "$num" -c "Auto-close: stale Dependabot (>30d). Reopen if needed." || true
+  done
+
+echo ""
+echo "— Refresh dashboard"
+bash cleanup-scripts/06-create-dashboard.sh
+sed -n '1,40p' pr-cleanup-reports/DASHBOARD.md
+
+echo ""
+echo "✅ Report saved: $REPORT"

--- a/cleanup-scripts/close-60d-rebase.sh
+++ b/cleanup-scripts/close-60d-rebase.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+cd "/Users/panagiotiskourkoutis/Dixis Project 2/Project-Dixis"
+export GH_REPO="lomendor/Project-Dixis"
+mkdir -p pr-cleanup-reports
+
+echo "=== Close PRs: needs-rebase & >60d (exclude protected) ==="
+REPORT="pr-cleanup-reports/auto-close-60d-$(date +%Y%m%d-%H%M%S).md"
+echo "# Auto-Close (>60d & needs-rebase)" > "$REPORT"
+echo "" >> "$REPORT"
+
+# macOS date for 60 days
+C60="$(date -v -60d +%Y-%m-%d)"
+PROTECTED='-label:wip -label:do-not-merge -label:keep-open -label:security -label:breaking-change -label:release'
+
+# Ensure label exists for audit
+gh label create "auto-closed-stale" --color "CFD3D7" --description "Auto-closed due to staleness" --force >/dev/null 2>&1 || true
+
+TOCLOSE=$(gh pr list --state open --search "label:needs-rebase updated:<$C60 $PROTECTED" \
+  --limit 200 --json number,title,updatedAt,url \
+  --jq '.[] | "\(.number)|\(.title)|\(.updatedAt)|\(.url)"')
+
+if [ -n "$TOCLOSE" ]; then
+  echo "$TOCLOSE" | while IFS='|' read -r num title upd url; do
+    echo "- #$num (last: ${upd%%T*}) $url — $title" | tee -a "$REPORT"
+    gh pr comment "$num" -b "Auto-close: conflicting PR (needs-rebase) χωρίς ενημέρωση >60 ημέρες. Αν παραμένει σχετικό, κάνε **rebase** και άνοιξέ το ξανά." || true
+    gh pr edit "$num" --add-label "auto-closed-stale" || true
+    gh pr close "$num" -c "Auto-close: stale conflicting PR (>60d)." || true
+  done
+else
+  echo "No PRs matched >60d & needs-rebase." | tee -a "$REPORT"
+fi
+
+echo ""
+echo "=== Dependabot: set auto-merge for mergeable PRs ===" | tee -a "$REPORT"
+DEPS=$(gh pr list --state open --author "dependabot[bot]" --limit 50 \
+  --json number,title,mergeable,url \
+  --jq '.[] | select(.mergeable != "CONFLICTING") | "\(.number)|\(.title)|\(.url)"')
+
+if [ -n "$DEPS" ]; then
+  echo "$DEPS" | while IFS='|' read -r num title url; do
+    echo "• Auto-merge request on #$num — $title ($url)" | tee -a "$REPORT"
+    gh pr merge "$num" --merge --delete-branch --auto || true
+  done
+else
+  echo "No mergeable Dependabot PRs right now." | tee -a "$REPORT"
+fi
+
+echo ""
+echo "=== Refresh dashboard ==="
+bash cleanup-scripts/06-create-dashboard.sh
+sed -n '1,40p' pr-cleanup-reports/DASHBOARD.md
+
+echo ""
+echo "✅ Report saved: $REPORT"

--- a/cleanup-scripts/ultra-aggressive-30d.sh
+++ b/cleanup-scripts/ultra-aggressive-30d.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -euo pipefail
+cd "/Users/panagiotiskourkoutis/Dixis Project 2/Project-Dixis"
+export GH_REPO="lomendor/Project-Dixis"
+mkdir -p pr-cleanup-reports
+
+echo "=== Ultra-Aggressive 30d: Close conflicts, merge Dependabot, nudge clean PRs ==="
+REPORT="pr-cleanup-reports/conflict-30d-$(date +%Y%m%d-%H%M%S).md"
+echo "# Close conflicting PRs >30d + dependabot rebase + nudges" > "$REPORT"
+echo "" >> "$REPORT"
+
+# macOS & Linux compatible date
+C30="$(date -v -30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d)"
+PROTECTED_QUERY='-label:wip -label:do-not-merge -label:keep-open -label:security -label:breaking-change'
+
+# A) Κλείσιμο PRs με conflicts και updated < 30d
+echo "=== A) Closing conflicting PRs (>30d) ===" | tee -a "$REPORT"
+CONFLICT_30=$(gh pr list --state open --search "updated:<$C30 $PROTECTED_QUERY" --limit 200 \
+  --json number,title,updatedAt,mergeable,url \
+  --jq '.[] | select(.mergeable=="CONFLICTING") | "\(.number)|\(.title)|\(.updatedAt)|\(.url)"')
+
+if [ -n "$CONFLICT_30" ]; then
+  echo "$CONFLICT_30" | while IFS='|' read -r num title upd url; do
+    echo "- #$num (last: ${upd%%T*}) $title $url" | tee -a "$REPORT"
+    gh pr comment "$num" -b "Auto-close: PR με conflicts και χωρίς δραστηριότητα >30 ημέρες. Κάνε **rebase** και ξανά-άνοιξέ το όταν είσαι έτοιμος." || true
+    gh pr edit "$num" --add-label "auto-closed-stale" || true
+    gh pr close "$num" -c "Auto-close: conflicting & inactive >30d." || true
+  done
+else
+  echo "No conflicting PRs >30d." | tee -a "$REPORT"
+fi
+
+# B) Dependabot: ζητάμε rebase στα conflicting, γίνεται merge όπου είναι έτοιμα
+echo -e "\n=== B) Dependabot handling ===" | tee -a "$REPORT"
+DEPS=$(gh pr list --state open --author "dependabot[bot]" --limit 50 \
+  --json number,title,mergeable,url --jq '.[] | "\(.number)|\(.title)|\(.mergeable)|\(.url)"')
+
+if [ -n "$DEPS" ]; then
+  echo "$DEPS" | while IFS='|' read -r num title mergeable url; do
+    case "$mergeable" in
+      CONFLICTING)
+        echo "• #$num rebase request ($url)" | tee -a "$REPORT"
+        gh pr comment "$num" -b "@dependabot rebase" || true
+        ;;
+      MERGEABLE)
+        echo "• #$num attempt merge ($url)" | tee -a "$REPORT"
+        gh pr merge "$num" --merge --delete-branch || true
+        ;;
+      *)
+        echo "• #$num pending checks ($mergeable) ($url)" | tee -a "$REPORT"
+        ;;
+    esac
+  done
+else
+  echo "No Dependabot PRs." | tee -a "$REPORT"
+fi
+
+# C) Nudge: PRs MERGEABLE αλλά χωρίς approvals
+echo -e "\n=== C) Nudging mergeable PRs without approvals ===" | tee -a "$REPORT"
+MERGEABLE=$(gh pr list --state open --limit 200 --json number,title,mergeable,url \
+  --jq '.[] | select(.mergeable=="MERGEABLE") | "\(.number)|\(.title)|\(.url)"')
+
+if [ -n "$MERGEABLE" ]; then
+  echo "$MERGEABLE" | while IFS='|' read -r num title url; do
+    APPROVED=$(gh pr view "$num" --json reviews --jq '[.reviews[] | select(.state=="APPROVED")] | length' 2>/dev/null || echo 0)
+    if [ "${APPROVED:-0}" -eq 0 ]; then
+      gh pr comment "$num" -b "Φιλική υπενθύμιση: το PR είναι **mergeable** αλλά χωρίς approvals. Ζητήστε review ή προσθέστε tests. Θα κλείσει στο επόμενο cleanup αν μείνει ανενεργό." || true
+      gh pr edit "$num" --add-label "maintainer-note" || true
+      echo "• Nudge #$num — $title ($url)" | tee -a "$REPORT"
+    fi
+  done
+else
+  echo "No mergeable PRs without approvals." | tee -a "$REPORT"
+fi
+
+# D) Dashboard
+echo -e "\n=== D) Refresh dashboard ==="
+bash cleanup-scripts/06-create-dashboard.sh
+sed -n '1,40p' pr-cleanup-reports/DASHBOARD.md
+
+echo -e "\n✅ Report saved: $REPORT"


### PR DESCRIPTION
Adds cleanup scripts used for repository hygiene. Excludes generated reports via .gitignore. Safe ops-only.