### PR TITLE
fix(deploy): Diagnose app crash with --no-autorestart

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -128,10 +128,10 @@ jobs:
             # Clear old PM2 logs to avoid confusion with previous restarts
             pm2 flush 2>/dev/null || true
 
-            # Start PM2 in fork mode (simple command, no complex flags)
+            # Start PM2 in fork mode with restart delay to avoid EADDRINUSE
             echo "Starting PM2 with: pm2 start server.js --name dixis-frontend"
             PORT=3000 HOSTNAME=0.0.0.0 DATABASE_URL="${DATABASE_URL}" RESEND_API_KEY="${RESEND_API_KEY}" \
-              pm2 start /var/www/dixis/current/frontend/server.js --name "dixis-frontend" 2>&1 || {
+              pm2 start /var/www/dixis/current/frontend/server.js --name "dixis-frontend" --no-autorestart 2>&1 || {
                 echo "PM2 start failed! Exit code: $?"
                 echo "Checking if server.js exists..."
                 ls -la /var/www/dixis/current/frontend/server.js || echo "server.js NOT FOUND!"
@@ -142,17 +142,30 @@ jobs:
 
             pm2 save
 
-            # Wait for app to start (Next.js takes ~25s to be ready)
-            sleep 30
+            # Wait for Next.js to become ready (~35s based on logs)
+            echo "Waiting 40s for Next.js to start..."
+            sleep 40
+
+            echo "=== DIAGNOSTICS AFTER 40s ==="
             pm2 status
-            echo "--- PM2 Error Logs ---"
-            pm2 logs dixis-frontend --err --nostream --lines 20 || true
-            echo "--- PM2 Output Logs ---"
-            pm2 logs dixis-frontend --out --nostream --lines 10 || true
+
             echo "--- Port 3000 Status ---"
             lsof -i:3000 2>/dev/null || echo "Nothing listening on port 3000!"
-            echo "--- Health Check ---"
-            curl -v --max-time 5 http://127.0.0.1:3000 2>&1 | head -20 || echo "Health check failed"
+
+            echo "--- Memory Info ---"
+            free -m || true
+
+            echo "--- PM2 Error Logs (FULL) ---"
+            pm2 logs dixis-frontend --err --nostream --lines 50 || true
+
+            echo "--- PM2 Output Logs (FULL) ---"
+            pm2 logs dixis-frontend --out --nostream --lines 50 || true
+
+            echo "--- Node.js Version ---"
+            node --version || true
+
+            echo "--- Health Check with extended timeout ---"
+            curl -v --max-time 15 http://127.0.0.1:3000/api/healthz 2>&1 || echo "Health check failed"
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}


### PR DESCRIPTION
## Summary
- Added `--no-autorestart` to PM2 to prevent restart loop and see the FIRST crash error
- Extended wait to 40s (logs show Next.js takes ~32s to be ready)
- Added memory diagnostics (`free -m`) to check for OOM
- Added node version check
- Extended error log capture to 50 lines

## Context
Site is DOWN (502). App is crash-looping but the real error is hidden behind EADDRINUSE errors from restart attempts. This PR disables auto-restart so we can see the actual first crash.

## Test plan
- [ ] Deploy should show the actual error in PM2 logs
- [ ] Memory info will help identify if OOM is the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)