### PR TITLE
fix(deploy): Aggressive memory limits for low-RAM VPS

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -107,8 +107,8 @@ jobs:
             echo "HOSTNAME=0.0.0.0" >> .env
             echo "DATABASE_URL=${DATABASE_URL}" >> .env
             echo "RESEND_API_KEY=${RESEND_API_KEY}" >> .env
-            # Memory limit for Node.js (VPS has limited RAM)
-            echo "NODE_OPTIONS=--max-old-space-size=384" >> .env
+            # Memory limit for Node.js (VPS has very limited RAM - aggressive limit)
+            echo "NODE_OPTIONS=--max-old-space-size=192" >> .env
             # Internal URL for SSR - prevents deadlock through nginx
             echo "INTERNAL_API_URL=http://localhost:3000" >> .env
             cat .env | head -5
@@ -139,22 +139,22 @@ jobs:
             pm2 flush 2>/dev/null || true
             rm -f /home/$USER/.pm2/logs/dixis-frontend-*.log 2>/dev/null || true
 
-            # Start PM2 with memory limit and restart controls
+            # Start PM2 with AGGRESSIVE memory limits for low-RAM VPS
             # Environment variables must be passed inline - Next.js standalone doesn't load .env
-            # --max-memory-restart 300M: Restart if memory exceeds 300MB (VPS has limited RAM)
-            # --max-restarts 10: Allow more restarts for stability
-            # --exp-backoff-restart-delay 2000: Wait 2s before restart to release port
-            echo "Starting PM2 with memory limit (300M) and max 10 restarts..."
-            NODE_OPTIONS="--max-old-space-size=384" \
+            # --max-memory-restart 150M: Restart before OOM killer intervenes (~170MB crash point)
+            # --max-restarts 20: More restarts allowed for resilience
+            # --exp-backoff-restart-delay 1000: Faster recovery (1s delay)
+            echo "Starting PM2 with AGGRESSIVE memory limits (150M) for low-RAM VPS..."
+            NODE_OPTIONS="--max-old-space-size=192" \
             PORT=3000 HOSTNAME=0.0.0.0 \
             DATABASE_URL="${DATABASE_URL}" \
             RESEND_API_KEY="${RESEND_API_KEY}" \
             INTERNAL_API_URL="http://localhost:3000" \
             pm2 start /var/www/dixis/current/frontend/server.js \
                 --name "dixis-frontend" \
-                --max-memory-restart 300M \
-                --max-restarts 10 \
-                --exp-backoff-restart-delay=2000 2>&1 || {
+                --max-memory-restart 150M \
+                --max-restarts 20 \
+                --exp-backoff-restart-delay=1000 2>&1 || {
                 echo "PM2 start failed! Exit code: $?"
                 echo "Checking if server.js exists..."
                 ls -la /var/www/dixis/current/frontend/server.js || echo "server.js NOT FOUND!"


### PR DESCRIPTION
## Summary
- Lower NODE_OPTIONS heap limit: 384MB → 192MB
- Lower PM2 max-memory-restart: 300M → 150M (restarts before VPS OOM killer kicks in at ~170MB)
- Increase max-restarts: 10 → 20 (more resilience during startup)
- Reduce exp-backoff-delay: 2s → 1s (faster recovery)

## Problem
The app was crash-looping every ~50-60 seconds because:
1. Memory grows from 40MB → 170MB during startup
2. VPS OOM killer kills the process before PM2's 300M limit
3. PM2 restarts but same pattern repeats

## Evidence
Deploy logs show the pattern:
- PM2 shows "online" at 39.5MB
- Memory grows: 66MB → 115MB → 168MB → crash
- App never responds to health checks during the crash-loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)