### PR TITLE
fix(deploy): Use sudo to remove old .env files with wrong permissions

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -88,8 +88,12 @@ jobs:
           script: |
             cd /var/www/dixis/current/frontend
 
-            # Remove ALL old .env files (they have wrong permissions from old deploys)
-            rm -f .env .env.local .env.production .env.production.local 2>/dev/null || true
+            # Remove ALL old .env files using sudo (they have wrong permissions from old deploys)
+            sudo rm -f .env .env.local .env.production .env.production.local 2>/dev/null || true
+
+            # Also remove from the actual symlink target directory
+            ACTUAL_DIR=$(readlink -f /var/www/dixis/current/frontend)
+            sudo rm -f "$ACTUAL_DIR/.env.production" 2>/dev/null || true
 
             # Create fresh .env file with production secrets
             echo "NODE_ENV=production" > .env
@@ -102,8 +106,12 @@ jobs:
             # Stop ALL PM2 processes completely
             pm2 kill 2>/dev/null || true
 
-            # Kill any process using port 3000
-            fuser -k 3000/tcp 2>/dev/null || true
+            # Kill any process using port 3000 (with sudo for extra permission)
+            sudo fuser -k 3000/tcp 2>/dev/null || fuser -k 3000/tcp 2>/dev/null || true
+
+            # Wait for port to be released and double-check
+            sleep 3
+            sudo fuser -k 3000/tcp 2>/dev/null || true
             sleep 2
 
             # Start PM2 with FULL absolute path (prevents using old cached paths)


### PR DESCRIPTION
## Summary
- Add `sudo` to rm commands to delete old .env files with wrong permissions
- Add `sudo` to fuser commands to ensure port 3000 processes are killed
- Resolve symlink and delete .env.production from actual target directory

## Problem
The old `.env.production` file at `/var/www/dixis/releases/20251105-201811/frontend/.env.production` has wrong permissions from a previous deployment. Next.js tries to read it and fails with EACCES error.

## Test plan
- [ ] Merge and deploy
- [ ] Verify site returns HTTP 200
- [ ] Check PM2 logs for no EACCES errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)