### PR TITLE
fix(e2e): include smoke-*.spec.ts in CI testMatch pattern

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
         ...devices['Desktop Chrome']
         // storageState disabled in CI - tests handle auth via UI or route stubs
       },
-      testMatch: ['**/smoke.spec.ts', '**/e3-docs-smoke.spec.ts', '**/auth-probe.spec.ts', '**/shipping-*.spec.ts', '**/checkout*.spec.ts'],
+      testMatch: ['**/smoke*.spec.ts', '**/e3-docs-smoke.spec.ts', '**/auth-probe.spec.ts', '**/shipping-*.spec.ts', '**/checkout*.spec.ts'],
       testIgnore: ['**/*@no-auth*.spec.ts']
     },
     // CI: Pure UI login tests (no storageState) - Phase-4.1
@@ -119,10 +119,10 @@ export default defineConfig({
       testMatch: ['**/auth-*.spec.ts', '**/admin-*.spec.ts']
     },
     // Unauthenticated tests (smoke, registration, etc.)
-    { 
+    {
       name: 'guest',
       use: { ...devices['Desktop Chrome'] },
-      testMatch: ['**/smoke.spec.ts', '**/register.spec.ts', '**/e3-docs-smoke.spec.ts']
+      testMatch: ['**/smoke*.spec.ts', '**/register.spec.ts', '**/e3-docs-smoke.spec.ts']
     }
   ],
 


### PR DESCRIPTION
## Summary

Fixes smoke matrix tests failing with 'No tests found' error by updating Playwright config testMatch pattern.

## Problem
Smoke matrix workflow runs:
- `smoke-healthz.spec.ts`
- `smoke-commission-preview.spec.ts`

But Playwright CI projects only matched `**/smoke.spec.ts`, causing "No tests found" error.

## Solution
Updated testMatch pattern from `**/smoke.spec.ts` to `**/smoke*.spec.ts` in:
- CI `consumer-ci` project (line 73)
- Local `guest` project (line 125)

## Testing
- ✅ Pattern now matches all smoke test files
- ✅ Backward compatible with existing `smoke.spec.ts`
- ✅ Enables smoke-healthz and smoke-commission-preview tests

## Related
- Follows up PR #852 (MONITOR-01c)
- Required for smoke matrix workflow to function

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)