### PR TITLE
fix(deploy): Kill PM2 daemon and port 3000 before starting

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -96,13 +96,16 @@ jobs:
             echo "RESEND_API_KEY=${RESEND_API_KEY}" >> .env
             cat .env | head -3
 
-            # Stop ALL existing frontend processes to avoid port conflicts
-            pm2 delete dixis-frontend 2>/dev/null || true
-            pm2 delete dixis-frontend-stg 2>/dev/null || true
+            # Stop ALL PM2 processes completely
+            pm2 kill 2>/dev/null || true
 
-            # Start with explicit env vars (Next.js standalone needs these at startup)
+            # Kill any process using port 3000
+            fuser -k 3000/tcp 2>/dev/null || true
+            sleep 2
+
+            # Start PM2 with FULL absolute path (prevents using old cached paths)
             PORT=3000 HOSTNAME=0.0.0.0 DATABASE_URL="${DATABASE_URL}" RESEND_API_KEY="${RESEND_API_KEY}" \
-              pm2 start server.js --name "dixis-frontend"
+              pm2 start /var/www/dixis/current/frontend/server.js --name "dixis-frontend"
             pm2 save
 
             # Wait for app to start and show logs if it failed


### PR DESCRIPTION
## Summary
- Use `pm2 kill` to completely stop PM2 daemon (prevents cached old paths)
- Use `fuser -k 3000/tcp` to ensure port 3000 is free
- Use full absolute path `/var/www/dixis/current/frontend/server.js`

## Root Cause
PM2 was starting from old cached path `/var/www/dixis/releases/20251105-201811/frontend/server.js` instead of current deployment directory.

## Test Plan
- [ ] Deploy workflow completes successfully
- [ ] PM2 starts from correct path
- [ ] https://dixis.gr returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)