### PR TITLE
feat(AG117.6): wire AddToCartButton to products page

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { getProducts } from '../../../lib/products'
+import { ProductCard } from '@/components/ProductCard'
 
 export const revalidate = 30
 
@@ -16,20 +17,15 @@ export default async function ProductsPage() {
           <div className="text-neutral-600">Δεν υπάρχουν διαθέσιμα προϊόντα.</div>
         ) : (
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-            {items.map((p: any) => (
-              <div key={p.id} className="border rounded-xl bg-white overflow-hidden">
-                <div className="aspect-square bg-gray-100 flex items-center justify-center text-xs text-gray-500">
-                  εικόνα
-                </div>
-                <div className="p-4 space-y-2">
-                  <div className="text-base font-semibold line-clamp-2">{p.title}</div>
-                  <div className="text-xs text-neutral-600">{p.producer || p.producer_name || 'Παραγωγός'}</div>
-                  <div className="flex items-center justify-between pt-2">
-                    <div className="font-semibold">{p.priceFormatted || p.price_text || '—'}</div>
-                    <button className="h-9 px-3 rounded bg-neutral-900 text-white text-sm">Προσθήκη</button>
-                  </div>
-                </div>
-              </div>
+            {items.map((p) => (
+              <ProductCard
+                key={p.id}
+                id={p.id}
+                title={p.title}
+                producer={p.producer}
+                priceCents={p.priceCents ?? 0}
+                image={p.imageUrl}
+              />
             ))}
           </div>
         )}

--- a/frontend/src/lib/products.ts
+++ b/frontend/src/lib/products.ts
@@ -5,18 +5,23 @@ export interface Product {
   title: string;
   producer: string;
   priceFormatted: string;
+  priceCents: number | null;
   imageUrl: string;
   isAvailable: boolean;
 }
 
-const MOCK_PRODUCTS: Product[] = Array.from({ length: 8 }).map((_, i) => ({
-  id: `mock-${i}`,
-  title: `Δείγμα Προϊόντος ${i + 1}`,
-  producer: 'Demo Παραγωγός',
-  priceFormatted: `${(2 + i * 0.4).toFixed(2)}€`,
-  imageUrl: 'https://images.unsplash.com/photo-1488459716781-31db52582fe9?w=800&h=800&fit=crop',
-  isAvailable: true,
-}));
+const MOCK_PRODUCTS: Product[] = Array.from({ length: 8 }).map((_, i) => {
+  const cents = Math.round((2 + i * 0.4) * 100);
+  return {
+    id: `mock-${i}`,
+    title: `Δείγμα Προϊόντος ${i + 1}`,
+    producer: 'Demo Παραγωγός',
+    priceFormatted: `${(cents / 100).toFixed(2)}€`,
+    priceCents: cents,
+    imageUrl: 'https://images.unsplash.com/photo-1488459716781-31db52582fe9?w=800&h=800&fit=crop',
+    isAvailable: true,
+  };
+});
 
 const fmtPrice = (item: any): string => {
   if (item.price_text) return item.price_text;
@@ -26,6 +31,12 @@ const fmtPrice = (item: any): string => {
 };
 
 const imgUrl = (item: any): string => item.image || item.img || 'https://images.unsplash.com/photo-1488459716781-31db52582fe9?w=800&h=800&fit=crop';
+
+const centsFrom = (item: any): number | null => {
+  if (typeof item.price_cents === 'number') return item.price_cents;
+  if (typeof item.price === 'number') return Math.round(item.price * 100);
+  return null;
+};
 
 export const getProducts = cache(async (): Promise<Product[]> => {
   // 1) Προσπάθησε REAL API (εάν υπάρχει NEXT_PUBLIC_API_BASE_URL)
@@ -42,6 +53,7 @@ export const getProducts = cache(async (): Promise<Product[]> => {
             title: it.title || it.name || 'Άγνωστο Προϊόν',
             producer: it.producer_name || it.producer?.name || 'Άγνωστος Παραγωγός',
             priceFormatted: fmtPrice(it),
+            priceCents: centsFrom(it),
             imageUrl: imgUrl(it),
             isAvailable: true
           }));
@@ -62,6 +74,7 @@ export const getProducts = cache(async (): Promise<Product[]> => {
           title: it.title || it.name || 'Άγνωστο Προϊόν',
           producer: it.producer_name || it.producer?.name || 'Άγνωστος Παραγωγός',
           priceFormatted: fmtPrice(it),
+          priceCents: centsFrom(it),
           imageUrl: imgUrl(it),
           isAvailable: true
         }));


### PR DESCRIPTION
## Summary
- Add `priceCents` field to Product interface for numeric price storage
- Implement `centsFrom()` helper to extract price in cents from API responses
- Wire ProductCard component with AddToCartButton to /products page
- Replace inline product cards with reusable ProductCard component

## Changes
- `frontend/src/lib/products.ts`: Add priceCents field + centsFrom() helper
- `frontend/src/app/(storefront)/products/page.tsx`: Use ProductCard instead of inline markup

## Evidence
- Products page now uses ProductCard component (AG117.6)
- "Προσθήκη" button is now functional and adds items to cart
- Price data flows from API → Product interface → ProductCard → AddToCartButton

🤖 Generated with [Claude Code](https://claude.com/claude-code)