### PR TITLE
feat(products): temporary demo feed for /products (AG116.15)

### DIFF
--- a/frontend/src/app/api/demo-products/route.ts
+++ b/frontend/src/app/api/demo-products/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+
+export const revalidate = 60
+
+async function readDemo(): Promise<any[]> {
+  const roots = [process.cwd(), path.join(process.cwd(), 'frontend')]
+  for (const root of roots) {
+    const candidate = path.join(root, 'public', 'demo', 'products.json')
+    try {
+      const raw = await fs.readFile(candidate, 'utf8')
+      return JSON.parse(raw)
+    } catch {}
+  }
+  return []
+}
+
+export async function GET() {
+  const data = await readDemo()
+  const res = NextResponse.json({ items: data }, { status: 200 })
+  res.headers.set('Cache-Control', 'public, max-age=30, s-maxage=60, stale-while-revalidate=120')
+  return res
+}

--- a/frontend/tests/e2e/products-feed.smoke.spec.ts
+++ b/frontend/tests/e2e/products-feed.smoke.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.BASE_URL || 'https://dixis.io'
+
+test('products renders cards from demo feed', async ({ page }) => {
+  await page.goto(`${BASE}/products`, { waitUntil: 'domcontentloaded' })
+  await page.waitForTimeout(1200)
+
+  const cards = page.locator('main .grid > div')
+  await expect(cards.first()).toBeVisible()
+
+  const count = await cards.count()
+  expect(count).toBeGreaterThan(3)
+})


### PR DESCRIPTION
## Purpose
Συνδέει το /products με προσωρινό API endpoint που σερβίρει demo data χωρίς database.

## Changes
- 🔌 **New API Route**: `/api/demo-products`
  - Reads from `public/demo/products.json`
  - Robust path resolution (works in dev & prod)
  - ISR with 60s revalidation + HTTP caching headers

- 📄 **Updated /products Page**:
  - Now fetches from `/api/demo-products`
  - Server-rendered with 30s revalidation
  - Removed i18n and ProductsDiagOverlay dependencies
  - Kept canonical URL from AG116.13

- ✅ **E2E Smoke Test**:
  - `products-feed.smoke.spec.ts`
  - Verifies cards render from demo feed
  - Checks for >3 products visible

## Technical Details
```typescript
// API Route
GET /api/demo-products
Response: { items: Product[] }
Cache: public, max-age=30, s-maxage=60, stale-while-revalidate=120

// Products Page
export const revalidate = 30
await fetch('/api/demo-products', { cache: 'no-store' })
```

## Impact
- ✅ Zero production DB impact (uses static JSON)
- ✅ Mobile-ready responsive grid (2-4 columns)
- ✅ Ready for Neon DB swap later
- ✅ Maintains SEO (canonical URL preserved)

## Next Step
Replace `/api/demo-products` with real Neon DB query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)