### PR TITLE
test(smoke): healthz + commission-preview (flag-guarded) [MONITOR-01]

### DIFF
--- a/frontend/tests/e2e/smoke-commission-preview.spec.ts
+++ b/frontend/tests/e2e/smoke-commission-preview.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Expect 404 on production because commission_engine_v1 is OFF by default.
+ * (When we enable on staging later, we will override BASE_URL in CI to hit staging and expect 200.)
+ */
+test('commission-preview endpoint guarded when flag OFF', async ({ request }) => {
+  const base = process.env.BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'https://dixis.io';
+  // Use a benign order id; endpoint should be hidden (404) when flag OFF
+  const res = await request.get(`${base}/api/orders/123/commission-preview`, { timeout: 15000 });
+  expect([401, 403, 404]).toContain(res.status());
+});

--- a/frontend/tests/e2e/smoke-healthz.spec.ts
+++ b/frontend/tests/e2e/smoke-healthz.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('healthz is healthy', async ({ request }) => {
+  const base = process.env.BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'https://dixis.io';
+  const res = await request.get(`${base}/api/healthz`, { timeout: 15000 });
+  expect(res.status(), 'healthz status').toBe(200);
+  const json = await res.json();
+  expect(json.status).toBe('healthy');
+});


### PR DESCRIPTION
Adds two Playwright smoke tests:
- /api/healthz returns 200 & {status:'healthy'}
- commission-preview is 404 when commission_engine_v1 is OFF (prod)

Next step: run same against *staging* with flag ON via CI matrix.