### PR TITLE
fix: uptime smoke workflow check pattern

### DIFF
--- a/.github/workflows/uptime-smoke.yml
+++ b/.github/workflows/uptime-smoke.yml
@@ -6,13 +6,15 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - name: Probe healthz on prod domains
+      - name: Probe healthz on prod domain
         run: |
           set -e
-          for URL in https://dixis.gr/api/healthz https://dixis.io/api/healthz; do
-            echo "Probing $URL"
-            if curl -fsS "$URL" | grep -qi healthy; then
-              echo "OK: $URL"; exit 0
-            fi
-          done
-          echo "❌ All probes failed"; exit 1
+          URL="https://dixis.io/api/healthz"
+          echo "Probing $URL"
+          RESPONSE=$(curl -fsS "$URL")
+          echo "Response: $RESPONSE"
+          if echo "$RESPONSE" | grep -qi '"status".*"ok"'; then
+            echo "✅ OK: $URL is healthy"
+            exit 0
+          fi
+          echo "❌ Health check failed"; exit 1


### PR DESCRIPTION
Fixes uptime-smoke workflow to:
- Check for `"status":"ok"` in JSON response (not "healthy" text)
- Only probe dixis.io (dixis.gr/api/healthz returns 404)
- Show response for debugging

Resolves first workflow run failure.