### PR TITLE
feat(AG129): Proper session token parsing

### DIFF
--- a/frontend/src/lib/auth/session.ts
+++ b/frontend/src/lib/auth/session.ts
@@ -1,11 +1,82 @@
 import { cookies } from 'next/headers';
 
+/**
+ * Extract phone number from session cookie
+ *
+ * Session token format: {type}_{phone}_{timestamp}
+ * Examples:
+ *   - admin_+306912345678_1701234567890
+ *   - user_+306987654321_1701234567890
+ *
+ * @returns Phone number or null if session is invalid/expired
+ */
 export async function getSessionPhone(): Promise<string | null> {
   const cookieStore = await cookies();
   const session = cookieStore.get('dixis_session');
-  if (!session) return null;
-  
-  // TODO: Implement proper session validation
-  // For now, return a placeholder
-  return '+306912345678';
+
+  if (!session?.value) {
+    return null;
+  }
+
+  const token = session.value;
+
+  // Parse token: {type}_{phone}_{timestamp}
+  const parts = token.split('_');
+
+  // Minimum: type + phone + timestamp = 3 parts
+  // But phone might contain underscores in international format
+  if (parts.length < 3) {
+    console.warn('[Session] Invalid token format');
+    return null;
+  }
+
+  const type = parts[0]; // 'admin' or 'user'
+  const timestamp = parseInt(parts[parts.length - 1], 10);
+
+  // Phone is everything between type and timestamp
+  // E.g., for "admin_+30_691_234_5678_1701234567890" -> "+30_691_234_5678"
+  const phone = parts.slice(1, -1).join('_');
+
+  // Validate type
+  if (type !== 'admin' && type !== 'user') {
+    console.warn('[Session] Unknown session type:', type);
+    return null;
+  }
+
+  // Validate timestamp (not expired - 7 days)
+  const maxAge = 7 * 24 * 60 * 60 * 1000; // 7 days in ms
+  const now = Date.now();
+
+  if (isNaN(timestamp) || now - timestamp > maxAge) {
+    console.warn('[Session] Session expired or invalid timestamp');
+    return null;
+  }
+
+  // Validate phone format (basic check)
+  if (!phone || phone.length < 6) {
+    console.warn('[Session] Invalid phone in token');
+    return null;
+  }
+
+  return phone;
+}
+
+/**
+ * Get session type (admin or user)
+ */
+export async function getSessionType(): Promise<'admin' | 'user' | null> {
+  const cookieStore = await cookies();
+  const session = cookieStore.get('dixis_session');
+
+  if (!session?.value) {
+    return null;
+  }
+
+  const type = session.value.split('_')[0];
+
+  if (type === 'admin' || type === 'user') {
+    return type;
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- Parse session token format: `{type}_{phone}_{timestamp}`
- Validate session type (admin/user)
- Check session expiry (7 days)
- Add `getSessionType()` helper

## Problem
Previously `getSessionPhone()` returned a hardcoded placeholder `+306912345678`, making all users appear as the same person.

## Solution
Properly parse the session token that's set during OTP verification.

## Test plan
- [ ] Login as admin → verify correct phone returned
- [ ] Test expired session → returns null
- [ ] Test invalid token format → returns null

🤖 Generated with [Claude Code](https://claude.com/claude-code)