### PR TITLE
fix(deploy): PM2 restart protection and diagnostics

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -125,19 +125,33 @@ jobs:
               sleep 2
             done
 
-            # Start PM2 in fork mode (not cluster - Next.js standalone doesn't support cluster)
+            # Clear old PM2 logs to avoid confusion with previous restarts
+            pm2 flush 2>/dev/null || true
+
+            # Start PM2 in fork mode with restart protection
+            # --min-uptime 30s: must run 30s before considered "stable"
+            # --max-restarts 3: max 3 restarts before giving up
+            # --restart-delay 5000: wait 5s between restarts (allow port release)
             PORT=3000 HOSTNAME=0.0.0.0 DATABASE_URL="${DATABASE_URL}" RESEND_API_KEY="${RESEND_API_KEY}" \
-              pm2 start /var/www/dixis/current/frontend/server.js --name "dixis-frontend"
+              pm2 start /var/www/dixis/current/frontend/server.js \
+              --name "dixis-frontend" \
+              --min-uptime 30000 \
+              --max-restarts 3 \
+              --restart-delay 5000
 
             pm2 save
 
-            # Wait for app to start (Next.js takes ~20s to be ready)
-            sleep 25
+            # Wait for app to start (Next.js takes ~25s to be ready)
+            sleep 30
             pm2 status
-            echo "--- PM2 Logs (last 15 lines) ---"
-            pm2 logs dixis-frontend --nostream --lines 15 || true
-            echo "--- Health Check (5s timeout) ---"
-            curl -sI --max-time 5 http://127.0.0.1:3000 | head -5 || echo "Health check failed"
+            echo "--- PM2 Error Logs ---"
+            pm2 logs dixis-frontend --err --nostream --lines 20 || true
+            echo "--- PM2 Output Logs ---"
+            pm2 logs dixis-frontend --out --nostream --lines 10 || true
+            echo "--- Port 3000 Status ---"
+            lsof -i:3000 2>/dev/null || echo "Nothing listening on port 3000!"
+            echo "--- Health Check ---"
+            curl -v --max-time 5 http://127.0.0.1:3000 2>&1 | head -20 || echo "Health check failed"
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}


### PR DESCRIPTION
## Summary
The app is crash-looping on deploy. PM2 shows "online" but the app quickly crashes and restarts. When PM2 restarts, the previous instance hasn't released port 3000 yet, causing EADDRINUSE errors.

## Root Cause
From deploy logs:
- First check: PID 1311537, uptime 1s, **0 restarts**
- After 25s: PID 1311801, uptime 14s, **2 restarts** 

The app crashed twice in 25 seconds, and each restart attempted before port 3000 was freed.

## Changes
1. **PM2 restart protection:**
   - `--min-uptime 30000`: Wait 30s before considering app "started"
   - `--max-restarts 3`: Stop after 3 failed restarts
   - `--restart-delay 5000`: Wait 5s between restarts to allow port release

2. **Better diagnostics:**
   - `pm2 flush`: Clear old logs before deploy
   - Separate error logs from output logs
   - `lsof -i:3000`: Show what's actually listening
   - Verbose curl (`-v`): Show connection details

## Test Plan
- [x] Workflow syntax valid
- [ ] Deploy completes
- [ ] Can see actual crash reason in logs
- [ ] Site returns 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)