### PR TITLE
fix(deploy): Remove old .env files before creating new one

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -88,7 +88,10 @@ jobs:
           script: |
             cd /var/www/dixis/current/frontend
 
-            # Create .env file with production secrets
+            # Remove ALL old .env files (they have wrong permissions from old deploys)
+            rm -f .env .env.local .env.production .env.production.local 2>/dev/null || true
+
+            # Create fresh .env file with production secrets
             echo "NODE_ENV=production" > .env
             echo "PORT=3000" >> .env
             echo "HOSTNAME=0.0.0.0" >> .env


### PR DESCRIPTION
## Summary
- Remove all old `.env*` files before creating new `.env`
- Old `.env.production` had wrong permissions (EACCES error)
- Next.js was crashing trying to read old file

## Root Cause
- rsync uses `--exclude='.env*'` which preserves old files
- Old `.env.production` was owned by different user with wrong permissions
- Next.js tries to load it and crashes

## Test Plan
- [ ] Deploy workflow completes
- [ ] No EACCES errors in PM2 logs
- [ ] https://dixis.gr returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)