### PR TITLE
fix(ci): use explicit paths for smoke matrix tests

### DIFF
--- a/.github/workflows/smoke-matrix.yml
+++ b/.github/workflows/smoke-matrix.yml
@@ -72,7 +72,10 @@ jobs:
           SKIP_WEBSERVER: "true"
         run: |
           cd frontend
-          npx playwright test "**/smoke*.spec.ts" --reporter=list
+          npx playwright test \
+            tests/e2e/smoke-healthz.spec.ts \
+            tests/e2e/smoke-commission-preview.spec.ts \
+            --reporter=list
 
       - name: Mark staging skipped (info)
         if: ${{ matrix.name == 'staging' && steps.preflight.outputs.skip == 'true' }}


### PR DESCRIPTION
## Problem

Smoke tests failed with regex error:
```
SyntaxError: Invalid regular expression: /**/smoke*.spec.ts/gi: Nothing to repeat
```

The glob pattern `"**/smoke*.spec.ts"` was being incorrectly parsed.

## Solution

Changed to explicit file paths matching the original approach:
```bash
npx playwright test \
  tests/e2e/smoke-healthz.spec.ts \
  tests/e2e/smoke-commission-preview.spec.ts
```

## Verification

Should now:
- ✅ Production: Run both smoke tests successfully
- ✅ Staging: Gracefully skip (unreachable)

## Related

- PR #855 - workflow_dispatch + preflight
- PR #856 - pnpm fix
- Failed run: https://github.com/lomendor/Project-Dixis/actions/runs/19442385700

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)