### PR TITLE
fix: Enlarge touch targets to 44px minimum for mobile

### DIFF
--- a/.claude/commands/plan-opus.md
+++ b/.claude/commands/plan-opus.md
@@ -1,0 +1,38 @@
+# Opus Planning Mode
+
+You are now in **Opus Planning Mode**. Your task: $ARGUMENTS
+
+## Instructions
+
+1. **PLANNING PHASE** (Current - Opus)
+   - Analyze the task thoroughly
+   - Explore the codebase as needed (read files, search, etc.)
+   - Create a detailed implementation plan
+   - Write the plan to a file at `.claude/plans/current-plan.md`
+   - List all files that need to be modified
+   - Estimate complexity (simple/medium/complex)
+
+2. **APPROVAL CHECKPOINT**
+   After creating the plan, ask the user:
+   ```
+   ## Plan Ready for Review
+
+   I've created the plan at `.claude/plans/current-plan.md`
+
+   **Next steps:**
+   1. Review the plan above
+   2. If approved, run: `/model sonnet` to switch to Sonnet
+   3. Then tell me: "execute the plan"
+
+   This saves Opus tokens by using Sonnet for implementation.
+   ```
+
+3. **IMPORTANT RULES**
+   - Do NOT start implementing code yet
+   - Only do research and planning
+   - Be thorough in the plan - Sonnet will follow it exactly
+   - Include code snippets/examples in the plan where helpful
+
+## Start Planning Now
+
+Analyze the task and create a comprehensive plan.

--- a/frontend/src/app/(storefront)/cart/page.tsx
+++ b/frontend/src/app/(storefront)/cart/page.tsx
@@ -76,9 +76,9 @@ export default function CartPage() {
                       <div className="font-semibold leading-tight line-clamp-2">{it.title}</div>
                       <div className="text-sm text-gray-500">{fmt.format(it.priceCents / 100)}</div>
                       <div className="mt-2 flex items-center gap-3 flex-wrap">
-                        <button type="button" onClick={() => dec(it.id)} className="h-8 w-8 rounded border hover:bg-gray-50 flex items-center justify-center" data-testid="qty-minus">−</button>
+                        <button type="button" onClick={() => dec(it.id)} className="h-11 w-11 rounded border hover:bg-gray-50 flex items-center justify-center text-lg" data-testid="qty-minus">−</button>
                         <span className="min-w-8 text-center" data-testid="qty">{it.qty}</span>
-                        <button type="button" onClick={() => inc(it.id)} className="h-8 w-8 rounded border hover:bg-gray-50 flex items-center justify-center" data-testid="qty-plus">+</button>
+                        <button type="button" onClick={() => inc(it.id)} className="h-11 w-11 rounded border hover:bg-gray-50 flex items-center justify-center text-lg" data-testid="qty-plus">+</button>
                       </div>
                     </div>
                   </div>

--- a/frontend/src/components/AddToCartButton.tsx
+++ b/frontend/src/components/AddToCartButton.tsx
@@ -27,7 +27,7 @@ export default function AddToCartButton(props: {
 
   return (
     <button
-      className={`h-9 px-3 rounded text-sm transition-colors ${
+      className={`h-11 px-4 rounded text-sm transition-colors ${
         isAdded
           ? 'bg-emerald-600 text-white'
           : 'bg-neutral-900 text-white hover:bg-neutral-800'

--- a/frontend/src/components/cart/AddToCartButton.tsx
+++ b/frontend/src/components/cart/AddToCartButton.tsx
@@ -28,7 +28,7 @@ export default function AddToCartButton(
   return (
     <button
       onClick={handleClick}
-      className={`h-10 px-4 rounded-md text-sm bg-brand text-white hover:opacity-90 ${className}`}
+      className={`h-11 px-4 rounded-md text-sm bg-brand text-white hover:opacity-90 ${className}`}
       aria-live="polite"
     >
       {ok ? '✅ Προστέθηκε' : 'Προσθήκη στο καλάθι'}


### PR DESCRIPTION
## Summary
- Enlarged all interactive button touch targets to meet WCAG 2.1 Level AAA guidelines
- Mobile users can now easily tap buttons without frustration

## Changes
- `frontend/src/components/AddToCartButton.tsx`: h-9 → h-11 (36px → 44px)
- `frontend/src/components/cart/AddToCartButton.tsx`: h-10 → h-11 (40px → 44px)
- `frontend/src/app/(storefront)/cart/page.tsx`: Quantity +/- buttons h-8 → h-11 (32px → 44px)

## Test plan
- [ ] On mobile: tap "Προσθήκη" buttons - should be easy to tap
- [ ] On cart page: tap +/- quantity buttons - should be easy to tap
- [ ] Visual check: buttons are noticeably larger and more accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)