### PR TITLE
FINANCE-02: Dynamic DB-driven fees + resolver

### DIFF
--- a/backend/app/Models/Commission.php
+++ b/backend/app/Models/Commission.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Commission extends Model
+{
+    protected $fillable = [
+        'order_id',
+        'producer_id',
+        'channel',
+        'order_gross',
+        'platform_fee',
+        'platform_fee_vat',
+        'producer_payout',
+        'currency',
+    ];
+
+    protected $casts = [
+        'order_gross' => 'decimal:2',
+        'platform_fee' => 'decimal:2',
+        'platform_fee_vat' => 'decimal:2',
+        'producer_payout' => 'decimal:2',
+    ];
+
+    /**
+     * Get the order that owns the commission.
+     */
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
+    }
+}

--- a/backend/app/Models/DixisSetting.php
+++ b/backend/app/Models/DixisSetting.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DixisSetting extends Model
+{
+    protected $fillable = ['key', 'value'];
+
+    protected $casts = [
+        'value' => 'array',
+    ];
+}

--- a/backend/app/Models/FeeRule.php
+++ b/backend/app/Models/FeeRule.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FeeRule extends Model
+{
+    protected $fillable = [
+        'producer_id',
+        'category_id',
+        'channel',
+        'rate',
+        'fee_vat_rate',
+        'priority',
+        'effective_from',
+        'effective_to',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'effective_from' => 'date',
+        'effective_to' => 'date',
+        'rate' => 'float',
+        'fee_vat_rate' => 'float',
+    ];
+}

--- a/backend/app/Services/CommissionService.php
+++ b/backend/app/Services/CommissionService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Commission;
+use App\Models\Order;
+
+class CommissionService
+{
+    public function __construct(
+        private FeeResolver $fees = new FeeResolver()
+    ) {}
+
+    /**
+     * Calculate and persist commission for an order.
+     *
+     * @param Order $order
+     * @param string $channel 'b2c' or 'b2b'
+     * @return Commission
+     */
+    public function settleForOrder(Order $order, string $channel = 'b2c'): Commission
+    {
+        // Get producer_id from order items (first item for simplicity)
+        // In multi-producer orders, you'd loop per item or aggregate
+        $producerId = $order->orderItems()->first()?->producer_id;
+        $categoryId = null; // TODO: derive from items if product categories exist
+
+        $resolved = $this->fees->resolve($producerId, $categoryId, $channel);
+
+        // Use order total (supports both 'total' and legacy 'total_amount')
+        $gross = (float)($order->total ?? $order->total_amount ?? 0);
+        $platformFee = round($gross * (float)$resolved['rate'], 2);
+        $platformFeeVat = round($platformFee * (float)$resolved['fee_vat_rate'], 2);
+        $producerPayout = round($gross - $platformFee - $platformFeeVat, 2);
+
+        return Commission::updateOrCreate(
+            ['order_id' => $order->id, 'producer_id' => $producerId],
+            [
+                'channel' => $channel,
+                'order_gross' => $gross,
+                'platform_fee' => $platformFee,
+                'platform_fee_vat' => $platformFeeVat,
+                'producer_payout' => $producerPayout,
+                'currency' => $order->currency ?? 'EUR',
+            ]
+        );
+    }
+}

--- a/backend/app/Services/FeeResolver.php
+++ b/backend/app/Services/FeeResolver.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\FeeRule;
+use App\Models\DixisSetting;
+use Illuminate\Support\Carbon;
+
+class FeeResolver
+{
+    /**
+     * Resolve fee configuration for a given producer, category, and channel.
+     *
+     * Priority: Producer override > Category rule > Global default
+     *
+     * @param int|null $producerId
+     * @param int|null $categoryId
+     * @param string $channel 'b2c' or 'b2b'
+     * @return array ['rate' => float, 'fee_vat_rate' => float, 'source' => string]
+     */
+    public function resolve(?int $producerId, ?int $categoryId, string $channel): array
+    {
+        $today = Carbon::today();
+
+        // 1) Specific rules by priority & specificity
+        $rule = FeeRule::query()
+            ->where('is_active', true)
+            ->where(function ($q) use ($today) {
+                $q->whereNull('effective_to')->orWhere('effective_to', '>=', $today);
+            })
+            ->where('effective_from', '<=', $today)
+            ->when($channel, fn($q) => $q->where(function ($sq) use ($channel) {
+                $sq->whereNull('channel')->orWhere('channel', $channel);
+            }))
+            ->when($producerId, fn($q) => $q->where(function ($sq) use ($producerId) {
+                $sq->whereNull('producer_id')->orWhere('producer_id', $producerId);
+            }))
+            ->when($categoryId, fn($q) => $q->where(function ($sq) use ($categoryId) {
+                $sq->whereNull('category_id')->orWhere('category_id', $categoryId);
+            }))
+            ->orderByRaw('producer_id IS NULL')   // non-null first
+            ->orderByRaw('category_id IS NULL')
+            ->orderByRaw('channel IS NULL')
+            ->orderBy('priority')
+            ->orderByDesc('effective_from')
+            ->first();
+
+        if ($rule) {
+            return [
+                'rate' => (float)$rule->rate,
+                'fee_vat_rate' => $rule->fee_vat_rate !== null
+                    ? (float)$rule->fee_vat_rate
+                    : $this->defaultVat(),
+                'source' => 'fee_rules',
+            ];
+        }
+
+        // 2) Global defaults from settings
+        $b2c = $this->getSetting('fee.b2c.rate', null);
+        $b2b = $this->getSetting('fee.b2b.rate', null);
+        $vat = $this->defaultVat();
+
+        $rate = $channel === 'b2b'
+            ? ($b2b ?? config('dixis.fees.b2b', 0.07))
+            : ($b2c ?? config('dixis.fees.b2c', 0.12));
+
+        return [
+            'rate' => (float)$rate,
+            'fee_vat_rate' => (float)$vat,
+            'source' => 'defaults',
+        ];
+    }
+
+    /**
+     * Get a setting value by key.
+     *
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    protected function getSetting(string $key, $default = null)
+    {
+        $s = DixisSetting::where('key', $key)->first();
+        return $s ? ($s->value['v'] ?? $default) : $default;
+    }
+
+    /**
+     * Get the default VAT rate for fees.
+     *
+     * @return float
+     */
+    protected function defaultVat(): float
+    {
+        $s = DixisSetting::where('key', 'fee.vat.rate')->first();
+        return (float)($s ? ($s->value['v'] ?? config('dixis.fees.fee_vat_rate', 0.24)) : config('dixis.fees.fee_vat_rate', 0.24));
+    }
+}

--- a/backend/config/dixis.php
+++ b/backend/config/dixis.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Dixis Platform Fee Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Default commission rates and VAT settings for the Dixis marketplace.
+    | These values are fallbacks when no DB-driven rules exist in fee_rules
+    | or dixis_settings tables.
+    |
+    */
+
+    'fees' => [
+        // Default B2C commission rate (12%)
+        'b2c' => env('DIXIS_FEE_B2C', 0.12),
+
+        // Default B2B commission rate (7%)
+        'b2b' => env('DIXIS_FEE_B2B', 0.07),
+
+        // VAT rate applied to platform fees (24% Greek VAT)
+        'fee_vat_rate' => env('DIXIS_FEE_VAT_RATE', 0.24),
+    ],
+];

--- a/backend/database/migrations/2025_11_15_220822_create_dixis_settings_table.php
+++ b/backend/database/migrations/2025_11_15_220822_create_dixis_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('dixis_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();     // e.g. fee.b2c.rate
+            $table->json('value')->nullable();   // arbitrary JSON
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('dixis_settings');
+    }
+};

--- a/backend/database/migrations/2025_11_15_220824_create_fee_rules_table.php
+++ b/backend/database/migrations/2025_11_15_220824_create_fee_rules_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('fee_rules', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('producer_id')->nullable()->index(); // override per producer
+            $table->unsignedBigInteger('category_id')->nullable()->index(); // override per category (no FK to avoid coupling)
+            $table->enum('channel', ['b2c','b2b'])->nullable();             // null = applies to both
+            $table->decimal('rate', 5, 4);           // e.g. 0.1200 = 12%
+            $table->decimal('fee_vat_rate', 5, 4)->nullable(); // override VAT on fee; null -> use default
+            $table->smallInteger('priority')->default(100);     // lower = higher priority
+            $table->date('effective_from')->default(DB::raw('CURRENT_DATE'));
+            $table->date('effective_to')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->index(['is_active','effective_from','effective_to']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('fee_rules');
+    }
+};

--- a/backend/database/migrations/2025_11_15_220826_create_commissions_table.php
+++ b/backend/database/migrations/2025_11_15_220826_create_commissions_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('commissions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('order_id')->index();
+            $table->unsignedBigInteger('producer_id')->nullable()->index();
+            $table->enum('channel', ['b2c','b2b'])->default('b2c');
+            $table->decimal('order_gross', 10, 2)->default(0.00);
+            $table->decimal('platform_fee', 10, 2)->default(0.00);
+            $table->decimal('platform_fee_vat', 10, 2)->default(0.00);
+            $table->decimal('producer_payout', 10, 2)->default(0.00);
+            $table->string('currency', 3)->default('EUR');
+            $table->timestamps();
+
+            $table->unique(['order_id', 'producer_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('commissions');
+    }
+};

--- a/backend/database/seeders/FeeDefaultsSeeder.php
+++ b/backend/database/seeders/FeeDefaultsSeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\DixisSetting;
+
+class FeeDefaultsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $defaults = [
+            'fee.b2c.rate' => (float)config('dixis.fees.b2c', 0.12),
+            'fee.b2b.rate' => (float)config('dixis.fees.b2b', 0.07),
+            'fee.vat.rate' => (float)config('dixis.fees.fee_vat_rate', 0.24),
+        ];
+
+        foreach ($defaults as $key => $value) {
+            $setting = DixisSetting::firstOrCreate(['key' => $key], ['value' => ['v' => $value]]);
+
+            // Update if value changed
+            if (!isset($setting->value['v']) || $setting->value['v'] !== $value) {
+                $setting->value = ['v' => $value];
+                $setting->save();
+            }
+        }
+
+        $this->command->info('✅ Fee defaults seeded: B2C='.$defaults['fee.b2c.rate'].' B2B='.$defaults['fee.b2b.rate'].' VAT='.$defaults['fee.vat.rate']);
+    }
+}


### PR DESCRIPTION
## Summary

Implements DB-driven commission rates with overrides (producer/category/channel), effective dates, and defaults seeded from env. No Redis required.

## Changes

**Database Schema:**
- `dixis_settings` table - Global key-value config (fee.b2c.rate, fee.b2b.rate, fee.vat.rate)
- `fee_rules` table - Granular rules with producer/category/channel overrides, priority, effective dates
- `commissions` table - Tracks calculated fees per order

**Models:**
- `DixisSetting` - Global settings with JSON values
- `FeeRule` - Rule-based fee configuration
- `Commission` - Calculated commission records

**Services:**
- `FeeResolver` - Priority-based resolution logic (producer > category > global defaults)
- `CommissionService` - Uses FeeResolver to calculate platform fees from orders

**Configuration:**
- `config/dixis.php` - Default rates (B2C 12%, B2B 7%, VAT 24%)
- `FeeDefaultsSeeder` - Seeds defaults from config to DB

## Priority Logic

1. Producer-specific rule (if exists)
2. Category-specific rule (if exists)
3. Channel-specific global setting (if exists)
4. Config file defaults

## Usage

### Change global B2C rate to 11.5%:
```sql
UPDATE dixis_settings SET value='{"v":0.115}' WHERE key='fee.b2c.rate';
```

### Add producer override (producer #42, B2B 6%, valid for 1 year):
```sql
INSERT INTO fee_rules (producer_id, channel, rate, priority, effective_from, effective_to, is_active)
VALUES (42, 'b2b', 0.06, 10, CURRENT_DATE, CURRENT_DATE + INTERVAL '1 year', true);
```

### Calculate commission for an order:
```php
use App\Services\CommissionService;

$service = new CommissionService();
$commission = $service->settleForOrder($order, 'b2c');
// Returns Commission model with calculated platform_fee, platform_fee_vat, producer_payout
```

## Test Plan

- [x] Migrations run successfully
- [x] Seeder populates defaults (B2C=0.12, B2B=0.07, VAT=0.24)
- [ ] Manual testing of FeeResolver priority logic
- [ ] Manual testing of CommissionService calculations
- [ ] Integration with actual order flow

## Next Steps

1. Admin UI for CRUD on fee rules (/ops dashboard)
2. Integration with order completion flow
3. Artisan command for bulk commission recalculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)