### PR TITLE
fix(ci): add 15s wait before smoke tests (AG116.25)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -45,6 +45,9 @@ jobs:
             echo "→ Restart"
             pm2 restart dixis-frontend --update-env
 
+            echo "→ Wait for startup"
+            sleep 15
+
             echo "→ Smoke"
             curl -sI http://127.0.0.1:3000 | head -1
             curl -s https://dixis.io/api/healthz | head -1


### PR DESCRIPTION
## Summary
Προσθέτει sleep 15 πριν τα smoke tests στο deploy-frontend workflow.

## Problem
Το deployment ολοκληρώνεται επιτυχώς (build + PM2 restart), αλλά το smoke test fail-άρει με exit status 7 επειδή η εφαρμογή χρειάζεται χρόνο να ξεκινήσει.

## Solution
Προσθέτουμε `sleep 15` μετά το `pm2 restart` και πριν τα smoke tests για να δώσουμε χρόνο στην εφαρμογή να ξεκινήσει πλήρως.

## Testing
- ✅ Production running: https://dixis.io
- ✅ Health API OK
- ✅ Demo products visible

## Files Changed
- `.github/workflows/deploy-frontend.yml`: +3 lines (add sleep 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)