### PR TITLE
fix(deploy): Restore inline env vars for PM2

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -140,10 +140,16 @@ jobs:
             rm -f /home/$USER/.pm2/logs/dixis-frontend-*.log 2>/dev/null || true
 
             # Start PM2 with memory limit and restart controls
+            # Environment variables must be passed inline - Next.js standalone doesn't load .env
             # --max-memory-restart 300M: Restart if memory exceeds 300MB (VPS has limited RAM)
             # --max-restarts 10: Allow more restarts for stability
             # --exp-backoff-restart-delay 2000: Wait 2s before restart to release port
             echo "Starting PM2 with memory limit (300M) and max 10 restarts..."
+            NODE_OPTIONS="--max-old-space-size=384" \
+            PORT=3000 HOSTNAME=0.0.0.0 \
+            DATABASE_URL="${DATABASE_URL}" \
+            RESEND_API_KEY="${RESEND_API_KEY}" \
+            INTERNAL_API_URL="http://localhost:3000" \
             pm2 start /var/www/dixis/current/frontend/server.js \
                 --name "dixis-frontend" \
                 --max-memory-restart 300M \


### PR DESCRIPTION
## Critical Fix

Next.js standalone mode doesn't load .env files automatically.
Environment variables must be passed inline when starting PM2.

The previous commit accidentally removed these, causing the app to crash
because DATABASE_URL and other secrets weren't available.

## Changes
- Restore NODE_OPTIONS, PORT, HOSTNAME, DATABASE_URL, RESEND_API_KEY inline
- Add INTERNAL_API_URL for SSR localhost fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)