### PR TITLE
fix(deploy): use --omit-dir-times to avoid rsync permission errors

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Rsync frontend (exclude cache/node_modules)
         run: |
-          rsync -az --delete \
+          rsync -rlpgoDz --omit-dir-times \
             --exclude node_modules --exclude .next \
             --exclude ".env" --exclude ".env.production" --exclude "prisma/.env" \
             ./frontend/ "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/var/www/dixis-marketplace/frontend/"


### PR DESCRIPTION
## Summary
- Replaces rsync `-az --delete` with `-rlpgoDz --omit-dir-times`
- Fixes "Operation not permitted" errors when rsync tries to set directory timestamps
- Removes `--delete` flag to prevent permission errors on file deletion

## Problem
Deploy was failing with:
```
rsync: [generator] failed to set times on "/var/www/dixis-marketplace/frontend/.": Operation not permitted (1)
```

## Solution
Use `--omit-dir-times` flag which tells rsync to skip setting modification times on directories.

## Test plan
- [ ] Run deploy-prod workflow after merge
- [ ] Verify site loads at https://dixis.gr

🤖 Generated with [Claude Code](https://claude.com/claude-code)