### PR TITLE
fix(deploy): Remove pkill that killed SSH session

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -135,11 +135,6 @@ jobs:
             pm2 flush 2>/dev/null || true
             rm -f /home/$USER/.pm2/logs/dixis-frontend-*.log 2>/dev/null || true
 
-            # Also kill any orphaned node processes (from crashed PM2 instances)
-            echo "Killing any orphaned node processes..."
-            pkill -f "server.js" 2>/dev/null || true
-            sleep 2
-
             # Start PM2 with memory limit and restart controls
             # --max-memory-restart 400M: Restart if memory exceeds 400MB (prevents OOM)
             # --max-restarts 5: Limit restart attempts to prevent infinite loops


### PR DESCRIPTION
## Emergency Fix

The `pkill -f "server.js"` command was matching something in the SSH session and killing it, causing the deploy to fail before PM2 even started.

The fuser cleanup is sufficient to clear port 3000.

## Problem
Previous deploy failed at "Killing any orphaned node processes..." with exit code 143 (SIGTERM).

## Test plan
- [ ] Deploy completes successfully
- [ ] Site loads (no more 502)

🤖 Generated with [Claude Code](https://claude.com/claude-code)