### PR TITLE
fix(deploy): VPS build reliability improvements

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -25,8 +25,14 @@ jobs:
           script_stop: true
           script: |
             set -euo pipefail
-            APP_DIR="$(pm2 jlist | jq -r '.[] | select(.name=="dixis-frontend") | .pm2_env.pm_cwd')"
-            [ -d "$APP_DIR" ] || { echo "APP_DIR not found"; exit 1; }
+
+            # Try to get APP_DIR from PM2, fallback to known path
+            APP_DIR="$(pm2 jlist 2>/dev/null | jq -r '.[] | select(.name=="dixis-frontend") | .pm2_env.pm_cwd' 2>/dev/null || echo '')"
+            if [ -z "$APP_DIR" ] || [ ! -d "$APP_DIR" ]; then
+              APP_DIR="/var/www/dixis/current/frontend"
+              echo "→ PM2 process not found, using fallback: $APP_DIR"
+            fi
+            [ -d "$APP_DIR" ] || { echo "APP_DIR $APP_DIR not found"; exit 1; }
             cd "$APP_DIR"
 
             echo "→ Sync main"
@@ -37,13 +43,19 @@ jobs:
             export NEXT_PUBLIC_BASE_URL="https://dixis.gr"
             export PRODUCTS_MODE="demo"
 
-            echo "→ Build"
+            echo "→ Build (with memory limit for low-RAM VPS)"
             rm -rf node_modules .next
             pnpm install --frozen-lockfile
-            pnpm build
+            NODE_OPTIONS="--max-old-space-size=1536" pnpm build
 
-            echo "→ Restart"
-            pm2 restart dixis-frontend --update-env
+            echo "→ Restart (or start if not exists)"
+            if pm2 describe dixis-frontend > /dev/null 2>&1; then
+              pm2 restart dixis-frontend --update-env
+            else
+              echo "→ PM2 process not found, starting fresh..."
+              pm2 start npm --name "dixis-frontend" -- start
+              pm2 save
+            fi
 
             echo "→ Wait for startup"
             sleep 15


### PR DESCRIPTION
## Summary
- Add NODE_OPTIONS=--max-old-space-size=1536 for low-RAM VPS build
- Add fallback path /var/www/dixis/current/frontend when PM2 process not found
- Add logic to start fresh PM2 process if needed

## Critical
**Site is currently DOWN (502 Bad Gateway)** - VPS build was hanging due to memory issues.

## Test plan
- [ ] PR merges
- [ ] Deploy workflow runs successfully
- [ ] dixis.gr returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)