### PR TITLE
feat(monitor): MONITOR-01 remote smoke + uptime + Lighthouse CI

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,36 +1,15 @@
 name: Lighthouse CI
 on:
-  workflow_dispatch:
-  push:
-    branches: [ main ]
   schedule:
-    - cron: "0 3 * * *"  # daily 03:00 EET
-
+    - cron: "0 2 * * *"
+  workflow_dispatch:
 jobs:
   lhci:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with: { node-version: '20' }
-      - uses: pnpm/action-setup@v4
-        with: { version: 9 }
-      - name: Install & Build (frontend)
-        working-directory: frontend
-        run: |
-          pnpm i --no-frozen-lockfile
-          pnpm build
-      - name: Start app
-        working-directory: frontend
-        run: |
-          pnpm start -- -p 3000 &
-          n=0; until [ $n -ge 30 ]; do curl -fsS http://localhost:3000 >/dev/null 2>&1 && break; n=$((n+1)); sleep 1; done
-      - name: Lighthouse CI
+      - name: Run Lighthouse CI
         uses: treosh/lighthouse-ci-action@v11
         with:
-          urls: |
-            http://localhost:3000/
-          configPath: ./frontend/lhci.config.json
-          uploadArtifacts: true
+          configPath: ./lighthouserc.json
           temporaryPublicStorage: true

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,33 +1,26 @@
-name: Uptime
+name: Uptime smoke
 on:
   schedule:
-    - cron: "*/10 * * * *"   # κάθε 10'
+    - cron: "*/10 * * * *"
   workflow_dispatch:
 jobs:
-  probe:
+  ping:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        url:
+          - "https://dixis.io/"
+          - "https://dixis.io/api/healthz"
+          - "https://dixis.io/robots.txt"
+          - "https://dixis.io/sitemap.xml"
     steps:
-      - name: Check /api/healthz
+      - name: Curl ${{ matrix.url }}
         run: |
-          set -euo pipefail
-          code=$(curl -s -o /dev/null -w "%{http_code}" https://dixis.io/api/healthz)
-          [ "$code" = "200" ] || { echo "healthz: $code"; exit 1; }
-
-      - name: Check robots.txt
-        run: |
-          set -euo pipefail
-          code=$(curl -s -o /dev/null -w "%{http_code}" https://dixis.io/robots.txt)
-          [ "$code" = "200" ] || { echo "robots: $code"; exit 1; }
-
-      - name: Check sitemap.xml
-        run: |
-          set -euo pipefail
-          code=$(curl -s -o /dev/null -w "%{http_code}" https://dixis.io/sitemap.xml)
-          [ "$code" = "200" ] || { echo "sitemap: $code"; exit 1; }
-
-      - name: Check homepage
-        run: |
-          set -euo pipefail
-          code=$(curl -s -o /dev/null -w "%{http_code}" https://dixis.io/)
-          [ "$code" = "200" ] || { echo "homepage: $code"; exit 1; }
+          for i in 1 2 3; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "${{ matrix.url }}") || code=0
+            echo "Attempt $i → $code"
+            [[ "$code" =~ ^2|3 ]] && exit 0
+            sleep 5
+          done
+          echo "Fail: ${{ matrix.url }}"; exit 1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,7 +105,8 @@
     "db:push:ci": "prisma db push --schema=prisma/schema.ci.prisma",
     "db:seed:ci": "node prisma/seed.ci.cjs",
     "db:migrate:deploy": "prisma migrate deploy",
-    "db:seed:dev": "node prisma/seed.dev.cjs"
+    "db:seed:dev": "node prisma/seed.dev.cjs",
+    "test:e2e:remote": "playwright test -c playwright.remote.config.ts -g \"smoke\""
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",

--- a/frontend/playwright.remote.config.ts
+++ b/frontend/playwright.remote.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from '@playwright/test';
+const baseURL = process.env.E2E_SITE_URL || 'https://dixis.io';
+export default defineConfig({
+  testDir: './tests/e2e/smoke',
+  timeout: 30_000,
+  retries: 0,
+  reporter: [['list']],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'mobile', use: { ...devices['Pixel 5'] } },
+  ],
+});

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,17 @@
+{
+  "ci": {
+    "collect": {
+      "url": ["https://dixis.io/", "https://dixis.io/products"],
+      "numberOfRuns": 1,
+      "settings": { "preset": "desktop" }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.7 }],
+        "categories:accessibility": ["warn", { "minScore": 0.8 }],
+        "categories:best-practices": ["warn", { "minScore": 0.85 }],
+        "categories:seo": ["warn", { "minScore": 0.85 }]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Implements MONITOR-01 automated observability infrastructure:
- Remote Playwright smoke tests (no webServer dependency)
- Uptime monitoring workflow (every 10 minutes)
- Nightly Lighthouse CI for performance tracking

## Changes
- **playwright.remote.config.ts**: Remote test config for live production testing
- **package.json**: Add `test:e2e:remote` script for remote smoke tests
- **uptime.yml**: GitHub Action to ping 4 critical endpoints every 10 minutes with 3 retries
- **lighthouse.yml**: Nightly Lighthouse CI workflow (2 AM UTC)
- **lighthouserc.json**: Performance budgets (perf 70%, a11y 80%, best-practices 85%, SEO 85%)

## Test Plan
- [x] Validate Playwright remote config
- [x] Validate workflow YAML syntax
- [ ] Run remote smoke tests locally: `E2E_SITE_URL="https://dixis.io" npm run test:e2e:remote`
- [ ] Monitor first uptime workflow execution
- [ ] Monitor first Lighthouse CI execution (nightly)

## References
Refs: #828 (MONITOR-01 checklist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)