### PR TITLE
FINANCE-03: Commission preview CLI + OPS endpoint

### DIFF
--- a/backend/app/Console/Commands/CommissionPreview.php
+++ b/backend/app/Console/Commands/CommissionPreview.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Services\CommissionService;
+use App\Models\Order;
+
+class CommissionPreview extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dixis:commission-preview
+        {--orderId= : Order ID to calculate commission for}
+        {--amount= : Net amount if not using orderId}
+        {--channel=b2c : b2c or b2b}
+        {--producerId= : Optional producer ID for custom rules}
+        {--categoryId= : Optional category ID for custom rules}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Preview commission calculation with dynamic rules';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(CommissionService $service)
+    {
+        $channel = $this->option('channel') === 'b2b' ? 'b2b' : 'b2c';
+        $producerId = $this->option('producerId') ? (int)$this->option('producerId') : null;
+        $categoryId = $this->option('categoryId') ? (int)$this->option('categoryId') : null;
+
+        if ($orderId = $this->option('orderId')) {
+            $order = Order::find((int)$orderId);
+            if (!$order) {
+                $this->error("Order {$orderId} not found");
+                return 1;
+            }
+
+            $commission = $service->settleForOrder($order, $channel);
+
+            $this->line(json_encode([
+                'order_id' => $order->id,
+                'channel' => $commission->channel,
+                'order_gross' => $commission->order_gross,
+                'platform_fee' => $commission->platform_fee,
+                'platform_fee_vat' => $commission->platform_fee_vat,
+                'producer_payout' => $commission->producer_payout,
+                'currency' => $commission->currency,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+            return 0;
+        }
+
+        if ($amount = $this->option('amount')) {
+            $amount = (float)$amount;
+
+            // Use FeeResolver directly for preview without Order
+            $resolved = app(\App\Services\FeeResolver::class)->resolve(
+                $producerId,
+                $categoryId,
+                $channel
+            );
+
+            $platformFee = round($amount * (float)$resolved['rate'], 2);
+            $platformFeeVat = round($platformFee * (float)$resolved['fee_vat_rate'], 2);
+            $producerPayout = round($amount - $platformFee - $platformFeeVat, 2);
+
+            $this->line(json_encode([
+                'amount' => $amount,
+                'channel' => $channel,
+                'rate' => $resolved['rate'],
+                'fee_vat_rate' => $resolved['fee_vat_rate'],
+                'platform_fee' => $platformFee,
+                'platform_fee_vat' => $platformFeeVat,
+                'producer_payout' => $producerPayout,
+                'source' => $resolved['source'],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+            return 0;
+        }
+
+        $this->error('Provide --orderId or --amount');
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Adds preview capabilities for commission calculations without modifying checkout flow. Provides both CLI (artisan command) and HTTP (OPS endpoint) interfaces for testing and ops tooling.

## Changes

**Artisan Command:**
- `dixis:commission-preview` - CLI command for commission preview
  - Supports `--amount` for simple calculations
  - Supports `--orderId` for order-based calculations
  - Supports `--channel` (b2c/b2b), `--producerId`, `--categoryId`

**API Endpoint:**
- `GET /api/ops/commission/preview` - Secured with `x-ops-token` header
  - Query params: `amount`, `orderId`, `channel`, `producerId`, `categoryId`
  - Returns JSON with commission breakdown

**Security:**
- Auto-generated `OPS_TOKEN` in `.env`
- Header-based authentication (404 on invalid token)

## Usage

### CLI Examples:
```bash
# Preview B2C commission on €100
php artisan dixis:commission-preview --amount=100 --channel=b2c

# Preview B2B commission on order #123
php artisan dixis:commission-preview --orderId=123 --channel=b2b

# With producer override
php artisan dixis:commission-preview --amount=200 --producerId=42 --channel=b2b
```

### HTTP Examples:
```bash
# Get OPS_TOKEN
export OPS_TOKEN=$(grep ^OPS_TOKEN= backend/.env | cut -d= -f2)

# Preview by amount
curl 'http://localhost:8001/api/ops/commission/preview?amount=100&channel=b2c' \
  -H "x-ops-token: $OPS_TOKEN" | jq .

# Preview by orderId
curl 'http://localhost:8001/api/ops/commission/preview?orderId=1&channel=b2b' \
  -H "x-ops-token: $OPS_TOKEN" | jq .
```

## Example Output

**B2C (12% commission):**
```json
{
  "amount": 100,
  "channel": "b2c",
  "rate": 0.12,
  "fee_vat_rate": 0.24,
  "platform_fee": 12,
  "platform_fee_vat": 2.88,
  "producer_payout": 85.12,
  "source": "defaults"
}
```

**B2B (7% commission):**
```json
{
  "amount": 100,
  "channel": "b2b",
  "rate": 0.07,
  "fee_vat_rate": 0.24,
  "platform_fee": 7,
  "platform_fee_vat": 1.68,
  "producer_payout": 91.32,
  "source": "defaults"
}
```

## Test Plan

- [x] CLI command works with `--amount`
- [x] CLI command integrates with FeeResolver
- [x] B2C/B2B rates calculated correctly
- [x] OPS_TOKEN generated and added to .env
- [ ] HTTP endpoint tested (requires local server)
- [ ] Integration with order-based calculation

## Next Steps

1. Test HTTP endpoint in dev environment
2. Add OPS dashboard UI for fee rule management
3. Wire CommissionService into order lifecycle
4. Add bulk commission recalculation command

🤖 Generated with [Claude Code](https://claude.com/claude-code)