### PR TITLE
fix(deploy): Use realpath for symlink resolution

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -35,10 +35,12 @@ jobs:
             [ -d "$APP_DIR" ] || { echo "APP_DIR $APP_DIR not found"; exit 1; }
             cd "$APP_DIR"
 
-            # Fix git safe.directory for different user ownership
-            REPO_ROOT="$(cd .. && pwd)"
+            # Fix git safe.directory for different user ownership (resolve symlinks)
+            REAL_APP_DIR="$(realpath "$APP_DIR" 2>/dev/null || pwd)"
+            REPO_ROOT="$(dirname "$REAL_APP_DIR")"
             git config --global --add safe.directory "$REPO_ROOT"
-            git config --global --add safe.directory "$APP_DIR"
+            git config --global --add safe.directory "$REAL_APP_DIR"
+            echo "→ Added safe.directory for: $REPO_ROOT and $REAL_APP_DIR"
 
             echo "→ Sync main"
             git fetch origin


### PR DESCRIPTION
## Summary
Fixes git safe.directory for VPS symlinked paths.

## Problem
- `/var/www/dixis/current` is a symlink to `/var/www/dixis/releases/20251105-201811`
- Previous fix added safe.directory for the symlink path, not the real path
- Git complains about the resolved path

## Solution
Use `realpath` to resolve symlinks before adding safe.directory.

## Critical
**Site is still DOWN (502)** - third fix attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)