### PR TITLE
fix(deploy): Add git safe.directory for VPS

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -35,6 +35,11 @@ jobs:
             [ -d "$APP_DIR" ] || { echo "APP_DIR $APP_DIR not found"; exit 1; }
             cd "$APP_DIR"
 
+            # Fix git safe.directory for different user ownership
+            REPO_ROOT="$(cd .. && pwd)"
+            git config --global --add safe.directory "$REPO_ROOT"
+            git config --global --add safe.directory "$APP_DIR"
+
             echo "→ Sync main"
             git fetch origin
             git reset --hard origin/main


### PR DESCRIPTION
## Summary
Fixes git "dubious ownership" error when deploy script runs on VPS.

## Problem
```
fatal: detected dubious ownership in repository at '/var/www/dixis/releases/20251105-201811'
```

## Solution
Add `git config --global --add safe.directory` before git operations.

## Critical
**Site is still DOWN (502)** - this is the second fix needed after PR #1144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)