### PR TITLE
fix(deploy): Use scp for DATABASE_URL to avoid shell escaping

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -52,42 +52,54 @@ jobs:
             ./frontend/ "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/var/www/dixis-marketplace/frontend/"
 
       - name: Remote deploy (install → migrate → build → pm2) with caches
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+          RUNTIME_DATABASE_URL: ${{ secrets.RUNTIME_DATABASE_URL_PROD || secrets.DATABASE_URL_PROD }}
         run: |
-          # Pass DATABASE_URL directly via SSH environment
-          ssh -o SendEnv=DATABASE_URL -o SendEnv=RUNTIME_DATABASE_URL "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" "DATABASE_URL='${{ secrets.DATABASE_URL_PROD }}' RUNTIME_DATABASE_URL='${{ secrets.RUNTIME_DATABASE_URL_PROD || secrets.DATABASE_URL_PROD }}' bash -lc '
+          # Write DATABASE_URL to a temp file to avoid shell escaping issues
+          echo "$DATABASE_URL" > /tmp/db_url.txt
+          scp /tmp/db_url.txt "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/tmp/db_url.txt"
+          rm /tmp/db_url.txt
+
+          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" 'bash -lc '\''
             set -euo pipefail
             cd /var/www/dixis-marketplace/frontend
 
             # --- Remote caches
-            REMOTE_CACHE_BASE=\$HOME/.cache/dixis
-            PNPM_STORE_DIR=\$REMOTE_CACHE_BASE/pnpm-store
-            NEXT_CACHE_DIR=\$REMOTE_CACHE_BASE/next
-            mkdir -p \"\$PNPM_STORE_DIR\" \"\$NEXT_CACHE_DIR\"
+            REMOTE_CACHE_BASE=$HOME/.cache/dixis
+            PNPM_STORE_DIR=$REMOTE_CACHE_BASE/pnpm-store
+            NEXT_CACHE_DIR=$REMOTE_CACHE_BASE/next
+            mkdir -p "$PNPM_STORE_DIR" "$NEXT_CACHE_DIR"
+
+            # --- Read DATABASE_URL from file (avoids shell escaping issues)
+            DATABASE_URL=$(cat /tmp/db_url.txt)
+            rm -f /tmp/db_url.txt
+            export DATABASE_URL
 
             # --- DATABASE_URL guard
-            [ -n \"\${DATABASE_URL:-}\" ] || { echo \"[ERR] DATABASE_URL empty\"; exit 1; }
+            [ -n "${DATABASE_URL:-}" ] || { echo "[ERR] DATABASE_URL empty"; exit 1; }
 
             corepack enable >/dev/null 2>&1 || true
             corepack prepare pnpm@9.15.9 --activate
             export CI=true
-            pnpm config set store-dir \"\$PNPM_STORE_DIR\"
+            pnpm config set store-dir "$PNPM_STORE_DIR"
 
             # Write env files
             rm -f prisma/.env
-            printf \"DATABASE_URL=%s\\n\" \"\$DATABASE_URL\" > .env
+            printf "DATABASE_URL=%s\n" "$DATABASE_URL" > .env
             cp .env .env.production
 
             pnpm install --frozen-lockfile
             pnpm prisma migrate deploy || exit 21
-            export NEXT_CACHE_DIR=\"\$NEXT_CACHE_DIR\"
+            export NEXT_CACHE_DIR="$NEXT_CACHE_DIR"
             pnpm build
 
             # Kill any existing process on port 3000 and restart
-            pkill -f \"next start\" || true
+            pkill -f "next start" || true
             sleep 2
             pm2 restart dixis-frontend --update-env || pm2 start npm --name dixis-frontend -- start
             curl -sI http://127.0.0.1:3000/api/healthz | head -n1 || true
-          '"
+          '\'''
 
       - name: Smoke
         run: |


### PR DESCRIPTION
## Summary
- Transfer DATABASE_URL via scp file instead of inline shell
- Fixes authentication issues caused by special characters in credentials

## Problem
Prisma migration failing with:
```
Error: P1000: Authentication failed against database server, 
the provided database credentials for `(not available)` are not valid.
```

## Solution
Write DATABASE_URL to temp file and scp it to VPS before reading, avoiding shell escaping issues.

## Test plan
- [ ] Deploy workflow completes successfully
- [ ] Prisma migrate deploy succeeds
- [ ] https://dixis.gr loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)