### PR TITLE
feat(AG127): Email delivery status visibility for producers

### DIFF
--- a/frontend/src/app/api/producer/orders/[id]/status/route.ts
+++ b/frontend/src/app/api/producer/orders/[id]/status/route.ts
@@ -55,6 +55,9 @@ export async function POST(
       success: emailResult.ok,
       dryRun: emailResult.dryRun,
       error: emailResult.error,
+      message: emailResult.ok
+        ? (emailResult.dryRun ? 'Email skipped (dry-run mode)' : 'Email sent successfully')
+        : 'Email failed to send',
     })
 
   } catch (error) {


### PR DESCRIPTION
## Summary

- **Email Status UI**: Shows producers whether customer notification email was sent, skipped (dev mode), or failed
- **Retry Functionality**: Failed emails can be retried with one click
- **Visual Feedback**: Color-coded status indicators (green=sent, yellow=skipped, red=failed)

## Problem Solved

**Before AG127:** When a producer updated order status, they had no visibility into whether the customer email notification was actually sent. Failed emails were silently logged to console only.

**After AG127:** Producers immediately see the email delivery status and can retry failed notifications.

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `producer/orders/[id]/page.tsx` | +104 | Email status UI, retry logic, state tracking |
| `api/producer/orders/[id]/status/route.ts` | +3 | Add readable message to API response |
| `producer-orders-management.spec.ts` | +110 | E2E tests for email status scenarios |

**Total: +217 LOC** (within 300 LOC limit)

## Test Plan

- [x] TypeScript check passes
- [x] Build succeeds
- [x] E2E tests added for:
  - Email sent successfully → green badge
  - Email failed → red badge + retry button

## Visual Preview

```
┌─────────────────────────────────────────────────┐
│ ✅ Email ειδοποίησης στάλθηκε                   │  (Success)
└─────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────┐
│ ⚠️ Email παραλείφθηκε (dev mode)                │  (Dry-run)
└─────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────┐
│ ❌ Αποτυχία αποστολής email    [Επανάληψη]      │  (Failed + Retry)
└─────────────────────────────────────────────────┘
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)