### PR TITLE
test(e2e): comprehensive Neon/Prisma products test (AG119.1b)

### DIFF
--- a/frontend/tests/e2e/products-neon.spec.ts
+++ b/frontend/tests/e2e/products-neon.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * AG119.1b: Comprehensive Neon/Prisma products test
+ * - Verifies ≥8 product cards render
+ * - Captures console errors
+ */
+test('products from Neon/Prisma render ≥8 cards without errors', async ({ page }) => {
+  const errors: string[] = []
+
+  // Capture console errors
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      errors.push(msg.text())
+    }
+  })
+
+  // Navigate to products page
+  await page.goto('/products', { waitUntil: 'domcontentloaded' })
+
+  // Verify heading
+  await expect(page.getByRole('heading', { name: /Προϊόντα/i })).toBeVisible()
+
+  // Verify grid and cards
+  const grid = page.locator('main .grid > div')
+  await expect(grid.first()).toBeVisible({ timeout: 10000 })
+
+  // Count should be ≥8 (we seeded 12)
+  const count = await grid.count()
+  expect(count, `Expected ≥8 product cards, got ${count}`).toBeGreaterThanOrEqual(8)
+
+  // Verify no console errors
+  expect(errors, `Console errors detected: ${errors.join(', ')}`).toEqual([])
+})


### PR DESCRIPTION
## Summary
Προσθέτει comprehensive E2E test για το Neon/Prisma products flow που ήδη υλοποιήθηκε σε PRs #991, #993, #994.

## Changes
- ✅ New test: `tests/e2e/products-neon.spec.ts`
  - Verifies ≥8 product cards render (seeded 12)
  - Captures console errors (fails if any)
  - Validates complete Prisma → API → UI flow

## Test Coverage
Builds on existing tests:
- `products-api-map.smoke.spec.ts` - API + page basic
- `products-api-has-items.spec.ts` - API structure
- `products-cards.smoke.spec.ts` - Card count >3

New test adds:
- Stricter assertion (≥8 vs >3)
- Console error capture
- Clear Neon/Prisma focus

## Existing Implementation (No Code Changes)
- Seed: `scripts/seed/products.js` (6 producers, 12 products)
- API: `/api/products` με pagination + Producer join
- Page: `/products` wired to API με Greek formatting

## Evidence
- File: frontend/tests/e2e/products-neon.spec.ts:1
- Commit: 6cae40fa
- Seeded data: 12 products from AG119.2 (PR #993)

🤖 Generated with [Claude Code](https://claude.com/claude-code)