### PR TITLE
urgent(domain): Migrate dixis.io → dixis.gr (Phase 1: Infrastructure)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -34,7 +34,7 @@ jobs:
             git reset --hard origin/main
 
             echo "→ Ensure env for demo build (NO secrets leak)"
-            export NEXT_PUBLIC_BASE_URL="https://dixis.io"
+            export NEXT_PUBLIC_BASE_URL="https://dixis.gr"
             export PRODUCTS_MODE="demo"
 
             echo "→ Build"
@@ -50,4 +50,4 @@ jobs:
 
             echo "→ Smoke"
             curl -sI http://127.0.0.1:3000 | head -1
-            curl -s https://dixis.io/api/healthz | head -1
+            curl -s https://dixis.gr/api/healthz | head -1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,4 +1,4 @@
-name: deploy-prod (dixis.io)
+name: deploy-prod (dixis.gr)
 on:
   workflow_dispatch:
     inputs:
@@ -97,5 +97,5 @@ jobs:
 
       - name: Smoke
         run: |
-          curl -sI https://dixis.io/api/healthz | head -n1
-          curl -sI https://dixis.io | head -n1
+          curl -sI https://dixis.gr/api/healthz | head -n1
+          curl -sI https://dixis.gr | head -n1

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,5 +66,5 @@ jobs:
       - name: Health check (HTTP via IP)
         run: |
           echo "🩺 Health check..."
-          curl -fsS -H "Host: staging.dixis.io" "http://${STAGING_HOST}/api/healthz"
+          curl -fsS -H "Host: staging.dixis.gr" "http://${STAGING_HOST}/api/healthz"
           echo "✅ Staging deployment successful!"

--- a/.github/workflows/e2e-prod-smoke.yml
+++ b/.github/workflows/e2e-prod-smoke.yml
@@ -1,4 +1,4 @@
-name: E2E Prod Smoke (dixis.io)
+name: E2E Prod Smoke (dixis.gr)
 
 on:
   workflow_dispatch:
@@ -33,7 +33,7 @@ jobs:
           pnpm install --no-frozen-lockfile
           pnpm exec playwright install --with-deps chromium
 
-      - name: Run smoke tests against https://dixis.io
+      - name: Run smoke tests against https://dixis.gr
         working-directory: frontend
         env:
           PLAYWRIGHT_JSON_OUTPUT_NAME: "report.json"
@@ -59,7 +59,7 @@ jobs:
             const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
             const title = `❌ E2E Prod Smoke failed — run #${{ github.run_id }}`;
             const body = [
-              "The scheduled E2E smoke on **https://dixis.io** failed.",
+              "The scheduled E2E smoke on **https://dixis.gr** failed.",
               "",
               `**Run:** ${runUrl}`,
               "",

--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           filename: perf/k6/products-smoke.js
         env:
-          BASE_URL: https://dixis.io
+          BASE_URL: https://dixis.gr
   cart:
     runs-on: ubuntu-latest
     steps:
@@ -21,4 +21,4 @@ jobs:
         with:
           filename: perf/k6/cart-smoke.js
         env:
-          BASE_URL: https://dixis.io
+          BASE_URL: https://dixis.gr

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,4 +1,4 @@
-name: Lighthouse CI (dixis.io)
+name: Lighthouse CI (dixis.gr)
 on:
   schedule:
     - cron: "0 6 * * 1"   # κάθε Δευτέρα 06:00
@@ -14,9 +14,9 @@ jobs:
         uses: treosh/lighthouse-ci-action@v12
         with:
           urls: |
-            https://dixis.io/
-            https://dixis.io/products
-            https://dixis.io/api/healthz
+            https://dixis.gr/
+            https://dixis.gr/products
+            https://dixis.gr/api/healthz
           uploadArtifacts: true
           temporaryPublicStorage: true
           configPath: .github/lhci-config.json

--- a/.github/workflows/prod-smoke-alert.yml
+++ b/.github/workflows/prod-smoke-alert.yml
@@ -18,13 +18,13 @@ jobs:
           echo "" >> fail-report.md
           echo "### Live checks" >> fail-report.md
           echo '#### /api/healthz' >> fail-report.md
-          curl -sS -i https://dixis.io/api/healthz | sed -n '1,5p' >> fail-report.md || true
+          curl -sS -i https://dixis.gr/api/healthz | sed -n '1,5p' >> fail-report.md || true
           echo '' >> fail-report.md
           echo '#### /api/products (first 200 chars)' >> fail-report.md
-          curl -sS https://dixis.io/api/products | head -c 200 >> fail-report.md || true
+          curl -sS https://dixis.gr/api/products | head -c 200 >> fail-report.md || true
           echo '' >> fail-report.md
           echo '#### /products 200?' >> fail-report.md
-          curl -sS -o /dev/null -w "HTTP %{http_code}\n" https://dixis.io/products >> fail-report.md || true
+          curl -sS -o /dev/null -w "HTTP %{http_code}\n" https://dixis.gr/products >> fail-report.md || true
 
       - name: Open issue
         uses: peter-evans/create-issue-from-file@v4

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -15,20 +15,20 @@ jobs:
       - name: Check /api/healthz
         run: |
           set -e
-          OUT="$(curl -sS https://dixis.io/api/healthz || true)"
+          OUT="$(curl -sS https://dixis.gr/api/healthz || true)"
           echo "$OUT"
           echo "$OUT" | jq -e '.status == "ok"' >/dev/null
 
       - name: Check /api/products shape
         run: |
           set -e
-          OUT="$(curl -sS https://dixis.io/api/products || true)"
+          OUT="$(curl -sS https://dixis.gr/api/products || true)"
           echo "$OUT"
           echo "$OUT" | jq -e 'has("source") and has("items") and (.items | type=="array")' >/dev/null
 
       - name: Check /products HTTP 200
         run: |
           set -e
-          CODE=$(curl -s -o /dev/null -w "%{http_code}" https://dixis.io/products)
+          CODE=$(curl -s -o /dev/null -w "%{http_code}" https://dixis.gr/products)
           echo "status=$CODE"
           [ "$CODE" -eq 200 ]

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Healthz (prod)
         run: |
           set -euo pipefail
-          URL="https://dixis.io/api/healthz"
+          URL="https://dixis.gr/api/healthz"
           echo "GET $URL"
           CODE="$(curl -sk -o /tmp/hz.json -w '%{http_code}' "$URL")"
           echo "HTTP $CODE"
@@ -26,6 +26,6 @@ jobs:
       - name: Homepage HEAD
         run: |
           set -euo pipefail
-          CODE=$(curl -skI -o /dev/null -w "%{http_code}" https://dixis.io/)
+          CODE=$(curl -skI -o /dev/null -w "%{http_code}" https://dixis.gr/)
           echo "HTTP $CODE"
           test "$CODE" = "200"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      PLAYWRIGHT_BASE_URL: https://dixis.io
+      PLAYWRIGHT_BASE_URL: https://dixis.gr
     defaults:
       run:
         working-directory: frontend

--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Healthz
         run: |
           set -euo pipefail
-          URL="https://staging.dixis.io/api/healthz"
+          URL="https://staging.dixis.gr/api/healthz"
           echo "GET $URL"
           CODE="$(curl -sk -o /tmp/hz.json -w '%{http_code}' "$URL")"
           echo "HTTP $CODE"

--- a/.github/workflows/uptime-healthz.yml
+++ b/.github/workflows/uptime-healthz.yml
@@ -14,7 +14,7 @@ jobs:
         id: curl
         run: |
           set -euo pipefail
-          code=$(curl -sk -o /dev/null -w "%{http_code}" "https://dixis.io/api/healthz")
+          code=$(curl -sk -o /dev/null -w "%{http_code}" "https://dixis.gr/api/healthz")
           echo "code=$code" >> "$GITHUB_OUTPUT"
           if [ "$code" != "200" ]; then
             echo "::error::healthz returned $code"

--- a/.github/workflows/uptime-ping.yml
+++ b/.github/workflows/uptime-ping.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Ping /api/healthz
         id: ping
         run: |
-          URL="https://dixis.io/api/healthz"
+          URL="https://dixis.gr/api/healthz"
           CODE=$(curl -s -o /tmp/body -w "%{http_code}" --max-time 10 "$URL" || echo "000")
           echo "status=$CODE" >> $GITHUB_OUTPUT
           BODY_B64=$(cat /tmp/body 2>/dev/null | base64 -w0 || echo "")
@@ -34,7 +34,7 @@ jobs:
             const status = process.env.STATUS || '000';
             const bodyB64 = process.env.BODY_B64 || '';
             const body = bodyB64 ? Buffer.from(bodyB64, 'base64').toString('utf-8') : '(no body)';
-            const title = `❌ Uptime failure (${status}) on https://dixis.io/api/healthz`;
+            const title = `❌ Uptime failure (${status}) on https://dixis.gr/api/healthz`;
             const description = [
               'Automated uptime check failed.',
               '',

--- a/.github/workflows/uptime-smoke.yml
+++ b/.github/workflows/uptime-smoke.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Probe healthz on prod domain
         run: |
           set -e
-          URL="https://dixis.io/api/healthz"
+          URL="https://dixis.gr/api/healthz"
           echo "Probing $URL"
           RESPONSE=$(curl -fsS "$URL")
           echo "Response: $RESPONSE"

--- a/.github/workflows/uptime-smokes.yml
+++ b/.github/workflows/uptime-smokes.yml
@@ -16,9 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         url:
-          - "https://dixis.io/"
-          - "https://dixis.io/products"
-          - "https://dixis.io/api/healthz"
+          - "https://dixis.gr/"
+          - "https://dixis.gr/products"
+          - "https://dixis.gr/api/healthz"
     steps:
       - name: Curl ${{ matrix.url }}
         run: |

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         url:
-          - "https://dixis.io/"
-          - "https://dixis.io/api/healthz"
-          - "https://dixis.io/robots.txt"
-          - "https://dixis.io/sitemap.xml"
+          - "https://dixis.gr/"
+          - "https://dixis.gr/api/healthz"
+          - "https://dixis.gr/robots.txt"
+          - "https://dixis.gr/sitemap.xml"
     steps:
       - name: Curl ${{ matrix.url }}
         run: |

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -72,7 +72,7 @@ DIXIS_DATA_SRC=demo
 
 # ── Feature Flags (Pass AG116.1) ─────────────────────────────────────
 # Landing Mode: Show coming-soon page instead of full catalog
-# Set to "true" for soft launch (dixis.io), "false" for full catalog
+# Set to "true" for soft launch (dixis.gr), "false" for full catalog
 PUBLIC_LANDING_MODE=false
 
 # Observability (Sentry - set in VPS only; leave empty in repo)
@@ -105,4 +105,4 @@ SMTP_PORT=587
 SMTP_SECURE=false
 SMTP_USER=
 SMTP_PASS=
-MAIL_FROM="Dixis <no-reply@dixis.io>"
+MAIL_FROM="Dixis <no-reply@dixis.gr>"

--- a/frontend/playwright.config.remote.ts
+++ b/frontend/playwright.config.remote.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 10_000 },
   use: {
-    baseURL: process.env.BASE_URL || 'https://dixis.io',
+    baseURL: process.env.BASE_URL || 'https://dixis.gr',
     trace: 'off',
   },
   webServer: undefined, // ΚΑΝΕΝΑΣ τοπικός server — τρέχουμε απέναντι στο production

--- a/frontend/playwright.config.smoke.prod.ts
+++ b/frontend/playwright.config.smoke.prod.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   webServer: undefined, // ΔΕΝ σηκώνουμε local server
   workers: 1,
   use: {
-    baseURL: 'https://dixis.io',
+    baseURL: 'https://dixis.gr',
     headless: true,
   },
   projects: [

--- a/frontend/playwright.remote.config.ts
+++ b/frontend/playwright.remote.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
-const baseURL = process.env.E2E_SITE_URL || 'https://dixis.io';
+const baseURL = process.env.E2E_SITE_URL || 'https://dixis.gr';
 export default defineConfig({
   testDir: './tests/e2e/smoke',
   timeout: 30_000,

--- a/frontend/playwright.smoke.config.ts
+++ b/frontend/playwright.smoke.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   timeout: 60_000,
   webServer: undefined, // δεν σηκώνουμε local server σε prod smoke
   use: {
-    baseURL: process.env.BASE_URL || 'https://dixis.io',
+    baseURL: process.env.BASE_URL || 'https://dixis.gr',
     trace: 'off',
     screenshot: 'off',
     video: 'off',

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -20,7 +20,7 @@ export const API_BASE_URL = getEnvVar(
 
 export const SITE_URL = getEnvVar(
   'NEXT_PUBLIC_SITE_URL',
-  'https://dixis.io'
+  'https://dixis.gr'
 );
 
 // Locale and Currency Configuration (Greek Defaults)

--- a/frontend/src/lib/email.ts
+++ b/frontend/src/lib/email.ts
@@ -65,8 +65,8 @@ export async function sendOrderConfirmation({
   }
 
   // Email config
-  const from = process.env.MAIL_FROM || 'Dixis <no-reply@dixis.io>'
-  const replyTo = process.env.MAIL_REPLY_TO || 'support@dixis.io'
+  const from = process.env.MAIL_FROM || 'Dixis <no-reply@dixis.gr>'
+  const replyTo = process.env.MAIL_REPLY_TO || 'support@dixis.gr'
 
   try {
     const html = renderOrderConfirmationHTML(order)
@@ -132,8 +132,8 @@ export async function sendOrderStatusUpdate({
   }
 
   // Email config
-  const from = process.env.MAIL_FROM || 'Dixis <no-reply@dixis.io>'
-  const replyTo = process.env.MAIL_REPLY_TO || 'support@dixis.io'
+  const from = process.env.MAIL_FROM || 'Dixis <no-reply@dixis.gr>'
+  const replyTo = process.env.MAIL_REPLY_TO || 'support@dixis.gr'
 
   const statusLabels: Record<string, string> = {
     processing: 'Σε Επεξεργασία',
@@ -339,9 +339,9 @@ function renderOrderConfirmationHTML(order: OrderEmailData): string {
         Μπορείτε να δείτε τα στοιχεία της παραγγελίας σας στο:
       </p>
       <p style="margin: 0;">
-        <a href="https://dixis.io/thank-you?id=${order.id}"
+        <a href="https://dixis.gr/thank-you?id=${order.id}"
            style="color: #059669; text-decoration: none; font-weight: bold; font-size: 14px;">
-          https://dixis.io/thank-you?id=${order.id}
+          https://dixis.gr/thank-you?id=${order.id}
         </a>
       </p>
     </div>

--- a/frontend/src/lib/flags.ts
+++ b/frontend/src/lib/flags.ts
@@ -15,11 +15,11 @@
 export const LANDING_MODE = process.env.PUBLIC_LANDING_MODE === 'true';
 
 /**
- * Check if current environment is production (dixis.io)
+ * Check if current environment is production (dixis.gr)
  */
 export function isProductionHost(): boolean {
   if (typeof window === 'undefined') return false;
-  return window.location.hostname.endsWith('dixis.io');
+  return window.location.hostname.endsWith('dixis.gr');
 }
 
 /**

--- a/frontend/src/lib/mailer.ts
+++ b/frontend/src/lib/mailer.ts
@@ -36,8 +36,8 @@ export async function sendOrderReceipt(params: {
 
   // Prefer public tracking URL if token exists, fallback to receipt URL
   const receiptUrl = publicToken
-    ? `https://dixis.io/orders/track/${publicToken}`
-    : `https://dixis.io/orders/receipt/${encodeURIComponent(orderId)}`;
+    ? `https://dixis.gr/orders/track/${publicToken}`
+    : `https://dixis.gr/orders/receipt/${encodeURIComponent(orderId)}`;
 
   const text = [
     `Ευχαριστούμε για την παραγγελία σας!`,
@@ -51,7 +51,7 @@ export async function sendOrderReceipt(params: {
     `Δείτε την απόδειξη: ${receiptUrl}`,
   ].join('\n');
 
-  const from = process.env.MAIL_FROM || 'Dixis <no-reply@dixis.io>';
+  const from = process.env.MAIL_FROM || 'Dixis <no-reply@dixis.gr>';
   await transport.sendMail({
     from,
     to,

--- a/frontend/src/lib/url.ts
+++ b/frontend/src/lib/url.ts
@@ -1,4 +1,4 @@
-export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://dixis.io';
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://dixis.gr';
 
 export function abs(path: string): string {
   if (!path) return SITE_URL;

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,7 +1,7 @@
 {
   "ci": {
     "collect": {
-      "url": ["https://dixis.io/", "https://dixis.io/products"],
+      "url": ["https://dixis.gr/", "https://dixis.gr/products"],
       "numberOfRuns": 1,
       "settings": { "preset": "desktop" }
     },

--- a/perf/k6/cart-smoke.js
+++ b/perf/k6/cart-smoke.js
@@ -1,7 +1,7 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 export const options = { vus: 3, duration: '30s', thresholds: { http_req_duration: ['p(95)<800'] } };
-const BASE = __ENV.BASE_URL || 'https://dixis.io';
+const BASE = __ENV.BASE_URL || 'https://dixis.gr';
 export default function () {
   // 1) list products
   const list = http.get(`${BASE}/api/products`);

--- a/perf/k6/products-smoke.js
+++ b/perf/k6/products-smoke.js
@@ -1,7 +1,7 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 export const options = { vus: 5, duration: '30s', thresholds: { http_req_duration: ['p(95)<800'] } };
-const BASE = __ENV.BASE_URL || 'https://dixis.io';
+const BASE = __ENV.BASE_URL || 'https://dixis.gr';
 export default function () {
   const res = http.get(`${BASE}/api/products`);
   check(res, { 'status 200': r => r.status === 200 });


### PR DESCRIPTION
## 🚨 URGENT: Domain Migration Phase 1

**Reason:** dixis.io domain expires TODAY - all hardcoded references must be updated immediately

## Changes (116 LOC across 29 files)

### GitHub Workflows (16 files)
✅ deploy-prod.yml, deploy-frontend.yml, deploy-staging.yml
✅ lighthouse-ci.yml
✅ smoke.yml, prod-smoke.yml, e2e-prod-smoke.yml, staging-smoke.yml, production-smoke.yml, prod-smoke-alert.yml
✅ All uptime-*.yml monitoring workflows (uptime.yml, uptime-ping.yml, uptime-healthz.yml, uptime-smoke.yml, uptime-smokes.yml)
✅ k6-smoke.yml load testing

### Source Code (7 files)
✅ lib/url.ts - SITE_URL default
✅ lib/email.ts - FROM/REPLY addresses (`no-reply@dixis.gr`, `support@dixis.gr`) + thank-you links  
✅ lib/mailer.ts - order tracking URLs
✅ lib/flags.ts - hostname check
✅ src/env.ts - base URL default
✅ .env.example - email defaults

### Config Files (6 files)
✅ lighthouserc.json - test URLs
✅ playwright.config.smoke.prod.ts - base URL
✅ playwright.config.remote.ts - remote test URL
✅ playwright.remote.config.ts - remote test URL
✅ playwright.smoke.config.ts - smoke test URL
✅ perf/k6/*.js - load test URLs (cart-smoke.js, products-smoke.js)

## Impact

**BREAKING:** All dixis.io references now point to dixis.gr
- ⚡ CI/CD workflows will use new domain for health checks & deployments
- 📧 Email notifications will use @dixis.gr addresses
- 🔗 Order tracking links will use dixis.gr
- 📊 Monitoring endpoints will check dixis.gr
- 🧪 E2E tests will run against dixis.gr (via workflow env vars)

## Test Plan

- [x] TypeScript check passes
- [x] Build succeeds (Next.js compiled cleanly)
- [ ] Wait for CI checks (~5 min)
- [ ] Merge IMMEDIATELY after CI passes

## Next Steps

After Phase 1 merges:
- **Phase 2**: Update E2E test fallback URLs (~30 min, 60 LOC)
- **Phase 3**: Update documentation (~30 min, 50 LOC) - optional/async

## Timeline

**Critical path:** Merge Phase 1 → Wait for CI → Merge immediately → Start Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)