### PR TITLE
fix(deploy): Use specific pgrep pattern to avoid killing SSH session

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -107,9 +107,8 @@ jobs:
             pm2 kill 2>/dev/null || true
             sleep 2
 
-            # Kill all node processes related to dixis (be specific to avoid killing other apps)
-            pkill -9 -f "dixis-frontend" 2>/dev/null || true
-            pkill -9 -f "server.js" 2>/dev/null || true
+            # Kill node processes using absolute path pattern (avoid killing SSH session)
+            pgrep -f "/var/www/dixis.*server.js" | xargs kill -9 2>/dev/null || true
 
             # Kill any process using port 3000 using multiple methods
             sudo fuser -k 3000/tcp 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Replace `pkill -9 -f "server.js"` with `pgrep -f "/var/www/dixis.*server.js"`
- The broad pattern was killing the SSH session causing deploy failure

## Problem
Previous deploy failed with "Process exited with status 137 from signal KILL" because pkill matched the SSH action process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)