### PR TITLE
PASS UI-SEARCH: mobile-first search & category pills

### DIFF
--- a/frontend/src/app/HomeClient.tsx
+++ b/frontend/src/app/HomeClient.tsx
@@ -11,6 +11,8 @@ import EmptyState from '@/components/EmptyState';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/contexts/ToastContext';
 import { greekNormalize, greekTextContains } from '@/lib/utils/greekNormalize';
+import SearchBar from '@/components/ui/SearchBar';
+import CategoryPills from '@/components/catalogue/CategoryPills';
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://dixis.gr";
 
@@ -300,7 +302,20 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
           </div>
         </section>
 
-        {/* Search & Filters Section */}
+        {/* Mobile-First Search & Category Pills */}
+        <section className="py-4 space-y-4">
+          <SearchBar
+            value={filters.search}
+            onChange={(query) => updateFilter('search', query)}
+            placeholder="Αναζήτηση σε μέλι, λάδι, βότανα..."
+          />
+          <CategoryPills
+            selected={filters.category}
+            onChange={(categoryId) => updateFilter('category', categoryId)}
+          />
+        </section>
+
+        {/* Advanced Filters Section */}
         <div className="py-6">
           
           {/* Enhanced Search and Filters */}

--- a/frontend/src/components/catalogue/CategoryPills.tsx
+++ b/frontend/src/components/catalogue/CategoryPills.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+interface Category {
+  id: string
+  label: string
+}
+
+const DEFAULT_CATEGORIES: Category[] = [
+  { id: '', label: 'Όλα' },
+  { id: 'Ελαιόλαδο', label: 'Ελαιόλαδο' },
+  { id: 'Μέλι', label: 'Μέλι' },
+  { id: 'Κρασί', label: 'Κρασί' },
+  { id: 'Βότανα', label: 'Βότανα' },
+  { id: 'Τυροκομικά', label: 'Τυροκομικά' },
+]
+
+interface CategoryPillsProps {
+  categories?: Category[]
+  selected: string
+  onChange: (categoryId: string) => void
+}
+
+export default function CategoryPills({
+  categories = DEFAULT_CATEGORIES,
+  selected,
+  onChange,
+}: CategoryPillsProps) {
+  return (
+    <div
+      className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide -mx-4 px-4 sm:mx-0 sm:px-0"
+      role="tablist"
+      aria-label="Κατηγορίες προϊόντων"
+    >
+      {categories.map((cat) => {
+        const isActive = selected === cat.id
+        return (
+          <button
+            key={cat.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(cat.id)}
+            className={`flex-shrink-0 min-h-[44px] px-4 py-2 rounded-full text-sm font-medium
+                       whitespace-nowrap transition-colors touch-manipulation
+                       ${isActive
+                         ? 'bg-dixis-green text-white shadow-sm'
+                         : 'bg-white text-gray-700 border border-gray-200 hover:border-dixis-green hover:text-dixis-green'
+                       }`}
+            data-testid={`category-pill-${cat.id || 'all'}`}
+          >
+            {cat.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/SearchBar.tsx
+++ b/frontend/src/components/ui/SearchBar.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+interface SearchBarProps {
+  value?: string
+  onChange: (query: string) => void
+  placeholder?: string
+  debounceMs?: number
+}
+
+export default function SearchBar({
+  value = '',
+  onChange,
+  placeholder = 'Αναζήτηση σε μέλι, λάδι, βότανα...',
+  debounceMs = 300,
+}: SearchBarProps) {
+  const [localValue, setLocalValue] = useState(value)
+
+  // Sync with external value
+  useEffect(() => {
+    setLocalValue(value)
+  }, [value])
+
+  // Debounced onChange
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onChange(localValue)
+    }, debounceMs)
+    return () => clearTimeout(timer)
+  }, [localValue, debounceMs, onChange])
+
+  const handleClear = useCallback(() => {
+    setLocalValue('')
+    onChange('')
+  }, [onChange])
+
+  return (
+    <div className="relative w-full">
+      {/* Search Icon */}
+      <svg
+        className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        />
+      </svg>
+
+      <input
+        type="text"
+        value={localValue}
+        onChange={(e) => setLocalValue(e.target.value)}
+        placeholder={placeholder}
+        className="w-full h-12 pl-10 pr-10 text-base bg-white border border-gray-200 rounded-xl
+                   focus:outline-none focus:ring-2 focus:ring-dixis-green focus:border-transparent
+                   placeholder:text-gray-400"
+        data-testid="search-input"
+      />
+
+      {/* Clear Button */}
+      {localValue && (
+        <button
+          type="button"
+          onClick={handleClear}
+          className="absolute right-3 top-1/2 -translate-y-1/2 w-6 h-6 flex items-center justify-center
+                     text-gray-400 hover:text-gray-600 transition-colors"
+          aria-label="Καθαρισμός αναζήτησης"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Mobile-first SearchBar + CategoryPills for storefront home.

**Changes:**
- `SearchBar.tsx`: Full-width input with debounce (300ms), clear button, Dixis brand styling
- `CategoryPills.tsx`: Horizontal scroll pills with ≥44px touch targets, 6 categories (Όλα, Ελαιόλαδο, Μέλι, Κρασί, Βότανα, Τυροκομικά)
- `HomeClient.tsx`: Wire new components to existing `updateFilter` callbacks

**Stats:**
- ~155 LOC total
- No business logic changes
- No API/DB changes
- Preserves existing data-testid selectors

**Mobile-First:**
- Default Tailwind styles = mobile
- sm/md/lg breakpoints only for larger screens
- Edge-to-edge pills on mobile, contained on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)