### PR TITLE
feat: Dynamic sitemap with all product pages

### DIFF
--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,19 +1,72 @@
-export default async function sitemap() {
+import { MetadataRoute } from 'next';
+import { prisma } from '@/lib/db/client';
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://dixis.gr';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // Static pages
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/products`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/producers`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
+    {
+      url: `${BASE_URL}/legal/terms`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.3,
+    },
+    {
+      url: `${BASE_URL}/legal/privacy`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.3,
+    },
+    {
+      url: `${BASE_URL}/contact`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  ];
+
+  // Dynamic product pages
+  let productPages: MetadataRoute.Sitemap = [];
+
   try {
-    // Αν υπάρχει DB, βάλε εδώ μελλοντικά δυναμικά URLs.
-    if (process.env.DATABASE_URL) {
-      // placeholder για dynamic sitemap (π.χ. products, categories)
-      return [
-        { url: 'https://dixis.gr/' },
-        { url: 'https://dixis.gr/products' }
-      ]
-    }
-  } catch (_) {
-    // ignore
+    const products = await prisma.product.findMany({
+      where: { isActive: true },
+      select: {
+        id: true,
+        updatedAt: true,
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    productPages = products.map((product) => ({
+      url: `${BASE_URL}/products/${product.id}`,
+      lastModified: product.updatedAt,
+      changeFrequency: 'weekly' as const,
+      priority: 0.8,
+    }));
+  } catch (error) {
+    console.error('[Sitemap] Error fetching products:', error);
+    // Continue with static pages only
   }
-  // Safe fallback χωρίς DB
-  return [
-    { url: 'https://dixis.gr/' },
-    { url: 'https://dixis.gr/products' }
-  ]
+
+  return [...staticPages, ...productPages];
 }


### PR DESCRIPTION
## Summary
- Implemented dynamic sitemap that includes all active product pages
- Google can now discover and index every product in the marketplace

## Changes
- `frontend/src/app/sitemap.ts`:
  - Query all active products from database
  - Generate `/products/{id}` URLs for each product
  - Add static pages: `/producers`, `/legal/terms`, `/legal/privacy`, `/contact`
  - Set SEO metadata: `lastModified`, `changeFrequency`, `priority`
  - Graceful error handling if DB query fails

## Before
```
sitemap.xml:
- /
- /products
(2 URLs total)
```

## After
```
sitemap.xml:
- / (priority: 1.0, daily)
- /products (priority: 0.9, daily)
- /producers (priority: 0.7, weekly)
- /products/1 (priority: 0.8, weekly)
- /products/2 (priority: 0.8, weekly)
- ... (all active products)
- /legal/terms (priority: 0.3, monthly)
- /legal/privacy (priority: 0.3, monthly)
- /contact (priority: 0.5, monthly)
```

## Test plan
- [ ] Build succeeds
- [ ] Visit `/sitemap.xml` - should list all pages
- [ ] Submit to Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)