### PR TITLE
feat(ui): Typography polish for Greek text

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -52,7 +52,13 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  /* Optimized font stack for Greek text */
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Noto Sans', sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 /* Improve text contrast for better accessibility */
@@ -155,18 +161,51 @@ button:hover,
   box-shadow: var(--shadow-sm);
 }
 
+/* Typography scale optimized for Greek text */
 h1 {
-  font-size: clamp(24px, 4vw, 34px);
+  font-size: clamp(28px, 5vw, 42px);
   margin: var(--space-5) 0 var(--space-3);
-  font-weight: 700;
-  line-height: 1.2;
+  font-weight: 800;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
 }
 
 h2 {
-  font-size: clamp(20px, 3vw, 28px);
+  font-size: clamp(22px, 4vw, 32px);
   margin: var(--space-4) 0 var(--space-3);
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+h3 {
+  font-size: clamp(18px, 3vw, 24px);
   font-weight: 600;
-  line-height: 1.3;
+  line-height: 1.35;
+}
+
+/* Greek-optimized text utilities */
+.text-balance {
+  text-wrap: balance;
+}
+
+.text-pretty {
+  text-wrap: pretty;
+}
+
+/* Truncation utilities for long Greek text */
+.truncate-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.truncate-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 a {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import '../styles/skeleton.css';
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Inter } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ToastProvider } from "@/contexts/ToastContext";
@@ -20,6 +20,13 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+// Inter font for excellent Greek language support
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin", "greek"],
+  display: "swap",
 });
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://dixis.gr";
@@ -117,7 +124,7 @@ export default function RootLayout({
   return (
     <html lang="el-GR" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${inter.variable} ${geistSans.variable} ${geistMono.variable} antialiased`}
         suppressHydrationWarning
       >
         <IOSGuard />


### PR DESCRIPTION
## Summary
- **Inter font**: Added with Greek subset for optimal Greek text rendering
- **Typography scale**: Larger, more impactful headings with tighter line heights
- **Text utilities**: New helpers for Greek text wrapping and truncation

## Changes (~55 LOC)
| File | Change |
|------|--------|
| `layout.tsx` | Added Inter font with Greek subset |
| `globals.css` | Typography scale, font stack, utilities |

## Typography Improvements
| Element | Before | After |
|---------|--------|-------|
| h1 | clamp(24px, 4vw, 34px) | clamp(28px, 5vw, 42px) |
| h2 | clamp(20px, 3vw, 28px) | clamp(22px, 4vw, 32px) |
| Body | 14px / 1.5 | 16px / 1.6 |
| Font | Arial | Inter (Greek support) |

## New Utilities
```css
.text-balance    /* Better line breaking */
.text-pretty     /* Prettier text wrap */
.truncate-2      /* 2-line clamp for Greek */
.truncate-3      /* 3-line clamp for Greek */
```

## Test plan
- [ ] Greek text renders with proper character support
- [ ] Headings are readable on mobile
- [ ] No text overflow issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)