### PR TITLE
test: AG119.1b — Products smoke tests

### DIFF
--- a/frontend/tests/e2e/products.api.smoke.spec.ts
+++ b/frontend/tests/e2e/products.api.smoke.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.BASE_URL || 'https://dixis.io'
+
+test('/api/products returns 200 with items array', async ({ request }) => {
+  const res = await request.get(`${BASE}/api/products`)
+  expect(res.status()).toBe(200)
+
+  const json = await res.json()
+  expect(json).toHaveProperty('source')
+  expect(json).toHaveProperty('count')
+  expect(json).toHaveProperty('items')
+  expect(Array.isArray(json.items)).toBeTruthy()
+})

--- a/frontend/tests/e2e/products.page.smoke.spec.ts
+++ b/frontend/tests/e2e/products.page.smoke.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.BASE_URL || 'https://dixis.io'
+
+test('/products page renders without errors', async ({ page }) => {
+  await page.goto(`${BASE}/products`, { waitUntil: 'domcontentloaded' })
+
+  // Wait for main content to load
+  await page.waitForSelector('main', { timeout: 10000 })
+
+  // Verify page title is visible
+  await expect(page.getByRole('heading', { name: /προϊόντα/i })).toBeVisible()
+
+  // Verify no infinite reload loops (wait 5s and check navigation count)
+  let navigationCount = 0
+  page.on('framenavigated', () => { navigationCount++ })
+  await page.waitForTimeout(5000)
+  expect(navigationCount).toBeLessThan(3)
+})


### PR DESCRIPTION
## Summary
Add smoke test coverage for `/api/products` API endpoint and `/products` page.

### Tests Added
- **products.api.smoke.spec.ts**: Verifies API returns 200 with correct JSON structure
- **products.page.smoke.spec.ts**: Verifies page renders without infinite reload loops

### Verification
- Production `/api/products`: ✅ Returns `{"source":"db","count":6,"items":[...]}`
- Production `/products` page: ✅ Renders correctly
- Smoke tests will run in CI against production

### Context
Part of AG119.1b - Products implementation smoke test coverage. Closes infrastructure gap identified when main branch already had working `/api/products` implementation with `PRODUCTS_MODE` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)