### PR TITLE
ops(staging): smoke health workflow

### DIFF
--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -1,0 +1,26 @@
+name: Staging Smoke
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/staging-smoke.yml'
+  schedule:
+    - cron: '*/30 * * * *' # κάθε 30'
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Healthz
+        run: |
+          set -euo pipefail
+          URL="https://staging.dixis.io/api/healthz"
+          echo "GET $URL"
+          CODE="$(curl -sk -o /tmp/hz.json -w '%{http_code}' "$URL")"
+          echo "HTTP $CODE"
+          cat /tmp/hz.json || true
+          test "$CODE" = "200"
+          grep -q '"status":"ok"' /tmp/hz.json

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -2,3 +2,9 @@
 - FAST LOOP: `quality-gates` (light checks) τρέχει σε κάθε PR. `heavy-checks` τρέχει ΜΟΝΟ όταν το PR δεν είναι draft και δεν έχει label `ci:light`.
 - e2e-full: Nightly + manual (`e2e-full.yml`).
 - Concurrency: cancel-in-progress για PR pipelines.
+
+### 2025-11-18 09:15 EET — Staging hardening complete
+- PM2 autostart (systemd) ενεργό
+- Certbot timer ενεργός (auto-renew)
+- Health: https://staging.dixis.io/api/healthz → 200 OK
+- Removed deprecated swcMinify από Next config


### PR DESCRIPTION
- Add .github/workflows/staging-smoke.yml for automated health checks
- Run every 30 minutes and on frontend changes
- Update docs/OPS/STATE.md with staging hardening status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
