### PR TITLE
fix(deploy): Remove rsync --exclude to delete old .env files

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -76,7 +76,7 @@ jobs:
           REMOTE_USER: ${{ secrets.VPS_USER }}
           SOURCE: "frontend/.next/standalone/"
           TARGET: "/var/www/dixis/current/frontend/"
-          ARGS: "-rlvz --delete --omit-dir-times --exclude='.env*'"
+          ARGS: "-rlvz --delete --omit-dir-times"
 
       - name: Configure and start app
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
## Summary
- Remove `--exclude='.env*'` from rsync ARGS
- This allows rsync's `--delete` flag to remove old .env.production file

## Root Cause
- Old `.env.production` has wrong permissions (owned by root)
- Can't be deleted by `rm` command (permission denied)
- Was being preserved by rsync's `--exclude='.env*'`
- Next.js tries to load it and fails with EACCES

## Test Plan
- [ ] rsync deletes old .env.production
- [ ] No EACCES errors in PM2 logs
- [ ] https://dixis.gr returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)