### PR TITLE
fix(deploy): Use Next.js standalone mode correctly

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -51,27 +51,27 @@ jobs:
           PRODUCTS_MODE: demo
         run: pnpm build
 
-      - name: Deploy to VPS via rsync
+      - name: Prepare standalone bundle
+        working-directory: frontend
+        run: |
+          # Next.js standalone mode requires copying static assets
+          cp -r .next/static .next/standalone/.next/static
+          cp -r public .next/standalone/public
+          # Copy prisma client for database access
+          mkdir -p .next/standalone/node_modules/.prisma
+          cp -r node_modules/.prisma/client .next/standalone/node_modules/.prisma/
+
+      - name: Deploy standalone to VPS
         uses: easingthemes/ssh-deploy@main
         with:
           SSH_PRIVATE_KEY: ${{ secrets.VPS_KEY }}
           REMOTE_HOST: ${{ secrets.VPS_HOST }}
           REMOTE_USER: ${{ secrets.VPS_USER }}
-          SOURCE: "frontend/.next/"
-          TARGET: "/var/www/dixis/current/frontend/.next/"
-          ARGS: "-avz --delete"
+          SOURCE: "frontend/.next/standalone/"
+          TARGET: "/var/www/dixis/current/frontend/"
+          ARGS: "-avz --delete --exclude='.env*'"
 
-      - name: Deploy node_modules (prisma client)
-        uses: easingthemes/ssh-deploy@main
-        with:
-          SSH_PRIVATE_KEY: ${{ secrets.VPS_KEY }}
-          REMOTE_HOST: ${{ secrets.VPS_HOST }}
-          REMOTE_USER: ${{ secrets.VPS_USER }}
-          SOURCE: "frontend/node_modules/.pnpm/@prisma+client*"
-          TARGET: "/var/www/dixis/current/frontend/node_modules/.pnpm/"
-          ARGS: "-avz"
-
-      - name: Restart PM2 on VPS
+      - name: Start app with PM2
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.VPS_HOST }}
@@ -80,13 +80,12 @@ jobs:
           script: |
             cd /var/www/dixis/current/frontend
 
-            # Start or restart PM2 process
-            if pm2 describe dixis-frontend > /dev/null 2>&1; then
-              pm2 restart dixis-frontend --update-env
-            else
-              pm2 start npm --name "dixis-frontend" -- start
-              pm2 save
-            fi
+            # Stop existing process if any
+            pm2 delete dixis-frontend 2>/dev/null || true
+
+            # Start standalone server with node (not npm)
+            PORT=3000 pm2 start server.js --name "dixis-frontend"
+            pm2 save
 
             sleep 10
             curl -sI http://127.0.0.1:3000 | head -1


### PR DESCRIPTION
## Summary
- Fix deployment to properly use Next.js standalone output mode
- Site is DOWN (502) because previous deploy tried `npm start` but standalone needs `node server.js`

## Changes
- Prepare standalone bundle by copying static assets and public folder
- Copy prisma client to standalone node_modules for DB access
- Deploy entire standalone folder (not just .next)
- Run with `node server.js` instead of `npm start`
- Preserve .env files on VPS with --exclude flag

## Test plan
- [ ] CI passes
- [ ] Deploy workflow succeeds
- [ ] Site returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)