### PR TITLE
fix: Display proper placeholder for products without images

### DIFF
--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -12,17 +12,25 @@ type Props = {
 
 export function ProductCard({ id, title, producer, priceCents, image }: Props) {
   const price = typeof priceCents === 'number' ? (priceCents / 100).toFixed(2) + '€' : '—'
-  const displayImage = image && image.length > 0 ? image : '/demo/placeholder.jpg'
+  const hasImage = image && image.length > 0
 
   return (
     <div data-testid="product-card" className="group flex flex-col h-full bg-white border border-gray-200 rounded-xl overflow-hidden hover:shadow-xl transition-all duration-300">
       <div data-testid="product-card-image" className="relative h-48 w-full bg-gray-100 overflow-hidden">
-        <img
-          src={displayImage}
-          alt={title}
-          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-          loading="lazy"
-        />
+        {hasImage ? (
+          <img
+            src={image}
+            alt={title}
+            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-gray-400">
+            <svg className="w-16 h-16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+          </div>
+        )}
       </div>
 
       <div className="flex flex-col flex-grow p-4">

--- a/frontend/src/components/catalogue/ProductCard.tsx
+++ b/frontend/src/components/catalogue/ProductCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Link from 'next/link';
+import Image from 'next/image';
 import { formatCurrency } from '@/lib/format';
 import AddToCartButton from '@/components/cart/AddToCartButton';
 
@@ -10,9 +11,10 @@ interface ProductCardProps {
   price: number;
   currency?: string;
   producer?: { name: string };
+  imageUrl?: string | null;
 }
 
-export default function ProductCard({ id, slug, name, price, currency = 'EUR', producer }: ProductCardProps) {
+export default function ProductCard({ id, slug, name, price, currency = 'EUR', producer, imageUrl }: ProductCardProps) {
   const href = `/products/${slug || id}`;
   return (
     <article className="border rounded-lg p-4 bg-white shadow-surface-sm hover:shadow-surface-md transition-shadow">
@@ -20,8 +22,22 @@ export default function ProductCard({ id, slug, name, price, currency = 'EUR', p
         href={href}
         className="block focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
       >
-        <div className="aspect-square bg-neutral-100 rounded mb-3 flex items-center justify-center text-neutral-400 text-sm">
-          Εικόνα
+        <div className="aspect-square bg-neutral-100 rounded mb-3 overflow-hidden relative">
+          {imageUrl ? (
+            <Image
+              src={imageUrl}
+              alt={name}
+              fill
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+              className="object-cover"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-neutral-400 text-sm">
+              <svg className="w-12 h-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+            </div>
+          )}
         </div>
         <h3 className="font-medium text-neutral-900">{name}</h3>
         {producer?.name && <p className="mt-1 text-sm text-neutral-600">{producer.name}</p>}

--- a/frontend/src/components/catalogue/ProductGrid.tsx
+++ b/frontend/src/components/catalogue/ProductGrid.tsx
@@ -19,6 +19,7 @@ export default function ProductGrid({ items }: ProductGridProps) {
           price={p.price}
           currency={p.currency}
           producer={p.producer}
+          imageUrl={p.imageUrl}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Fixed product images showing broken placeholder by using inline SVG icon
- Products without images now display a clean camera icon instead of 404 error
- Updated both ProductCard components for consistency

## Changes
- `frontend/src/components/ProductCard.tsx`: Replace missing `/demo/placeholder.jpg` with SVG
- `frontend/src/components/catalogue/ProductCard.tsx`: Added imageUrl support with Next.js Image
- `frontend/src/components/catalogue/ProductGrid.tsx`: Pass imageUrl to ProductCard

## Test plan
- [ ] View /products page - products without images show camera icon placeholder
- [ ] Products with images display normally
- [ ] No broken image icons or 404 errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)