### PR TITLE
fix(deploy): Fix entire repo permissions for VPS

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -42,11 +42,10 @@ jobs:
             git config --global --add safe.directory "$REAL_APP_DIR"
             echo "→ Added safe.directory for: $REPO_ROOT and $REAL_APP_DIR"
 
-            # Fix .git permissions if needed (repo may be owned by different user)
-            if [ -d "$REPO_ROOT/.git" ]; then
-              chmod -R u+w "$REPO_ROOT/.git" 2>/dev/null || sudo chmod -R a+w "$REPO_ROOT/.git" || true
-              echo "→ Fixed .git permissions"
-            fi
+            # Fix repo permissions if needed (repo may be owned by different user)
+            # Fix entire repo, not just .git, so git reset can write to files
+            chmod -R u+w "$REPO_ROOT" 2>/dev/null || sudo chmod -R a+w "$REPO_ROOT" || true
+            echo "→ Fixed repo permissions for: $REPO_ROOT"
 
             echo "→ Sync main"
             git fetch origin


### PR DESCRIPTION
## Summary
Fixes git reset permission errors during VPS deployment.

## Problem
```
error: unable to unlink old '.github/workflows/***-frontend.yml': Permission denied
error: unable to unlink old 'package.json': Permission denied
```

## Solution
Expand chmod to cover entire repo directory, not just .git.

## Critical
**Site is still DOWN (502)** - fifth fix attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)