### PR TITLE
fix(deploy): Add memory limits to prevent app crashes

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -135,10 +135,23 @@ jobs:
             pm2 flush 2>/dev/null || true
             rm -f /home/$USER/.pm2/logs/dixis-frontend-*.log 2>/dev/null || true
 
-            # Start PM2 with 1s exp-backoff restart delay to avoid EADDRINUSE
-            echo "Starting PM2 with: pm2 start server.js --name dixis-frontend --exp-backoff-restart-delay=1000"
+            # Also kill any orphaned node processes (from crashed PM2 instances)
+            echo "Killing any orphaned node processes..."
+            pkill -f "server.js" 2>/dev/null || true
+            sleep 2
+
+            # Start PM2 with memory limit and restart controls
+            # --max-memory-restart 400M: Restart if memory exceeds 400MB (prevents OOM)
+            # --max-restarts 5: Limit restart attempts to prevent infinite loops
+            # --exp-backoff-restart-delay 1000: Wait 1s before restart to release port
+            echo "Starting PM2 with memory limit (400M) and max 5 restarts..."
+            NODE_OPTIONS="--max-old-space-size=512" \
             PORT=3000 HOSTNAME=0.0.0.0 DATABASE_URL="${DATABASE_URL}" RESEND_API_KEY="${RESEND_API_KEY}" \
-              pm2 start /var/www/dixis/current/frontend/server.js --name "dixis-frontend" --exp-backoff-restart-delay=1000 2>&1 || {
+              pm2 start /var/www/dixis/current/frontend/server.js \
+                --name "dixis-frontend" \
+                --max-memory-restart 400M \
+                --max-restarts 5 \
+                --exp-backoff-restart-delay=1000 2>&1 || {
                 echo "PM2 start failed! Exit code: $?"
                 echo "Checking if server.js exists..."
                 ls -la /var/www/dixis/current/frontend/server.js || echo "server.js NOT FOUND!"


### PR DESCRIPTION
## Summary
- Add `NODE_OPTIONS=--max-old-space-size=512` to limit Node.js heap memory
- Add PM2 `--max-memory-restart 400M` to restart gracefully before OOM
- Add `--max-restarts 5` to prevent infinite restart loops
- Kill orphaned node processes before starting

## Problem
The app was growing from 50MB to 220MB+ and crashing every ~50 seconds on the VPS, causing 502 errors.

## Test plan
- [ ] Merge and deploy to production
- [ ] Verify site loads (no more 502)
- [ ] Check PM2 logs for stable memory usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)