### PR TITLE
docs(readme): add CI/uptime/e2e badges (AG116.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![policy-gate](https://github.com/lomendor/Project-Dixis/actions/workflows/policy-gate.yml/badge.svg)](https://github.com/lomendor/Project-Dixis/actions/workflows/policy-gate.yml)
 [![e2e-postgres](https://github.com/lomendor/Project-Dixis/actions/workflows/e2e-postgres.yml/badge.svg)](https://github.com/lomendor/Project-Dixis/actions/workflows/e2e-postgres.yml)
 [![CodeQL](https://github.com/lomendor/Project-Dixis/actions/workflows/codeql.yml/badge.svg)](https://github.com/lomendor/Project-Dixis/actions/workflows/codeql.yml)
+[![Quality Gates](https://github.com/lomendor/Project-Dixis/actions/workflows/quality-gates.yml/badge.svg)](https://github.com/lomendor/Project-Dixis/actions/workflows/quality-gates.yml)
+[![Uptime Monitoring](https://github.com/lomendor/Project-Dixis/actions/workflows/uptime-ping.yml/badge.svg)](https://github.com/lomendor/Project-Dixis/actions/workflows/uptime-ping.yml)
+[![E2E Prod Smoke](https://github.com/lomendor/Project-Dixis/actions/workflows/e2e-prod-smoke.yml/badge.svg)](https://github.com/lomendor/Project-Dixis/actions/workflows/e2e-prod-smoke.yml)
 
 **Modern Laravel 11 API** for agricultural marketplace connecting producers and consumers.
 


### PR DESCRIPTION
## Summary
Adds status badges for improved observability:
- **Quality Gates**: Comprehensive CI checks
- **Uptime Monitoring**: 15-minute health checks against https://dixis.io/api/healthz
- **E2E Prod Smoke**: Daily production smoke tests

## Evidence
All three workflows are active and passing:
- quality-gates.yml: PR gating workflow
- uptime-ping.yml: Fixed in AG116.6 with base64 encoding (PR #880)
- e2e-prod-smoke.yml: Scheduled daily at 03:07 EET (PR #869)

## Impact
Improves README visibility into production monitoring infrastructure deployed in AG116 series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)