### PR TITLE
fix(ops): use unique timestamp delimiter for uptime workflow

### DIFF
--- a/.github/workflows/uptime-ping.yml
+++ b/.github/workflows/uptime-ping.yml
@@ -20,9 +20,10 @@ jobs:
           URL="https://dixis.io/api/healthz"
           CODE=$(curl -s -o /tmp/body -w "%{http_code}" --max-time 10 "$URL" || echo "000")
           echo "status=$CODE" >> $GITHUB_OUTPUT
-          echo "body<<EOF" >> $GITHUB_OUTPUT
+          DELIMITER="HEALTHZ_RESPONSE_$(date +%s%N)"
+          echo "body<<$DELIMITER" >> $GITHUB_OUTPUT
           (cat /tmp/body 2>/dev/null || true) >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "$DELIMITER" >> $GITHUB_OUTPUT
 
       - name: Create issue on failure
         if: steps.ping.outputs.status != '200'


### PR DESCRIPTION
## Problem
Uptime workflow still failing with EOF delimiter collision.

The response body from `/api/healthz` may contain "EOF" string, causing GitHub Actions to misparse the heredoc delimiter.

## Solution
Use timestamp-based unique delimiter (`HEALTHZ_RESPONSE_<timestamp>`) that won't collide with any response content.

## Testing
Will trigger manual workflow run after merge to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>