### PR TITLE
fix(database): accept DATABASE_URL (fallback DB_URL)

### DIFF
--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -33,7 +33,7 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
-            'url' => env('DB_URL'),
+            'url' => env('DATABASE_URL', env('DB_URL')),
             'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
@@ -44,7 +44,7 @@ return [
 
         'mysql' => [
             'driver' => 'mysql',
-            'url' => env('DB_URL'),
+            'url' => env('DATABASE_URL', env('DB_URL')),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),
             'database' => env('DB_DATABASE', 'laravel'),
@@ -64,7 +64,7 @@ return [
 
         'mariadb' => [
             'driver' => 'mariadb',
-            'url' => env('DB_URL'),
+            'url' => env('DATABASE_URL', env('DB_URL')),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),
             'database' => env('DB_DATABASE', 'laravel'),
@@ -84,7 +84,7 @@ return [
 
         'pgsql' => [
             'driver' => 'pgsql',
-            'url' => env('DB_URL'),
+            'url' => env('DATABASE_URL', env('DB_URL')),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '5432'),
             'database' => env('DB_DATABASE', 'laravel'),
@@ -99,7 +99,7 @@ return [
 
         'sqlsrv' => [
             'driver' => 'sqlsrv',
-            'url' => env('DB_URL'),
+            'url' => env('DATABASE_URL', env('DB_URL')),
             'host' => env('DB_HOST', 'localhost'),
             'port' => env('DB_PORT', '1433'),
             'database' => env('DB_DATABASE', 'laravel'),


### PR DESCRIPTION
## Problem
Production .env used `DATABASE_URL` (standard convention) but Laravel's `config/database.php` expected `DB_URL`, causing connection failures with `fe_sendauth: no password supplied`.

## Solution
- Updated all database drivers to check `DATABASE_URL` first, then fallback to `DB_URL`
- Maintains backward compatibility with existing `DB_URL` configurations
- Follows Laravel/Heroku standard of using `DATABASE_URL`

## Changes
- `backend/config/database.php`: Updated 5 drivers (sqlite, mysql, mariadb, pgsql, sqlsrv)
  - Before: `'url' => env('DB_URL')`
  - After: `'url' => env('DATABASE_URL', env('DB_URL'))`

## Testing
- ✅ Production hotfix verified config now reads DATABASE_URL correctly
- ✅ Health endpoint responding
- ✅ Database connection working

## Impact
- No breaking changes - existing `DB_URL` configs continue to work
- New deployments can use standard `DATABASE_URL`
- Fixes production database configuration issue