### PR TITLE
feat(ui): Product cards visual glow-up

### DIFF
--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -15,8 +15,8 @@ export function ProductCard({ id, title, producer, priceCents, image }: Props) {
   const hasImage = image && image.length > 0
 
   return (
-    <div data-testid="product-card" className="group flex flex-col h-full bg-white border border-gray-200 rounded-xl overflow-hidden hover:shadow-xl transition-all duration-300">
-      <div data-testid="product-card-image" className="relative h-48 w-full bg-gray-100 overflow-hidden">
+    <div data-testid="product-card" className="group flex flex-col h-full bg-white rounded-2xl border border-gray-100 overflow-hidden hover:shadow-xl hover:shadow-emerald-100/50 hover:-translate-y-1 transition-all duration-300">
+      <div data-testid="product-card-image" className="relative aspect-square w-full bg-gradient-to-br from-gray-50 to-gray-100 overflow-hidden">
         {hasImage ? (
           <img
             src={image}
@@ -25,26 +25,38 @@ export function ProductCard({ id, title, producer, priceCents, image }: Props) {
             loading="lazy"
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center text-gray-400">
+          <div className="w-full h-full flex items-center justify-center text-gray-300">
             <svg className="w-16 h-16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
             </svg>
           </div>
         )}
+        {/* Price badge */}
+        <div className="absolute bottom-3 right-3">
+          <span data-testid="product-card-price" className="inline-flex items-center px-3 py-1.5 rounded-full text-sm font-bold bg-emerald-600 text-white shadow-lg">
+            {price}
+          </span>
+        </div>
       </div>
 
       <div className="flex flex-col flex-grow p-4">
-        <div className="mb-2">
-          <span data-testid="product-card-producer" className="text-xs font-semibold text-emerald-600 uppercase tracking-wider">
+        {/* Producer */}
+        <div className="flex items-center gap-1.5 mb-2">
+          <div className="w-4 h-4 rounded-full bg-emerald-100 flex items-center justify-center">
+            <svg className="w-2.5 h-2.5 text-emerald-600" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clipRule="evenodd" />
+            </svg>
+          </div>
+          <span data-testid="product-card-producer" className="text-xs font-medium text-emerald-700 uppercase tracking-wide">
             {producer || 'Παραγωγός'}
           </span>
-          <h3 data-testid="product-card-title" className="text-base font-bold text-gray-900 line-clamp-2 mt-1 leading-tight">
-            {title}
-          </h3>
         </div>
+        {/* Product name */}
+        <h3 data-testid="product-card-title" className="font-semibold text-gray-900 line-clamp-2 group-hover:text-emerald-700 transition-colors">
+          {title}
+        </h3>
 
-        <div className="mt-auto flex items-center justify-between pt-4 border-t border-gray-50">
-          <span data-testid="product-card-price" className="text-lg font-bold text-gray-900">{price}</span>
+        <div className="mt-auto pt-4">
           <div data-testid="product-card-add">
             <AddToCartButton id={String(id)} title={title} priceCents={priceCents} />
           </div>

--- a/frontend/src/components/catalogue/ProductCard.tsx
+++ b/frontend/src/components/catalogue/ProductCard.tsx
@@ -17,33 +17,62 @@ interface ProductCardProps {
 export default function ProductCard({ id, slug, name, price, currency = 'EUR', producer, imageUrl }: ProductCardProps) {
   const href = `/products/${slug || id}`;
   return (
-    <article className="border rounded-lg p-4 bg-white shadow-surface-sm hover:shadow-surface-md transition-shadow">
+    <article className="group relative bg-white rounded-2xl border border-gray-100 overflow-hidden hover:shadow-xl hover:shadow-emerald-100/50 hover:-translate-y-1 transition-all duration-300">
       <Link
         href={href}
-        className="block focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+        className="block focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500"
       >
-        <div className="aspect-square bg-neutral-100 rounded mb-3 overflow-hidden relative">
+        {/* Image container */}
+        <div className="aspect-square bg-gradient-to-br from-gray-50 to-gray-100 overflow-hidden relative">
           {imageUrl ? (
             <Image
               src={imageUrl}
               alt={name}
               fill
               sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
-              className="object-cover"
+              className="object-cover group-hover:scale-105 transition-transform duration-500"
             />
           ) : (
-            <div className="w-full h-full flex items-center justify-center text-neutral-400 text-sm">
-              <svg className="w-12 h-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <div className="w-full h-full flex items-center justify-center text-gray-300">
+              <svg className="w-16 h-16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
             </div>
           )}
+          {/* Price badge */}
+          <div className="absolute bottom-3 right-3">
+            <span className="inline-flex items-center px-3 py-1.5 rounded-full text-sm font-bold bg-emerald-600 text-white shadow-lg">
+              {formatCurrency(price, currency)}
+            </span>
+          </div>
         </div>
-        <h3 className="font-medium text-neutral-900">{name}</h3>
-        {producer?.name && <p className="mt-1 text-sm text-neutral-600">{producer.name}</p>}
-        <p className="mt-2 font-semibold text-brand">{formatCurrency(price, currency)}</p>
+
+        {/* Content */}
+        <div className="p-4">
+          {/* Producer */}
+          {producer?.name && (
+            <div className="flex items-center gap-1.5 mb-2">
+              <div className="w-4 h-4 rounded-full bg-emerald-100 flex items-center justify-center">
+                <svg className="w-2.5 h-2.5 text-emerald-600" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clipRule="evenodd" />
+                </svg>
+              </div>
+              <span className="text-xs font-medium text-emerald-700 uppercase tracking-wide">
+                {producer.name}
+              </span>
+            </div>
+          )}
+          {/* Product name */}
+          <h3 className="font-semibold text-gray-900 line-clamp-2 group-hover:text-emerald-700 transition-colors">
+            {name}
+          </h3>
+        </div>
       </Link>
-      <div className="mt-2"><AddToCartButton id={id} title={name} price={price} currency={currency} className="w-full" /></div>
+
+      {/* Add to cart */}
+      <div className="px-4 pb-4">
+        <AddToCartButton id={id} title={name} price={price} currency={currency} className="w-full" />
+      </div>
     </article>
   );
 }

--- a/frontend/src/components/marketing/FeaturedProducts.tsx
+++ b/frontend/src/components/marketing/FeaturedProducts.tsx
@@ -1,4 +1,5 @@
 import { abs } from '@/lib/url';
+import Link from 'next/link';
 
 async function getProducts(){
   const res = await fetch(abs('/api/products?page=1&pageSize=8'), { cache: 'no-store' });
@@ -9,27 +10,63 @@ async function getProducts(){
 export default async function FeaturedProducts(){
   const { items=[] } = await getProducts();
   return (
-    <section className="mt-8">
-      <div className="flex items-baseline justify-between">
-        <h2 className="text-xl font-semibold">Προτεινόμενα προϊόντα</h2>
-        <a href="/products" className="text-sm underline">Όλα τα προϊόντα</a>
+    <section className="mt-12">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">Προτεινόμενα προϊόντα</h2>
+          <p className="text-gray-600 mt-1">Επιλεγμένα με αγάπη από τους παραγωγούς μας</p>
+        </div>
+        <Link href="/products" className="inline-flex items-center gap-2 text-emerald-700 font-medium hover:text-emerald-800 transition-colors">
+          Όλα τα προϊόντα
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </Link>
       </div>
       {items.length === 0 ? (
-        <p className="mt-4 text-neutral-600">Δεν υπάρχουν προϊόντα ακόμη.</p>
+        <div className="text-center py-12 bg-gray-50 rounded-2xl">
+          <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-gray-100 flex items-center justify-center">
+            <svg className="w-8 h-8 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+            </svg>
+          </div>
+          <p className="text-gray-600">Δεν υπάρχουν προϊόντα ακόμη.</p>
+          <p className="text-gray-500 text-sm mt-1">Σύντομα θα έχουμε νέα προϊόντα!</p>
+        </div>
       ) : (
-        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
           {items.map((p:any)=>(
-            <div key={p.id} className="border rounded-lg p-4 bg-white shadow-surface-sm hover:shadow-surface-md transition-shadow">
-              <h3 className="font-medium text-neutral-900">{p.name}</h3>
-              <p className="mt-1 text-sm text-neutral-600">{p.producer?.name}</p>
-              <p className="mt-2 font-semibold text-brand">{p.price} {p.currency}</p>
-              <a
-                href={`/products/${p.slug || p.id}`}
-                className="mt-3 inline-block text-sm text-brand underline"
-              >
-                Δες προϊόν
-              </a>
-            </div>
+            <Link
+              key={p.id}
+              href={`/products/${p.slug || p.id}`}
+              className="group bg-white rounded-2xl border border-gray-100 overflow-hidden hover:shadow-xl hover:shadow-emerald-100/50 hover:-translate-y-1 transition-all duration-300"
+            >
+              {/* Image placeholder */}
+              <div className="aspect-square bg-gradient-to-br from-gray-50 to-gray-100 flex items-center justify-center text-gray-300 relative">
+                <svg className="w-16 h-16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                {/* Price badge */}
+                <div className="absolute bottom-3 right-3">
+                  <span className="inline-flex items-center px-3 py-1.5 rounded-full text-sm font-bold bg-emerald-600 text-white shadow-lg">
+                    {p.price} {p.currency}
+                  </span>
+                </div>
+              </div>
+              <div className="p-4">
+                {p.producer?.name && (
+                  <div className="flex items-center gap-1.5 mb-2">
+                    <div className="w-4 h-4 rounded-full bg-emerald-100 flex items-center justify-center">
+                      <svg className="w-2.5 h-2.5 text-emerald-600" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clipRule="evenodd" />
+                      </svg>
+                    </div>
+                    <span className="text-xs font-medium text-emerald-700 uppercase tracking-wide">{p.producer.name}</span>
+                  </div>
+                )}
+                <h3 className="font-semibold text-gray-900 line-clamp-2 group-hover:text-emerald-700 transition-colors">{p.name}</h3>
+              </div>
+            </Link>
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- **Product cards**: Complete visual redesign with modern, appealing styling
- **Featured section**: Improved layout with subtitle and better empty state

## Changes (~80 LOC)
| File | Change |
|------|--------|
| `ProductCard.tsx` | Rounded corners, hover lift, price badge, producer icon |
| `catalogue/ProductCard.tsx` | Same improvements for catalogue view |
| `FeaturedProducts.tsx` | Better header, improved grid, empty state design |

## Visual Effects
- 🎯 **Hover**: Cards lift up (-translate-y-1) with emerald shadow glow
- 💰 **Price**: Green pill badge floating on image
- 👨‍🌾 **Producer**: Small icon + styled name in emerald
- 🖼️ **Image**: Zoom effect on hover (scale-105)

## Test plan
- [ ] Product cards display correctly on products page
- [ ] Hover effects work smoothly
- [ ] Price badges are readable
- [ ] Producer names display with icon
- [ ] Empty state shows when no products

🤖 Generated with [Claude Code](https://claude.com/claude-code)