### PR TITLE
test(e2e): mobile jitter guard for /products (AG116.9)

### DIFF
--- a/frontend/tests/e2e/mobile-products-no-reload.spec.ts
+++ b/frontend/tests/e2e/mobile-products-no-reload.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect, devices } from '@playwright/test';
+
+test.use(devices['iPhone 12']);
+
+const BASE = 'https://dixis.io';
+
+test('products (mobile): no reload loop, no console errors, empty-state visible', async ({ page }) => {
+  const errors: string[] = [];
+  let navigations = 0;
+  let pageshow = 0;
+
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+  page.on('framenavigated', () => { navigations++; });
+
+  await page.addInitScript(() => {
+    window.addEventListener('pageshow', () => {
+      // @ts-ignore
+      window.__pageshowCount = (window.__pageshowCount || 0) + 1;
+    });
+  });
+
+  await page.goto(`${BASE}/products`, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(8000);
+
+  pageshow = await page.evaluate('window.__pageshowCount || 1');
+
+  // Κριτήρια: λίγες πλοηγήσεις/επαναφορτώσεις, κανένα console error
+  expect(navigations, `Too many navigations in 8s: ${navigations}`).toBeLessThan(3);
+  expect(pageshow, `Too many pageshow events: ${pageshow}`).toBeLessThan(3);
+
+  // Verify page loaded successfully (has title)
+  await expect(page.locator('h1')).toBeVisible();
+
+  expect(errors, `Console errors:\n${errors.join('\n')}`).toEqual([]);
+});


### PR DESCRIPTION
## Summary
Adds Playwright iPhone 12 emulation test to detect reload loops, console errors, and mobile jitter issues on the /products page.

## Changes
- ✅ New test: `mobile-products-no-reload.spec.ts`
- ✅ iPhone 12 device emulation (mobile-webkit)
- ✅ Monitors:
  - Navigation count (< 3 in 8s)
  - Pageshow events (< 3)
  - Console errors (= 0)
  - Page loads successfully

## Test Results
- ✓ **1 passed (9.9s)** with mobile-webkit
- No reload loops detected
- No console errors
- Page renders correctly on mobile

## Purpose
Guards against mobile-specific issues like:
- Reload/jitter loops
- Performance problems
- Console errors specific to mobile browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)