### PR TITLE
fix: button text color - use text-white

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         // Primary - Cyprus Green with glow hover
-        default: 'bg-primary text-primary-foreground hover:bg-primary-light hover:shadow-glow active:scale-[0.98]',
+        default: 'bg-primary text-white hover:bg-primary-light hover:shadow-glow active:scale-[0.98]',
         // Secondary - Outlined
         secondary: 'bg-white text-primary border-2 border-primary hover:bg-primary-pale active:scale-[0.98]',
         // Ghost - Subtle


### PR DESCRIPTION
## Summary
- Fixed invisible button text on primary buttons (e.g., "Δες προϊόντα" in Hero section)
- Changed from `text-primary-foreground` to `text-white` since the nested Tailwind color wasn't being applied correctly

## Problem
The primary button in Hero section showed empty (no text visible) on production (dixis.gr) after the mobile-first UI update.

## Root Cause
Tailwind's nested color definition `primary: { foreground: '#ffffff' }` doesn't generate the expected `text-primary-foreground` utility class properly.

## Solution
Use explicit `text-white` instead of `text-primary-foreground` for the default button variant.

## Test plan
- [ ] Verify button text "Δες προϊόντα" is visible on dixis.gr after deploy
- [ ] Check all primary buttons have white text on green background

🤖 Generated with [Claude Code](https://claude.com/claude-code)