### PR TITLE
urgent(domain): Migrate dixis.io → dixis.gr (Phase 2: E2E Tests)

### DIFF
--- a/frontend/tests/e2e/cart-add-checkout.smoke.spec.ts
+++ b/frontend/tests/e2e/cart-add-checkout.smoke.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-const BASE = process.env.BASE_URL || 'https://dixis.io';
+const BASE = process.env.BASE_URL || 'https://dixis.gr';
 
 test.describe('Cart add → badge → cart page', () => {
   test('add two items updates cart badge and /cart loads cleanly', async ({ page }) => {

--- a/frontend/tests/e2e/cart-checkout-m0.spec.ts
+++ b/frontend/tests/e2e/cart-checkout-m0.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-const BASE = process.env.BASE_URL || 'https://dixis.io';
+const BASE = process.env.BASE_URL || 'https://dixis.gr';
 
 test.describe('Cart & Checkout M0 (prod)', () => {
   test('add items → cart persists → checkout success', async ({ page }) => {

--- a/frontend/tests/e2e/cart-mvp.spec.ts
+++ b/frontend/tests/e2e/cart-mvp.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-const BASE = process.env.BASE_URL || 'https://dixis.io'
+const BASE = process.env.BASE_URL || 'https://dixis.gr'
 
 test.describe('Cart MVP', () => {
   test('add updates badge', async ({ page }) => {

--- a/frontend/tests/e2e/cart-qty-controls.spec.ts
+++ b/frontend/tests/e2e/cart-qty-controls.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-const BASE = process.env.BASE_URL || 'https://dixis.io'
+const BASE = process.env.BASE_URL || 'https://dixis.gr'
 
 /**
  * AG119.2.1: Cart qty +/- controls E2E test

--- a/frontend/tests/e2e/cart-smoke.spec.ts
+++ b/frontend/tests/e2e/cart-smoke.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-const BASE = process.env.BASE_URL || 'https://dixis.io';
+const BASE = process.env.BASE_URL || 'https://dixis.gr';
 
 test('cart page loads', async ({ page }) => {
   await page.goto(`${BASE}/cart`, { waitUntil: 'domcontentloaded' });

--- a/frontend/tests/e2e/diag-products-loop.spec.ts
+++ b/frontend/tests/e2e/diag-products-loop.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 
-const BASE = 'https://dixis.io';
+const BASE = 'https://dixis.gr';
 
 // Διαγνωστικό μόνο: δεν κάνει asserts, απλώς γράφει λεπτομερή logs για 12s
 test('AG116.3 diag: /products reload loop — collect logs for 12s', async ({ page }) => {

--- a/frontend/tests/e2e/mobile-products-no-reload.spec.ts
+++ b/frontend/tests/e2e/mobile-products-no-reload.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, devices } from '@playwright/test';
 
 test.use(devices['iPhone 12']);
 
-const BASE = 'https://dixis.io';
+const BASE = 'https://dixis.gr';
 
 test('products (mobile): no reload loop, no console errors, empty-state visible', async ({ page }) => {
   const errors: string[] = [];

--- a/frontend/tests/e2e/mobile-reload-loop.smoke.spec.ts
+++ b/frontend/tests/e2e/mobile-reload-loop.smoke.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-const BASE = process.env.BASE_URL || 'https://dixis.io';
+const BASE = process.env.BASE_URL || 'https://dixis.gr';
 
 test.describe('mobile safari smokes', () => {
   test.use({

--- a/frontend/tests/e2e/products-api-map.smoke.spec.ts
+++ b/frontend/tests/e2e/products-api-map.smoke.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-const BASE = process.env.BASE_URL || 'https://dixis.io'
+const BASE = process.env.BASE_URL || 'https://dixis.gr'
 
 test('products page renders and API responds', async ({ page, request }) => {
   const res = await request.get(`${BASE}/api/products`)

--- a/frontend/tests/e2e/products-card-ui.smoke.spec.ts
+++ b/frontend/tests/e2e/products-card-ui.smoke.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-const BASE = process.env.BASE_URL || 'https://dixis.io'
+const BASE = process.env.BASE_URL || 'https://dixis.gr'
 
 test.describe('Products UI — Stable Smoke', () => {
   test('renders grid and product cards without console errors', async ({ page }) => {

--- a/frontend/tests/e2e/products-cards.smoke.spec.ts
+++ b/frontend/tests/e2e/products-cards.smoke.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-const BASE = process.env.BASE_URL || 'https://dixis.io'
+const BASE = process.env.BASE_URL || 'https://dixis.gr'
 
 test('products page renders multiple product cards', async ({ page }) => {
   await page.goto(`${BASE}/products`, { waitUntil: 'domcontentloaded' })

--- a/frontend/tests/e2e/products-demo.smoke.spec.ts
+++ b/frontend/tests/e2e/products-demo.smoke.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.use({ viewport: { width: 390, height: 844 } }); // iPhone-ish
 
-const BASE = 'https://dixis.io';
+const BASE = 'https://dixis.gr';
 
 test('products-demo renders cards and no console errors', async ({ page }) => {
   const errors: string[] = [];

--- a/frontend/tests/e2e/products-feed.smoke.spec.ts
+++ b/frontend/tests/e2e/products-feed.smoke.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-const BASE = process.env.BASE_URL || 'https://dixis.io'
+const BASE = process.env.BASE_URL || 'https://dixis.gr'
 
 test('products renders cards from demo feed', async ({ page }) => {
   await page.goto(`${BASE}/products`, { waitUntil: 'domcontentloaded' })

--- a/frontend/tests/e2e/products-mobile-webkit.smoke.spec.ts
+++ b/frontend/tests/e2e/products-mobile-webkit.smoke.spec.ts
@@ -10,7 +10,7 @@ test.use({
   hasTouch: true,
 });
 
-const BASE = process.env.BASE_URL || 'https://dixis.io';
+const BASE = process.env.BASE_URL || 'https://dixis.gr';
 
 test('products (WebKit iOS emu): no reload loop/jitter', async ({ page }) => {
   let navigations = 0;

--- a/frontend/tests/e2e/products-mobile.smoke.spec.ts
+++ b/frontend/tests/e2e/products-mobile.smoke.spec.ts
@@ -5,7 +5,7 @@ test.use({
   ...devices['iPhone 13'],
 });
 
-const BASE = process.env.BASE_URL || 'https://dixis.io';
+const BASE = process.env.BASE_URL || 'https://dixis.gr';
 
 test('products mobile: no reload loop & no console errors', async ({ page }) => {
   const errors: string[] = [];

--- a/frontend/tests/e2e/products-neon.smoke.spec.ts
+++ b/frontend/tests/e2e/products-neon.smoke.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-const BASE = process.env.BASE_URL || 'https://dixis.io'
+const BASE = process.env.BASE_URL || 'https://dixis.gr'
 
 test('products: grid renders and no console errors', async ({ page }) => {
   const errors: string[] = []

--- a/frontend/tests/e2e/products-source.smoke.spec.ts
+++ b/frontend/tests/e2e/products-source.smoke.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-const BASE = process.env.BASE_URL || 'https://dixis.io'
+const BASE = process.env.BASE_URL || 'https://dixis.gr'
 test('products page shows source and renders grid', async ({ page }) => {
   await page.goto(`${BASE}/products`, { waitUntil: 'domcontentloaded' })
   await expect(page.getByText(/Πηγή:\s+(demo|db)/)).toBeVisible()

--- a/frontend/tests/e2e/products-ui.smoke.spec.ts
+++ b/frontend/tests/e2e/products-ui.smoke.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-const BASE = process.env.BASE_URL || 'https://dixis.io'
+const BASE = process.env.BASE_URL || 'https://dixis.gr'
 
 test.skip('flaky: products page renders grid', async ({ page }) => {
   await page.goto(`${BASE}/products`, { waitUntil: 'domcontentloaded' })

--- a/frontend/tests/e2e/products.api.smoke.spec.ts
+++ b/frontend/tests/e2e/products.api.smoke.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-const BASE = process.env.BASE_URL || 'https://dixis.io'
+const BASE = process.env.BASE_URL || 'https://dixis.gr'
 
 test('/api/products returns 200 with items array', async ({ request }) => {
   const res = await request.get(`${BASE}/api/products`)

--- a/frontend/tests/e2e/products.page.smoke.spec.ts
+++ b/frontend/tests/e2e/products.page.smoke.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-const BASE = process.env.BASE_URL || 'https://dixis.io'
+const BASE = process.env.BASE_URL || 'https://dixis.gr'
 
 test('/products page renders without errors', async ({ page }) => {
   await page.goto(`${BASE}/products`, { waitUntil: 'domcontentloaded' })

--- a/frontend/tests/e2e/smoke-commission-preview.spec.ts
+++ b/frontend/tests/e2e/smoke-commission-preview.spec.ts
@@ -5,7 +5,7 @@ import { test, expect } from '@playwright/test';
  * (When we enable on staging later, we will override BASE_URL in CI to hit staging and expect 200.)
  */
 test('commission-preview endpoint guarded when flag OFF', async ({ request }) => {
-  const base = process.env.BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'https://dixis.io';
+  const base = process.env.BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'https://dixis.gr';
   // Use a benign order id; endpoint should be hidden (404) when flag OFF
   const res = await request.get(`${base}/api/orders/123/commission-preview`, { timeout: 15000 });
   expect([401, 403, 404]).toContain(res.status());

--- a/frontend/tests/e2e/smoke-healthz.spec.ts
+++ b/frontend/tests/e2e/smoke-healthz.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('healthz is healthy', async ({ request }) => {
-  const base = process.env.BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'https://dixis.io';
+  const base = process.env.BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'https://dixis.gr';
   const res = await request.get(`${base}/api/healthz`, { timeout: 15000 });
   expect(res.status(), 'healthz status').toBe(200);
   const json = await res.json();

--- a/frontend/tests/e2e/smoke/health.spec.ts
+++ b/frontend/tests/e2e/smoke/health.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, request } from '@playwright/test';
 
-const API = process.env.E2E_BASE_URL ?? 'https://dixis.io/api/healthz';
-const SITE = process.env.E2E_SITE_URL ?? 'https://dixis.io';
+const API = process.env.E2E_BASE_URL ?? 'https://dixis.gr/api/healthz';
+const SITE = process.env.E2E_SITE_URL ?? 'https://dixis.gr';
 
 test('api /healthz returns healthy', async () => {
   const ctx = await request.newContext();

--- a/frontend/tests/e2e/smoke/site-meta.spec.ts
+++ b/frontend/tests/e2e/smoke/site-meta.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-const SITE = process.env.E2E_SITE_URL ?? 'https://dixis.io';
+const SITE = process.env.E2E_SITE_URL ?? 'https://dixis.gr';
 
 test('robots.txt responds 200', async ({ page }) => {
   const resp = await page.goto(`${SITE}/robots.txt`, { waitUntil: 'domcontentloaded' });


### PR DESCRIPTION
## Phase 2: E2E Test URL Updates

Updates fallback URLs in E2E tests to use dixis.gr

**Files:** 24 test files  
**Changes:** 25 LOC (one file had 2 changes)  
**Pattern:** BASE_URL fallback changes only

## Key Changes

- Updated `const BASE = process.env.BASE_URL || 'https://dixis.io'` → `'https://dixis.gr'`
- Maintained environment variable precedence - workflows already set BASE_URL in Phase 1
- Kept `frontend/tests/e2e/smoke/healthz.spec.ts` dual candidate pattern for resilience during DNS propagation

## Test Plan

- [x] TypeScript check passed
- [ ] Wait for CI checks (E2E tests will use new domain)
- [ ] Merge immediately after CI passes

## Context

Part of urgent domain migration due to dixis.io expiry today. Phase 1 (infrastructure + source code) already merged in PR #1028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)