### PR TITLE
test(e2e): remote Playwright config for prod smokes (AG116.15R)

### DIFF
--- a/frontend/playwright.config.remote.ts
+++ b/frontend/playwright.config.remote.ts
@@ -1,0 +1,16 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: process.env.BASE_URL || 'https://dixis.io',
+    trace: 'off',
+  },
+  webServer: undefined, // ΚΑΝΕΝΑΣ τοπικός server — τρέχουμε απέναντι στο production
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'iphone',   use: { ...devices['iPhone 13'] } },
+  ],
+});


### PR DESCRIPTION
## Purpose
Προσθήκη remote Playwright config για τρέξιμο smoke tests απευθείας στο production χωρίς local webServer.

## Changes
- 📝 **New File**: `playwright.config.remote.ts`
  - No `webServer` configuration
  - baseURL: `https://dixis.io`
  - Projects: chromium + iPhone 13
  - Timeout: 30s per test

## Usage
```bash
# Run smoke tests against production
pnpm exec playwright test --config=playwright.config.remote.ts

# Specific tests
pnpm exec playwright test   tests/e2e/reload-and-css.smoke.spec.ts   tests/e2e/products-feed.smoke.spec.ts   --config=playwright.config.remote.ts
```

## Test Results (Pre-Merge)
✅ **All 6 tests passed** in 10.8s:
- ✓ homepage: styles applied (chromium + iPhone)
- ✓ products: cards render (chromium + iPhone)
- ✓ products: no reload loop (chromium + iPhone)

## Benefits
- ✅ Validate production deployments immediately
- ✅ No local server startup delay
- ✅ True end-to-end production testing
- ✅ Mobile testing with iPhone 13 emulation

## Impact
- Zero runtime changes
- Additive only (doesn't affect existing configs)
- Can be used in CI for post-deploy validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)