### PR TITLE
test(e2e): AG116.3 diagnostics for /products reload loop (logs only)

### DIFF
--- a/frontend/playwright.smoke.config.ts
+++ b/frontend/playwright.smoke.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     {
       name: 'production-smoke',
       use: { ...devices['Desktop Chrome'] },
-      testMatch: ['**/reload-and-css.smoke.spec.ts']
+      testMatch: ['**/reload-and-css.smoke.spec.ts', '**/diag-*.spec.ts']
     }
   ],
 

--- a/frontend/tests/e2e/diag-products-loop.spec.ts
+++ b/frontend/tests/e2e/diag-products-loop.spec.ts
@@ -1,0 +1,57 @@
+import { test } from '@playwright/test';
+
+const BASE = 'https://dixis.io';
+
+// Διαγνωστικό μόνο: δεν κάνει asserts, απλώς γράφει λεπτομερή logs για 12s
+test('AG116.3 diag: /products reload loop — collect logs for 12s', async ({ page }) => {
+  let navs = 0;
+  const consoles: string[] = [];
+  const errors: string[] = [];
+  const responses: { status: number; url: string }[] = [];
+
+  page.on('framenavigated', (frame) => {
+    if (frame === page.mainFrame()) navs++;
+  });
+
+  page.on('console', (msg) => {
+    consoles.push(`[console.${msg.type()}] ${msg.text()}`);
+  });
+
+  page.on('pageerror', (err) => {
+    errors.push(`[pageerror] ${String(err)}`);
+  });
+
+  page.on('response', (res) => {
+    const u = res.url();
+    const s = res.status();
+    if (u.includes('/products') || u.includes('_next') || u.endsWith('.js') || u.endsWith('.css')) {
+      responses.push({ status: s, url: u });
+    }
+  });
+
+  await page.goto(`${BASE}/products`, { waitUntil: 'domcontentloaded' });
+
+  // Καταγραφή current href ανά 500ms για να δούμε εάν αλλάζει συχνά
+  await page.addInitScript(() => {
+    (window as any).__hrefHistory = [];
+    setInterval(() => {
+      (window as any).__hrefHistory.push(location.href);
+    }, 500);
+  });
+
+  // Περιμένουμε 12s για να πιάσουμε το "τρέμουλο"
+  await page.waitForTimeout(12_000);
+
+  const hrefHistory = await page.evaluate(() => (window as any).__hrefHistory || []);
+  // Τύπωσε σύνοψη (reads από τα CI logs)
+  console.log('AG116.3 >>> SUMMARY');
+  console.log(`navigations(main)=${navs}`);
+  console.log(`console.count=${consoles.length}`, `pageerrors.count=${errors.length}`, `responses.count=${responses.length}`);
+  console.log('href.sample=', hrefHistory.slice(-10)); // τελευταίες 10 εγγραφές
+  console.log('--- top console lines ---');
+  consoles.slice(0, 15).forEach(l => console.log(l));
+  console.log('--- last console lines ---');
+  consoles.slice(-15).forEach(l => console.log(l));
+  console.log('--- last 15 responses ---');
+  responses.slice(-15).forEach(r => console.log(`${r.status} ${r.url}`));
+});


### PR DESCRIPTION
## Diagnostic Test for Issue #866

Collects detailed console/pageerror/navigation/response logs for 12 seconds on /products page.

### Purpose
No assertions — information-only test to support P0 investigation.

### Key Findings
**ROOT CAUSE IDENTIFIED**: All static assets return **400 Bad Request** with **text/html MIME type** instead of actual JS/CSS files.

**Impact**: 
- Browser refuses to execute scripts (wrong MIME type)
- Without working JavaScript, Next.js attempts reload
- Cycle repeats infinitely (10 navigations in 12s)

**Observations**:
- 230 console errors in 12 seconds
- 130 responses, all _next/static assets return 400
- CSS and JS files served as 'text/html' instead of proper MIME types
- Example: `/_next/static/chunks/webpack-5eb93372492e06cb.js` → 400, MIME: text/html

### Next Steps
Fix Nginx configuration to properly proxy _next/static requests with correct MIME types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)