### PR TITLE
fix(deploy): Find prisma client correctly in pnpm

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -57,9 +57,16 @@ jobs:
           # Next.js standalone mode requires copying static assets
           cp -r .next/static .next/standalone/.next/static
           cp -r public .next/standalone/public
-          # Copy prisma client for database access
-          mkdir -p .next/standalone/node_modules/.prisma
-          cp -r node_modules/.prisma/client .next/standalone/node_modules/.prisma/
+
+          # Copy prisma client (pnpm puts it in a different location)
+          PRISMA_CLIENT=$(find node_modules/.pnpm -type d -name ".prisma" -path "*@prisma+client*" | head -1)
+          if [ -n "$PRISMA_CLIENT" ]; then
+            mkdir -p .next/standalone/node_modules/.prisma
+            cp -r "$PRISMA_CLIENT/client" .next/standalone/node_modules/.prisma/
+            echo "Copied prisma client from: $PRISMA_CLIENT"
+          else
+            echo "Warning: Prisma client not found, Next.js standalone should include it"
+          fi
 
       - name: Deploy standalone to VPS
         uses: easingthemes/ssh-deploy@main


### PR DESCRIPTION
## Summary
Previous deploy failed because prisma client path was hardcoded to `node_modules/.prisma/client` which doesn't exist with pnpm.

## Fix
Use `find` to dynamically locate the prisma client in pnpm's nested directory structure.

## Test plan
- [ ] CI passes
- [ ] Deploy workflow succeeds
- [ ] Site returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)