### PR TITLE
fix(smoke): align prod smoke to local Playwright & no webServer

### DIFF
--- a/.github/workflows/e2e-prod-smoke.yml
+++ b/.github/workflows/e2e-prod-smoke.yml
@@ -31,14 +31,14 @@ jobs:
         working-directory: frontend
         run: |
           pnpm install --no-frozen-lockfile
-          pnpm dlx playwright install --with-deps chromium
+          pnpm exec playwright install --with-deps chromium
 
       - name: Run smoke tests against https://dixis.io
         working-directory: frontend
         env:
           PLAYWRIGHT_JSON_OUTPUT_NAME: "report.json"
         run: |
-          pnpm dlx playwright test tests/e2e/reload-and-css.smoke.spec.ts --config=playwright.smoke.config.ts --reporter=list
+          pnpm exec playwright test tests/e2e/reload-and-css.smoke.spec.ts --config=playwright.smoke.config.ts --reporter=list
 
       - name: Upload Playwright artifacts
         if: always()

--- a/frontend/playwright.smoke.config.ts
+++ b/frontend/playwright.smoke.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from '@playwright/test';
-import base from './playwright.config';
 
 export default defineConfig({
-  ...base,
-  globalSetup: undefined, // No global setup needed for read-only smoke tests
-  testMatch: ['**/*.smoke.spec.ts'],
-  reporter: [['list']],
-  projects: undefined, // Override projects to use top-level testMatch
+  testDir: './tests/e2e',
+  timeout: 60_000,
+  webServer: undefined, // δεν σηκώνουμε local server σε prod smoke
+  use: {
+    baseURL: process.env.BASE_URL || 'https://dixis.io',
+    trace: 'off',
+    screenshot: 'off',
+    video: 'off',
+  },
 });


### PR DESCRIPTION
Fixes e2e prod smoke test failures by:
- Using local `pnpm exec playwright` instead of `pnpm dlx` (avoids version mismatch)
- Removing webServer from smoke config (tests run against https://dixis.io, not localhost)

This resolves: **Playwright Test did not expect test() to be called here** error

**Testing:**
- Smoke tests now use project's pinned Playwright@1.55.0
- No local server conflicts
- Tests run cleanly against production