### PR TITLE
chore(ci): uptime smokes (cron) — /, /products, /api/healthz (AG116.10)

### DIFF
--- a/.github/workflows/uptime-smokes.yml
+++ b/.github/workflows/uptime-smokes.yml
@@ -1,0 +1,43 @@
+name: Uptime Smokes
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+jobs:
+  smokes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: uptime-smokes
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        url:
+          - "https://dixis.io/"
+          - "https://dixis.io/products"
+          - "https://dixis.io/api/healthz"
+    steps:
+      - name: Curl ${{ matrix.url }}
+        run: |
+          URL="${{ matrix.url }}"
+          read -r CODE TIME <<<"$(curl -sS -o /dev/null -w "%{http_code} %{time_total}" "$URL")"
+          echo "GET $URL -> $CODE in ${TIME}s"
+
+          # Status must be 200
+          if [ "$CODE" != "200" ]; then
+            echo "::error title=Bad status::$URL → $CODE"
+            echo "- $URL → $CODE" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          # Latency guard: ≤ 2.5s
+          awk -v t="$TIME" 'BEGIN{ if (t>2.5) exit 1 }' || {
+            echo "::error title=Slow response::$URL took ${TIME}s (>2.5s)"
+            echo "- SLOW: $URL → ${TIME}s" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
+          echo "- OK: $URL → $CODE in ${TIME}s" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
Adds scheduled uptime monitoring workflow that runs every 10 minutes to verify critical endpoints are healthy and responsive.

## Changes
- ✅ New workflow: `.github/workflows/uptime-smokes.yml`
- ✅ Schedule: Every 10 minutes (`*/10 * * * *`)
- ✅ Manual trigger: `workflow_dispatch`

## Monitored URLs
- `https://dixis.io/` (homepage)
- `https://dixis.io/products` (products page)
- `https://dixis.io/api/healthz` (health endpoint)

## Guards
- ✅ **Status**: Must be 200 (fails on any other status)
- ✅ **Latency**: Must be ≤2.5s (fails if slower)
- ✅ **Summary**: Produces GitHub step summary with results

## Configuration
- `fail-fast: false` → All URLs tested even if one fails
- `concurrency.cancel-in-progress: true` → Prevents overlapping runs
- `timeout-minutes: 5` → Safety timeout per job

## Benefits
- Early detection of downtime
- Latency degradation alerts
- Per-URL visibility in matrix
- Automatic GitHub step summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)