### PR TITLE
fix(ci): use pnpm for smoke-matrix deps install

### DIFF
--- a/.github/workflows/smoke-matrix.yml
+++ b/.github/workflows/smoke-matrix.yml
@@ -48,11 +48,21 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Enable corepack
+        if: ${{ matrix.name != 'staging' || steps.preflight.outputs.skip != 'true' }}
+        run: corepack enable
+
       - name: Install deps
         if: ${{ matrix.name != 'staging' || steps.preflight.outputs.skip != 'true' }}
         run: |
           cd frontend
-          npm ci
+          pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        if: ${{ matrix.name != 'staging' || steps.preflight.outputs.skip != 'true' }}
+        run: |
+          cd frontend
+          npx playwright install --with-deps
 
       - name: Run smoke tests
         if: ${{ matrix.name != 'staging' || steps.preflight.outputs.skip != 'true' }}


### PR DESCRIPTION
## Problem

Smoke matrix production job failed with:
```
npm error The `npm ci` command can only install with an existing package-lock.json
```

The project uses pnpm (has pnpm-lock.yaml), not npm.

## Solution

- Added `corepack enable` step
- Changed `npm ci` to `pnpm install --frozen-lockfile`
- Added Playwright browsers installation step
- Aligns with all other workflows in the project

## Verification

Smoke matrix should now:
- ✅ Production: Install deps with pnpm, run smoke tests
- ✅ Staging: Gracefully skip (unreachable preflight)

## Related

- PR #855 - Added workflow_dispatch and preflight skip
- Fixes failed run: https://github.com/lomendor/Project-Dixis/actions/runs/19442143979

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)