### PR TITLE
fix(deploy): Use rsync without archive mode to avoid permission errors

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -76,7 +76,7 @@ jobs:
           REMOTE_USER: ${{ secrets.VPS_USER }}
           SOURCE: "frontend/.next/standalone/"
           TARGET: "/var/www/dixis/current/frontend/"
-          ARGS: "-avz --delete --exclude='.env*'"
+          ARGS: "-rlvz --delete --omit-dir-times --exclude='.env*'"
 
       - name: Start app with PM2
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
## Summary
Previous deploy failed with: `rsync: [generator] failed to set times on "/var/www/dixis/current/frontend/.": Operation not permitted`

## Fix
Changed rsync args from `-avz` to `-rlvz --omit-dir-times`
- `-a` (archive) includes `-t` (times) which requires permission to set directory timestamps
- `--omit-dir-times` specifically skips setting directory timestamps

## Test plan
- [ ] CI passes
- [ ] Deploy workflow succeeds
- [ ] Site returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)