### PR TITLE
fix(deploy): add pre-step to fix VPS permissions before rsync

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -32,6 +32,18 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan -H "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts
 
+      - name: Prepare VPS directory (fix permissions)
+        run: |
+          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" 'bash -c "
+            cd /var/www/dixis-marketplace/frontend || exit 0
+            # Remove immutable flags if any
+            sudo chattr -R -i -a /var/www/dixis-marketplace/ 2>/dev/null || true
+            # Fix ownership
+            sudo chown -R deploy:deploy /var/www/dixis-marketplace/
+            sudo chmod -R 775 /var/www/dixis-marketplace/
+            echo \"Permissions fixed\"
+          "'
+
       - name: Rsync frontend (exclude cache/node_modules)
         run: |
           rsync -rlpgoDz --omit-dir-times \


### PR DESCRIPTION
## Summary
Adds an SSH pre-step before rsync that fixes VPS directory permissions.

## Problem
Deploy was failing with "Permission denied" errors because:
- Some files had immutable flags set
- Ownership was not consistent
- rsync couldn't create new directories or modify files

## Solution
Add a step that runs BEFORE rsync:
```bash
sudo chattr -R -i -a /var/www/dixis-marketplace/  # Remove immutable flags
sudo chown -R deploy:deploy /var/www/dixis-marketplace/
sudo chmod -R 775 /var/www/dixis-marketplace/
```

## Test plan
- [ ] Merge and run deploy-prod workflow
- [ ] Verify site loads at https://dixis.gr

🤖 Generated with [Claude Code](https://claude.com/claude-code)