### PR TITLE
fix(test): disable globalSetup for smoke config

### DIFF
--- a/frontend/playwright.smoke.config.ts
+++ b/frontend/playwright.smoke.config.ts
@@ -3,6 +3,7 @@ import base from './playwright.config';
 
 export default defineConfig({
   ...base,
+  globalSetup: undefined, // No global setup needed for read-only smoke tests
   testMatch: ['**/*.smoke.spec.ts'],
   reporter: [['list']],
   projects: undefined, // Override projects to use top-level testMatch


### PR DESCRIPTION
## Problem
E2E Prod Smoke (dixis.io) CI workflow αποτυγχάνει με error:
```
Error: Playwright Test did not expect test() to be called here.
```

## Root Cause
Το `playwright.smoke.config.ts` κληρονομούσε το `globalSetup` από το base config, το οποίο:
1. Κάνει import test files
2. Triggering Playwright test() function εκτός του κατάλληλου context
3. Προκαλεί configuration error στο CI

## Solution
Override `globalSetup: undefined` στο smoke config.

**Rationale:** Τα read-only smoke tests κατά του production δεν χρειάζονται:
- Authentication setup
- Storage state management
- Global fixtures

Είναι simple UI/API validation tests που τρέχουν ανώνυμα.

## Testing
✅ Local test με smoke config: Working
✅ CI check θα επαληθεύσει το fix

## Impact
- **Risk:** Minimal - αφαιρεί μόνο το μη απαραίτητο globalSetup
- **Files Changed:** 1 file, 1 line
- **Breaking Changes:** None

🤖 Generated with [Claude Code](https://claude.com/claude-code)