### PR TITLE
fix: Increase PM2 memory limit to 350M for stable production

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -139,22 +139,22 @@ jobs:
             pm2 flush 2>/dev/null || true
             rm -f /home/$USER/.pm2/logs/dixis-frontend-*.log 2>/dev/null || true
 
-            # Start PM2 with STABILITY-FOCUSED config for low-RAM VPS
+            # Start PM2 with PRODUCTION config - VPS has 8GB RAM (plenty!)
             # Environment variables must be passed inline - Next.js standalone doesn't load .env
-            # Analysis: App peaks at ~175MB during startup, settles ~150MB after warmup
-            # --max-memory-restart 256M: Above startup peak (175MB) to allow initialization
+            # Analysis: App uses ~300MB after warmup with traffic
+            # --max-memory-restart 350M: Above normal usage, prevents unnecessary restarts
             # --kill-timeout 5000: Clean process shutdown to prevent EADDRINUSE on restart
-            # --max-restarts 10: Fewer restarts - focus on stability not resilience
-            # --exp-backoff-restart-delay 3000: Longer delay (3s) to ensure port is released
-            echo "Starting PM2 with stability-focused config (256M limit, 5s kill timeout)..."
-            NODE_OPTIONS="--max-old-space-size=320" \
+            # --max-restarts 10: Reasonable restart limit
+            # --exp-backoff-restart-delay 3000: Delay between restarts
+            echo "Starting PM2 with production config (350M limit, 5s kill timeout)..."
+            NODE_OPTIONS="--max-old-space-size=384" \
             PORT=3000 HOSTNAME=0.0.0.0 \
             DATABASE_URL="${DATABASE_URL}" \
             RESEND_API_KEY="${RESEND_API_KEY}" \
             INTERNAL_API_URL="http://localhost:3000" \
             pm2 start /var/www/dixis/current/frontend/server.js \
                 --name "dixis-frontend" \
-                --max-memory-restart 256M \
+                --max-memory-restart 350M \
                 --kill-timeout 5000 \
                 --max-restarts 10 \
                 --exp-backoff-restart-delay=3000 2>&1 || {


### PR DESCRIPTION
## Summary
- Increases PM2 memory limit from 256M to 350M
- Increases NODE_OPTIONS from 320MB to 384MB
- VPS has 8GB RAM, previous limits were causing unnecessary restarts

## Context
The site was crashing due to PM2 restart storms. Investigation revealed:
- Load average was 17.03 (should be ~2)
- Multiple PM2 instances running under different users
- Old deployments still consuming resources
- Memory limit (256M) was too low for warm app (~300MB)

## Test Plan
- [x] Site is now UP at https://dixis.gr
- [x] Health check returns OK
- [x] No restarts after memory limit increase

🤖 Generated with [Claude Code](https://claude.com/claude-code)