### PR TITLE
fix(ssr): Use localhost for server-side API calls to prevent deadlock

### DIFF
--- a/frontend/src/lib/url.ts
+++ b/frontend/src/lib/url.ts
@@ -1,8 +1,19 @@
 export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://dixis.gr';
 
+// Internal URL for server-side API calls (avoids self-deadlock through nginx)
+const INTERNAL_URL = process.env.INTERNAL_API_URL || 'http://localhost:3000';
+
 export function abs(path: string): string {
   if (!path) return SITE_URL;
   // ensure path starts with /
   const p = path.startsWith('/') ? path : `/${path}`;
+
+  // On server-side, use localhost to avoid deadlock through nginx
+  // The app would otherwise call itself through https://dixis.gr which
+  // goes through nginx and back to the same app that's still starting
+  if (typeof window === 'undefined') {
+    return `${INTERNAL_URL}${p}`;
+  }
+
   return new URL(p, SITE_URL).toString();
 }


### PR DESCRIPTION
## Summary
- Fix self-deadlock during server-side rendering
- Use `localhost:3000` for internal API calls instead of `https://dixis.gr`

## Root Cause
The app was crash-looping every ~50 seconds. Analysis of deploy logs showed:
- Memory grows from 50MB → 165MB over 50 seconds
- App never reaches "Ready" state
- PM2 restarts with EADDRINUSE errors

**The deadlock**:
1. Homepage SSR calls `FeaturedProducts` component
2. `FeaturedProducts` fetches `abs('/api/products')` → `https://dixis.gr/api/products`
3. Request goes through nginx → port 3000 → **the same app that's still starting**
4. App waits for itself to respond → **deadlock**
5. Request times out, memory grows, crash

## Fix
On server-side, use `localhost:3000` directly to bypass nginx. The app can now call its own API routes during SSR without going through the external load balancer.

## Test plan
- [ ] Deploy to VPS
- [ ] Site responds without crashing
- [ ] Homepage loads with products
- [ ] No crash loop in PM2

🤖 Generated with [Claude Code](https://claude.com/claude-code)