### PR TITLE
fix(ops): uptime workflow - base64 fallback for GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/uptime-ping.yml
+++ b/.github/workflows/uptime-ping.yml
@@ -20,21 +20,20 @@ jobs:
           URL="https://dixis.io/api/healthz"
           CODE=$(curl -s -o /tmp/body -w "%{http_code}" --max-time 10 "$URL" || echo "000")
           echo "status=$CODE" >> $GITHUB_OUTPUT
-          DELIMITER="HEALTHZ_RESPONSE_$(date +%s%N)"
-          echo "body<<$DELIMITER" >> $GITHUB_OUTPUT
-          (cat /tmp/body 2>/dev/null || true) >> $GITHUB_OUTPUT
-          echo "$DELIMITER" >> $GITHUB_OUTPUT
+          BODY_B64=$(cat /tmp/body 2>/dev/null | base64 -w0 || echo "")
+          echo "body_b64=$BODY_B64" >> $GITHUB_OUTPUT
 
       - name: Create issue on failure
         if: steps.ping.outputs.status != '200'
         uses: actions/github-script@v7
         env:
           STATUS: ${{ steps.ping.outputs.status }}
-          BODY: ${{ steps.ping.outputs.body }}
+          BODY_B64: ${{ steps.ping.outputs.body_b64 }}
         with:
           script: |
             const status = process.env.STATUS || '000';
-            const body = process.env.BODY || '(no body)';
+            const bodyB64 = process.env.BODY_B64 || '';
+            const body = bodyB64 ? Buffer.from(bodyB64, 'base64').toString('utf-8') : '(no body)';
             const title = `❌ Uptime failure (${status}) on https://dixis.io/api/healthz`;
             const description = [
               'Automated uptime check failed.',


### PR DESCRIPTION
## Summary
- Replaces heredoc delimiter approach with base64 encoding
- Avoids 'Matching delimiter not found' errors completely
- Response body encoded as single-line string, eliminating special character conflicts

## Changes
- `BODY_B64=$(cat /tmp/body | base64 -w0)` - encode response as base64
- `echo "body_b64=$BODY_B64"` - output as single-line variable
- Decode base64 in JavaScript: `Buffer.from(bodyB64, 'base64').toString('utf-8')`

## Evidence
- Previous attempts with EOF and timestamp delimiters all failed
- Base64 encoding ensures no delimiter collisions possible
- Verified: https://github.com/lomendor/Project-Dixis/actions/runs/19479007598 (delimiter error)

## Test Plan
- [x] Commit workflow changes
- [ ] Trigger manual workflow run
- [ ] Verify no delimiter errors in logs
- [ ] Verify issue creation works on failure

Fixes: AG116.6 (uptime workflow GITHUB_OUTPUT delimiter issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)