### PR TITLE
docs(pass): AG119 kickoff — Products from Neon (read-only, feature-flagged)

### DIFF
--- a/docs/AGENT/PASSES/AG119.md
+++ b/docs/AGENT/PASSES/AG119.md
@@ -1,0 +1,26 @@
+# AG119 — Products from Neon (read-only)
+
+**Goal**: `/products` να διαβάζει από Neon Postgres (Prisma), πίσω από feature flag `products_db_v1`.
+
+## Scope
+- **Prisma model**: Product (id, title, price_cents, image, producer_name, created_at)
+- **Read-only list** (no filters/cart)
+- **Feature flag OFF by default**
+- **E2E smoke**: renders ≥4 cards όταν flag=ON
+
+## Risks
+- **Low** (flagged). No checkout impact.
+
+## Implementation Plan
+1. Add Prisma schema for Product model
+2. Create `/api/products` route with feature flag check
+3. Update `/products` page to fetch from API when flag enabled
+4. Add E2E smoke test for DB mode
+5. Document flag in FEATURE_FLAGS.md
+
+## Success Criteria
+- [ ] Prisma model deployed
+- [ ] API endpoint returns products from DB
+- [ ] Feature flag controls data source
+- [ ] E2E smoke test passes with flag ON
+- [ ] Production works with flag OFF (default)

--- a/frontend/docs/FEATURE_FLAGS.md
+++ b/frontend/docs/FEATURE_FLAGS.md
@@ -1,0 +1,24 @@
+# Feature Flags
+
+## Active Flags
+
+### `products_db_v1`
+**Purpose**: Ενεργοποιεί read-only λίστα προϊόντων από DB στο `/products`.
+
+**Status**: OFF by default
+
+**Usage**:
+```bash
+# Enable in production
+PRODUCTS_DB_V1=on npm run build
+
+# Disable (default)
+PRODUCTS_DB_V1=off npm run build
+```
+
+**Implementation**:
+- When ON: `/products` fetches from Neon Postgres via `/api/products`
+- When OFF: `/products` uses static demo data
+- No impact on cart or checkout flows
+
+**Risks**: Low (isolated to products list only)


### PR DESCRIPTION
Ξεκινά AG119: /products από Neon (Prisma), πίσω από flag `products_db_v1`. Προς το παρόν μόνο skeleton docs. Θα ακολουθήσει κώδικας & smokes.