### PR TITLE
fix(deploy): Increase timeout to 30m for slow VPS

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -23,6 +23,7 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_KEY }}
           script_stop: true
+          command_timeout: 30m
           script: |
             set -euo pipefail
 


### PR DESCRIPTION
## Summary
Increases SSH command timeout from 10m to 30m.

## Problem
VPS has slow I/O, pnpm install takes >10 minutes.

## Solution
Add `command_timeout: 30m` to appleboy/ssh-action.

## Critical
**Site is still DOWN (502)** - sixth fix attempt. Getting very close!

🤖 Generated with [Claude Code](https://claude.com/claude-code)