### PR TITLE
ci(staging): rsync deploy + healthz endpoint

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,6 +2,14 @@ name: Deploy Staging
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - '.github/workflows/deploy-staging.yml'
 
 concurrency:
   group: deploy-staging
@@ -10,65 +18,53 @@ concurrency:
 jobs:
   deploy:
     name: staging-deploy
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: staging
     env:
       STAGING_HOST: ${{ secrets.STAGING_HOST }}
       STAGING_USER: ${{ secrets.STAGING_USER }}
       STAGING_PATH: ${{ secrets.STAGING_PATH }}
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      BASE_URL: ${{ vars.STAGING_BASE_URL }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Preflight secrets
-        id: preflight
-        shell: bash
-        run: |
-          set -e
-          MISSING=0
-          for k in STAGING_HOST STAGING_USER STAGING_PATH SSH_PRIVATE_KEY; do
-            if [ -z "${!k:-}" ]; then
-              echo "❗ Missing secret: $k"
-              MISSING=1
-            fi
-          done
-          if [ $MISSING -eq 1 ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Install rsync
+        run: sudo apt-get update && sudo apt-get install -y rsync openssh-client
 
-      - name: Mark SKIPPED (no secrets yet)
-        if: ${{ steps.preflight.outputs.skip == 'true' }}
-        run: |
-          echo "ℹ️ Staging deploy skipped: define repo environment 'staging' secrets:"
-          echo "   • STAGING_HOST  (e.g. 203.0.113.10)"
-          echo "   • STAGING_USER  (e.g. deploy)"
-          echo "   • STAGING_PATH  (e.g. /var/www/staging.dixis.io)"
-          echo "   • SSH_PRIVATE_KEY (PEM private key for the deploy user)"
-
-      - name: Setup SSH
-        if: ${{ steps.preflight.outputs.skip != 'true' }}
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Add host to known_hosts
-        if: ${{ steps.preflight.outputs.skip != 'true' }}
+      - name: Setup SSH key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "$STAGING_HOST" >> ~/.ssh/known_hosts
 
-      - name: SSH reachability check
-        if: ${{ steps.preflight.outputs.skip != 'true' }}
+      - name: Preflight
         run: |
-          ssh -o BatchMode=yes "${STAGING_USER}@${STAGING_HOST}" "echo '✅ SSH OK on ' \$(hostname)"
+          echo "🎯 Deployment target:"
+          echo "  Host: $STAGING_HOST"
+          echo "  User: $STAGING_USER"
+          echo "  Path: $STAGING_PATH"
 
-      # Placeholder deploy (no-op). We'll replace with real rsync/Docker on next pass.
-      - name: Placeholder deploy step
-        if: ${{ steps.preflight.outputs.skip != 'true' }}
+      - name: Create remote folders
         run: |
-          echo "🚀 (placeholder) would deploy repo to $STAGING_USER@$STAGING_HOST:$STAGING_PATH"
-          echo "Next pass will rsync/build/restart services."
+          ssh -i ~/.ssh/id_ed25519 ${STAGING_USER}@${STAGING_HOST} \
+            "mkdir -p ${STAGING_PATH}/current ${STAGING_PATH}/public"
+
+      - name: Deploy (rsync)
+        run: |
+          rsync -avz --delete \
+            --exclude ".git" \
+            --exclude "node_modules" \
+            --exclude "vendor" \
+            --exclude ".env" \
+            --exclude "*.log" \
+            ./ ${STAGING_USER}@${STAGING_HOST}:${STAGING_PATH}/current/
+
+      - name: Health check (HTTP via IP)
+        run: |
+          echo "🩺 Health check..."
+          curl -fsS -H "Host: staging.dixis.io" "http://${STAGING_HOST}/api/healthz"
+          echo "✅ Staging deployment successful!"


### PR DESCRIPTION
## Summary

Replaces placeholder staging deployment with real rsync deployment.

## Changes

**1. Real Deployment with rsync:**
- Deploys on push to main or manual trigger
- Excludes: .git, node_modules, vendor, .env, logs
- Creates current/ and public/ subdirectories  
- Uses SSH key from secrets

**2. Health Check:**
- HTTP health check with Host header
- Validates deployment via /api/healthz
- Uses IP address (works pre-DNS)

**3. Trigger Conditions:**
- Push to main branch
- Pull request to main (paths: frontend/**, backend/**, workflow)
- Manual workflow_dispatch

## Infrastructure Status

✅ **VPS Ready:**
- Nginx configured with healthz endpoint
- Deploy user with sudo access
- SSH keys configured
- Path: /var/www/staging.dixis.io

✅ **GitHub Secrets:**
- STAGING_HOST = 147.93.126.235
- STAGING_USER = deploy
- STAGING_PATH = /var/www/staging.dixis.io
- SSH_VESCRIBE_KEY = (configured)

⏳ **DNS Pending:**
- Need A record: staging.dixis.io → 147.93.126.235
- Health check works via IP + Host header for now

## Testing

Will deploy on merge to main. Test command:
```bash
curl -H "Host: staging.dixis.io" http://147.93.126.235/api/healthz
```

## Related

- Issue #854 - Staging setup tracking
- PR #859 - Initial workflow skeleton

## Next Steps

After merge:
1. Add DNS A record for staging.dixis.io
2. Install SSL cert with certbot (optional next PR)
3. Deploy actual application build

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)