### PR TITLE
fix(ops): correct EOF delimiter in uptime-ping workflow

### DIFF
--- a/.github/workflows/uptime-ping.yml
+++ b/.github/workflows/uptime-ping.yml
@@ -20,9 +20,9 @@ jobs:
           URL="https://dixis.io/api/healthz"
           CODE=$(curl -s -o /tmp/body -w "%{http_code}" --max-time 10 "$URL" || echo "000")
           echo "status=$CODE" >> $GITHUB_OUTPUT
-          printf "body<<'EOF'\n" >> $GITHUB_OUTPUT
+          echo "body<<EOF" >> $GITHUB_OUTPUT
           (cat /tmp/body 2>/dev/null || true) >> $GITHUB_OUTPUT
-          printf "\nEOF\n" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create issue on failure
         if: steps.ping.outputs.status != '200'


### PR DESCRIPTION
## Problem
Uptime ping workflow was failing with:
```
Invalid value. Matching delimiter not found ''EOF''
```

## Solution
Fixed GITHUB_OUTPUT heredoc syntax:
- Changed `printf "\nEOF\n"` to `echo "EOF"`
- Changed `printf "body<<'EOF'\n"` to `echo "body<<EOF"`

## Testing
- Manual workflow run to verify it works correctly
- Healthz check should return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>