### PR TITLE
urgent(domain): Migrate dixis.io → dixis.gr (Phase 2.5: SEO & Config)

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -38,7 +38,7 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: 'https',
-        hostname: 'dixis.io',
+        hostname: 'dixis.gr',
       },
       {
         protocol: 'https',

--- a/frontend/src/app/HomeClient.tsx
+++ b/frontend/src/app/HomeClient.tsx
@@ -12,7 +12,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/contexts/ToastContext';
 import { greekNormalize, greekTextContains } from '@/lib/utils/greekNormalize';
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://dixis.io";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://dixis.gr";
 
 interface Filters {
   search: string;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -22,7 +22,7 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://dixis.io";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://dixis.gr";
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -10,7 +10,7 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 3600; // Revalidate every hour
 
 // SEO metadata for homepage
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://dixis.io";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://dixis.gr";
 
 export const metadata: Metadata = {
   title: LANDING_MODE

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -9,6 +9,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ['/ops'],
       },
     ],
-    sitemap: 'https://dixis.io/sitemap.xml',
+    sitemap: 'https://dixis.gr/sitemap.xml',
   }
 }

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -4,8 +4,8 @@ export default async function sitemap() {
     if (process.env.DATABASE_URL) {
       // placeholder για dynamic sitemap (π.χ. products, categories)
       return [
-        { url: 'https://dixis.io/' },
-        { url: 'https://dixis.io/products' }
+        { url: 'https://dixis.gr/' },
+        { url: 'https://dixis.gr/products' }
       ]
     }
   } catch (_) {
@@ -13,7 +13,7 @@ export default async function sitemap() {
   }
   // Safe fallback χωρίς DB
   return [
-    { url: 'https://dixis.io/' },
-    { url: 'https://dixis.io/products' }
+    { url: 'https://dixis.gr/' },
+    { url: 'https://dixis.gr/products' }
   ]
 }

--- a/frontend/src/components/SEOHead.tsx
+++ b/frontend/src/components/SEOHead.tsx
@@ -24,7 +24,7 @@ export default function SEOHead({
   jsonLd,
   noIndex = false,
 }: SEOHeadProps): null {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://dixis.io';
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://dixis.gr';
   
   useEffect(() => {
     // Update document title

--- a/frontend/src/server/mailer.ts
+++ b/frontend/src/server/mailer.ts
@@ -12,7 +12,7 @@ export function makeTransport(){
 }
 
 export async function sendMail(opts: { to: string, subject: string, text?: string, html?: string }){
-  const from = process.env.MAIL_FROM || `Dixis <no-reply@${(process.env.NEXT_PUBLIC_SITE_URL||'https://dixis.io').replace(/^https?:\/\//,'')}>`;
+  const from = process.env.MAIL_FROM || `Dixis <no-reply@${(process.env.NEXT_PUBLIC_SITE_URL||'https://dixis.gr').replace(/^https?:\/\//,'')}>`;
   const tx = makeTransport();
   return tx.sendMail({ from, ...opts });
 }


### PR DESCRIPTION
## Phase 2.5: SEO & Configuration Updates

**CRITICAL**: These files were missed in Phase 1 & 2 but are essential for SEO, email delivery, and site configuration.

## Changes (8 files, 11 LOC)

### Next.js Configuration
- **next.config.ts**: Updated image domain from dixis.io to dixis.gr

### SEO & Metadata
- **layout.tsx**: Root layout SEO metadata base URL
- **page.tsx**: Home page metadata
- **HomeClient.tsx**: Client-side home component
- **SEOHead.tsx**: SEO head component
- **robots.ts**: Sitemap URL in robots.txt
- **sitemap.ts**: All sitemap URLs (4 instances)

### Server Configuration
- **server/mailer.ts**: Email FROM address default domain

## Impact

**Critical for:**
- 🔍 SEO: Search engines will see correct domain in metadata, sitemap, robots.txt
- 📧 Email: Server mailer will use @dixis.gr addresses
- 🖼️ Images: Next.js image optimization will allow dixis.gr domain
- 🗺️ Sitemap: All sitemap URLs point to dixis.gr

## Test Plan

- [x] TypeScript check passed
- [ ] Wait for CI checks
- [ ] Merge immediately after CI passes

## Context

Discovered during Phase 2 verification - these production files were overlooked but are essential. Domain expires today.

**Previous PRs:**
- Phase 1 (#1028): Workflows + source code
- Phase 2 (#1030): E2E test URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)