### PR TITLE
fix(deploy): PM2 fork mode for Next.js standalone

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -125,23 +125,19 @@ jobs:
               sleep 2
             done
 
-            # Start PM2 with single instance (no cluster mode)
+            # Start PM2 in fork mode (not cluster - Next.js standalone doesn't support cluster)
             PORT=3000 HOSTNAME=0.0.0.0 DATABASE_URL="${DATABASE_URL}" RESEND_API_KEY="${RESEND_API_KEY}" \
-              pm2 start /var/www/dixis/current/frontend/server.js \
-              --name "dixis-frontend" \
-              -i 1 \
-              --wait-ready \
-              --listen-timeout 30000
+              pm2 start /var/www/dixis/current/frontend/server.js --name "dixis-frontend"
 
             pm2 save
 
-            # Wait for app to fully start
-            sleep 15
+            # Wait for app to start (Next.js takes ~20s to be ready)
+            sleep 25
             pm2 status
-            echo "--- PM2 Logs (last 20 lines) ---"
-            pm2 logs dixis-frontend --nostream --lines 20 || true
-            echo "--- Health Check ---"
-            curl -sI http://127.0.0.1:3000 | head -5 || echo "Health check failed"
+            echo "--- PM2 Logs (last 15 lines) ---"
+            pm2 logs dixis-frontend --nostream --lines 15 || true
+            echo "--- Health Check (5s timeout) ---"
+            curl -sI --max-time 5 http://127.0.0.1:3000 | head -5 || echo "Health check failed"
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}


### PR DESCRIPTION
## Summary
- Previous PR #1168 used cluster mode with `--wait-ready` which is incompatible with Next.js
- Next.js standalone doesn't call `process.send('ready')`, so PM2 waits forever
- The curl health check also hung, causing workflow timeout

## Changes
- Remove `-i 1` flag (this forces cluster mode)
- Remove `--wait-ready` and `--listen-timeout` (cluster-only features)
- Add `--max-time 5` to curl to prevent hanging
- Use simple fork mode: `pm2 start server.js --name "dixis-frontend"`

## Evidence from PR #1168 logs
```
[PM2] Starting server.js in cluster_mode (1 instance)
status: launching → online
but then: Run Command Timeout (after 10 min)
```
The app was online but PM2 was waiting for ready signal that never came.

## Test Plan
- [x] Workflow syntax valid
- [ ] Deploy completes within timeout
- [ ] Site returns 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)