### PR TITLE
feat(ui): Color system consolidation & brand palette

### DIFF
--- a/frontend/src/styles/brand.css
+++ b/frontend/src/styles/brand.css
@@ -1,11 +1,40 @@
+/**
+ * Dixis Brand Color System
+ *
+ * Primary: Cypress Green - Trust, freshness, nature
+ * Accent: Warm Amber - Energy, warmth, Greek sun
+ */
+
 :root {
-  --brand-primary: #0f5c2e;            /* cypress green */
+  /* Primary - Cypress Green palette */
+  --brand-primary: #0f5c2e;
+  --brand-primary-light: #16a34a;
+  --brand-primary-dark: #0a4421;
   --brand-primary-foreground: #ffffff;
-  --brand-accent: #0ea5e9;             /* secondary */
+
+  /* Accent - Warm Amber palette */
+  --brand-accent: #f59e0b;
+  --brand-accent-light: #fbbf24;
+  --brand-accent-dark: #d97706;
+
+  /* Semantic colors */
+  --brand-success: #10b981;
+  --brand-warning: #f59e0b;
+  --brand-error: #ef4444;
+  --brand-info: #0ea5e9;
+
+  /* Gradients */
+  --brand-gradient-primary: linear-gradient(135deg, #0f5c2e 0%, #16a34a 100%);
+  --brand-gradient-hero: linear-gradient(135deg, #064e3b 0%, #065f46 50%, #047857 100%);
 }
 
 .dark {
-  --brand-primary: #0f5c2e;
+  --brand-primary: #16a34a;
+  --brand-primary-light: #22c55e;
+  --brand-primary-dark: #0f5c2e;
   --brand-primary-foreground: #ffffff;
-  --brand-accent: #38bdf8;
+
+  --brand-accent: #fbbf24;
+  --brand-accent-light: #fcd34d;
+  --brand-accent-dark: #f59e0b;
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -9,12 +9,41 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
+        /* Brand colors - consistent with brand.css */
         brand: {
-          DEFAULT: 'hsl(var(--brand-primary))',
-          foreground: 'hsl(var(--brand-primary-foreground))'
+          DEFAULT: 'var(--brand-primary)',
+          light: 'var(--brand-primary-light)',
+          dark: 'var(--brand-primary-dark)',
+          foreground: 'var(--brand-primary-foreground)'
         },
-        primary: { DEFAULT: '#0f5c2e', foreground: '#ffffff' },  /* cypress green */
-        secondary: { DEFAULT: '#0ea5e9', foreground: '#ffffff' },
+        /* Primary palette - Cypress Green */
+        primary: {
+          DEFAULT: '#0f5c2e',
+          50: '#f0fdf4',
+          100: '#dcfce7',
+          200: '#bbf7d0',
+          300: '#86efac',
+          400: '#4ade80',
+          500: '#22c55e',
+          600: '#16a34a',
+          700: '#0f5c2e',
+          800: '#0a4421',
+          900: '#052e16',
+          foreground: '#ffffff'
+        },
+        /* Accent palette - Warm Amber */
+        accent: {
+          DEFAULT: '#f59e0b',
+          50: '#fffbeb',
+          100: '#fef3c7',
+          200: '#fde68a',
+          300: '#fcd34d',
+          400: '#fbbf24',
+          500: '#f59e0b',
+          600: '#d97706',
+          700: '#b45309',
+          foreground: '#1c1917'
+        },
         neutral: {
           0:'#ffffff', 50:'#fafafa', 100:'#f5f5f5', 200:'#e5e5e5', 300:'#d4d4d4',
           600:'#525252', 700:'#404040', 800:'#262626', 900:'#171717'
@@ -27,8 +56,14 @@ const config: Config = {
       boxShadow: {
         'surface-sm': '0 1px 1px rgba(0,0,0,.04), 0 2px 4px rgba(0,0,0,.06)',
         'surface-md': '0 2px 2px rgba(0,0,0,.05), 0 6px 12px rgba(0,0,0,.08)',
-        'surface-lg': '0 8px 8px rgba(0,0,0,.06), 0 16px 24px rgba(0,0,0,.10)'
+        'surface-lg': '0 8px 8px rgba(0,0,0,.06), 0 16px 24px rgba(0,0,0,.10)',
+        'brand-glow': '0 4px 14px 0 rgba(15, 92, 46, 0.25)',
+        'accent-glow': '0 4px 14px 0 rgba(245, 158, 11, 0.25)'
       },
+      backgroundImage: {
+        'brand-gradient': 'linear-gradient(135deg, #0f5c2e 0%, #16a34a 100%)',
+        'hero-gradient': 'linear-gradient(135deg, #064e3b 0%, #065f46 50%, #047857 100%)'
+      }
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- **Brand palette**: Consolidated color system with Cypress Green (primary) and Warm Amber (accent)
- **Design tokens**: Extended Tailwind scales from 50-900 for both palettes
- **Utilities**: New glow shadows and gradient backgrounds

## Changes (~65 LOC)
| File | Change |
|------|--------|
| `brand.css` | Full color palette definition with semantic colors |
| `tailwind.config.ts` | Extended color scales, glow shadows, gradient utilities |

## Color Philosophy
- 🌲 **Primary (Cypress Green)**: Trust, freshness, nature - connects to Greek agriculture
- ☀️ **Accent (Warm Amber)**: Energy, warmth - represents Greek sun

## New Utilities
```css
/* Shadows */
shadow-brand-glow  /* Green glow for buttons */
shadow-accent-glow /* Amber glow for highlights */

/* Gradients */
bg-brand-gradient  /* Primary button gradient */
bg-hero-gradient   /* Hero section background */
```

## Test plan
- [ ] Build passes with new tokens
- [ ] Existing components render correctly
- [ ] New utilities can be used in components

🤖 Generated with [Claude Code](https://claude.com/claude-code)