### PR TITLE
feat(mobile): Add hamburger menu for mobile navigation

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useState } from 'react';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
 
@@ -7,19 +8,71 @@ const CartBadge = dynamic(
   { ssr: false }
 );
 
-export default function Header(){
+const navLinks = [
+  { href: '/products', label: 'Προϊόντα' },
+  { href: '/orders/lookup', label: 'Παραγγελία' },
+  { href: '/producers', label: 'Για Παραγωγούς' },
+  { href: '/legal/terms', label: 'Όροι' },
+];
+
+export default function Header() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
   return (
     <header className="border-b bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 sticky top-0 z-40">
       <div className="max-w-6xl mx-auto px-4 h-14 flex items-center justify-between">
         <Link href="/" className="font-extrabold tracking-tight text-xl">Dixis</Link>
+
+        {/* Desktop Navigation */}
         <nav className="hidden sm:flex items-center gap-5 text-sm">
-          <Link href="/products" className="hover:underline">Προϊόντα</Link>
-          <Link href="/orders/lookup" className="hover:underline">Παραγγελία</Link>
-          <Link href="/producers" className="hover:underline">Για Παραγωγούς</Link>
-          <Link href="/legal/terms" className="hover:underline">Όροι</Link>
+          {navLinks.map((link) => (
+            <Link key={link.href} href={link.href} className="hover:underline">
+              {link.label}
+            </Link>
+          ))}
         </nav>
-        <CartBadge />
+
+        <div className="flex items-center gap-2">
+          <CartBadge />
+
+          {/* Mobile Menu Button */}
+          <button
+            type="button"
+            className="sm:hidden p-2 -mr-2 min-h-[44px] min-w-[44px] flex items-center justify-center"
+            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            aria-expanded={mobileMenuOpen}
+            aria-label={mobileMenuOpen ? 'Κλείσιμο μενού' : 'Άνοιγμα μενού'}
+          >
+            {mobileMenuOpen ? (
+              <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            ) : (
+              <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            )}
+          </button>
+        </div>
       </div>
+
+      {/* Mobile Menu */}
+      {mobileMenuOpen && (
+        <nav className="sm:hidden border-t bg-white">
+          <div className="max-w-6xl mx-auto px-4 py-2">
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="block py-3 text-base hover:bg-gray-50 -mx-4 px-4"
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </nav>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- Add hamburger menu button (44px min tap target)
- Add dropdown mobile navigation menu
- Menu closes when link is clicked
- Proper aria labels for accessibility

## Problem
Mobile users (60%+ of traffic) couldn't access navigation - it was hidden with `hidden sm:flex`.

## Solution
Added responsive hamburger menu that shows on mobile screens.

## Test plan
- [ ] Open on mobile/narrow screen
- [ ] Tap hamburger icon
- [ ] Verify all nav links visible
- [ ] Tap a link - menu closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)