### PR TITLE
ci(staging): add safe deploy skeleton (env+preflight)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,74 @@
+name: Deploy Staging
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: staging-deploy
+    runs-on: ubuntu-latest
+    environment: staging
+    env:
+      STAGING_HOST: ${{ secrets.STAGING_HOST }}
+      STAGING_USER: ${{ secrets.STAGING_USER }}
+      STAGING_PATH: ${{ secrets.STAGING_PATH }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      BASE_URL: ${{ vars.STAGING_BASE_URL }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Preflight secrets
+        id: preflight
+        shell: bash
+        run: |
+          set -e
+          MISSING=0
+          for k in STAGING_HOST STAGING_USER STAGING_PATH SSH_PRIVATE_KEY; do
+            if [ -z "${!k:-}" ]; then
+              echo "❗ Missing secret: $k"
+              MISSING=1
+            fi
+          done
+          if [ $MISSING -eq 1 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mark SKIPPED (no secrets yet)
+        if: ${{ steps.preflight.outputs.skip == 'true' }}
+        run: |
+          echo "ℹ️ Staging deploy skipped: define repo environment 'staging' secrets:"
+          echo "   • STAGING_HOST  (e.g. 203.0.113.10)"
+          echo "   • STAGING_USER  (e.g. deploy)"
+          echo "   • STAGING_PATH  (e.g. /var/www/staging.dixis.io)"
+          echo "   • SSH_PRIVATE_KEY (PEM private key for the deploy user)"
+
+      - name: Setup SSH
+        if: ${{ steps.preflight.outputs.skip != 'true' }}
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Add host to known_hosts
+        if: ${{ steps.preflight.outputs.skip != 'true' }}
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "$STAGING_HOST" >> ~/.ssh/known_hosts
+
+      - name: SSH reachability check
+        if: ${{ steps.preflight.outputs.skip != 'true' }}
+        run: |
+          ssh -o BatchMode=yes "${STAGING_USER}@${STAGING_HOST}" "echo '✅ SSH OK on ' \$(hostname)"
+
+      # Placeholder deploy (no-op). We'll replace with real rsync/Docker on next pass.
+      - name: Placeholder deploy step
+        if: ${{ steps.preflight.outputs.skip != 'true' }}
+        run: |
+          echo "🚀 (placeholder) would deploy repo to $STAGING_USER@$STAGING_HOST:$STAGING_PATH"
+          echo "Next pass will rsync/build/restart services."


### PR DESCRIPTION
## Summary

Adds staging environment and deploy workflow with safe preflight checks.

## Changes

1. **Created GitHub Environment 'staging'**
   - Separate environment for staging deployments
   - Ready for environment-specific secrets

2. **Deploy Staging Workflow**
   - Manual trigger via `workflow_dispatch`
   - Preflight secret validation
   - Gracefully skips if secrets missing
   - SSH reachability check when secrets available
   - Placeholder deploy step (no-op for now)

## Required Secrets (staging environment)

To enable actual deployments, set these secrets:
- `STAGING_HOST` - Server IP/hostname (e.g., 203.0.113.10)
- `STAGING_USER` - SSH user (e.g., deploy)
- `STAGING_PATH` - Deployment path (e.g., /var/www/staging.dixis.io)
- `SSH_PRIVATE_KEY` - PEM private key for SSH auth

## Behavior

**Without secrets**: Workflow succeeds with informative skip message
**With secrets**: Performs SSH reachability check + placeholder deploy

## Next Steps

- Set staging environment secrets
- Replace placeholder with actual rsync/Docker deploy
- Add health check after deploy
- Integrate with smoke matrix workflow

## Related

- Issue #854 - Staging setup tracking
- PR #855-858 - Smoke matrix setup

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)