### PR TITLE
feat(ui): mobile-first polish for product/cart/checkout pages (PASS UI-MOBILE-FIRST)

### DIFF
--- a/frontend/src/app/(storefront)/cart/page.tsx
+++ b/frontend/src/app/(storefront)/cart/page.tsx
@@ -48,12 +48,12 @@ export default function CartPage() {
   return (
     <main className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
       <div className="max-w-5xl mx-auto">
-        <h1 className="text-2xl font-bold mb-4">Καλάθι</h1>
+        <h1 className="text-xl sm:text-2xl font-bold mb-4">Καλάθι</h1>
 
         {list.length === 0 ? (
           <div className="bg-white border rounded-xl p-10 text-center" data-testid="empty-cart">
             <p className="text-gray-600 mb-4" data-testid="empty-cart-message">Το καλάθι σας είναι άδειο.</p>
-            <Link href="/products" className="inline-block bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700">
+            <Link href="/products" className="inline-block bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light active:opacity-90 touch-manipulation">
               Συνέχεια αγορών
             </Link>
           </div>
@@ -95,18 +95,18 @@ export default function CartPage() {
                 <span className="text-lg font-bold" data-testid="total">Σύνολο: {fmt.format(totalCents / 100)}</span>
               </div>
               <p className="text-xs text-gray-500 mt-2">Οι τελικές χρεώσεις (μεταφορικά/ΦΠΑ) υπολογίζονται στο checkout.</p>
-              <button onClick={clear} className="mt-2 w-full inline-flex justify-center border border-red-300 text-red-600 px-4 py-2 rounded-lg hover:bg-red-50">
+              <button onClick={clear} className="mt-2 w-full inline-flex justify-center border border-red-300 text-red-600 px-4 py-2 rounded-lg hover:bg-red-50 active:bg-red-100 touch-manipulation">
                 Καθαρισμός
               </button>
               <button
                 onClick={handleCheckout}
                 disabled={loading}
-                className="mt-4 w-full inline-flex justify-center bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="mt-4 w-full inline-flex justify-center bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light disabled:opacity-50 disabled:cursor-not-allowed touch-manipulation active:opacity-90"
                 data-testid="go-checkout"
               >
                 {loading ? 'Παρακαλώ περιμένετε...' : 'Συνέχεια στο checkout'}
               </button>
-              <Link href="/products" className="mt-2 w-full inline-flex justify-center border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50">
+              <Link href="/products" className="mt-2 w-full inline-flex justify-center border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 active:bg-gray-100 touch-manipulation">
                 Συνέχεια αγορών
               </Link>
             </aside>

--- a/frontend/src/app/(storefront)/checkout/page.tsx
+++ b/frontend/src/app/(storefront)/checkout/page.tsx
@@ -73,7 +73,7 @@ function CheckoutContent() {
       <main className="min-h-screen bg-gray-50 py-8 px-4">
         <div className="max-w-2xl mx-auto bg-white border rounded-xl p-10 text-center">
           <p className="text-gray-600 mb-4">Το καλάθι σας είναι κενό</p>
-          <a href="/products" className="inline-block bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700">
+          <a href="/products" className="inline-block bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light active:opacity-90 touch-manipulation">
             Προβολή Προϊόντων
           </a>
         </div>
@@ -84,7 +84,7 @@ function CheckoutContent() {
   return (
     <main className="min-h-screen bg-gray-50 py-8 px-4" data-testid="checkout-page">
       <div className="max-w-2xl mx-auto">
-        <h1 className="text-2xl font-bold mb-6">Checkout</h1>
+        <h1 className="text-xl sm:text-2xl font-bold mb-6">Checkout</h1>
 
         <div className="bg-white border rounded-xl p-6 mb-6">
           <h2 className="font-semibold mb-4">Στοιχεία Παραγγελίας</h2>
@@ -204,7 +204,7 @@ function CheckoutContent() {
             <button
               type="submit"
               disabled={loading}
-              className="w-full h-12 bg-emerald-600 hover:bg-emerald-700 disabled:bg-gray-400 text-white font-medium rounded-lg text-base"
+              className="w-full h-12 bg-primary hover:bg-primary-light disabled:bg-gray-400 text-white font-medium rounded-lg text-base touch-manipulation active:opacity-90"
               data-testid="checkout-submit"
             >
               {loading ? 'Επεξεργασία...' : 'Ολοκλήρωση Παραγγελίας'}

--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -32,13 +32,13 @@ export default async function Page() {
       <div className="max-w-7xl mx-auto">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-8">
           <div>
-            <h1 className="text-3xl font-bold text-gray-900">Προϊόντα</h1>
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Προϊόντα</h1>
             <p className="mt-2 text-sm text-gray-600">Απευθείας από παραγωγούς — {total} συνολικά.</p>
           </div>
         </div>
 
         {items.length > 0 ? (
-          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
             {items.map((p: ApiItem) => (
               <ProductCard
                 key={p.id}

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -15,8 +15,8 @@ export function ProductCard({ id, title, producer, priceCents, image }: Props) {
   const hasImage = image && image.length > 0
 
   return (
-    <div data-testid="product-card" className="group flex flex-col h-full bg-white border border-gray-200 rounded-xl overflow-hidden hover:shadow-xl transition-all duration-300">
-      <div data-testid="product-card-image" className="relative h-48 w-full bg-gray-100 overflow-hidden">
+    <div data-testid="product-card" className="group flex flex-col h-full bg-white border border-gray-200 rounded-xl overflow-hidden hover:shadow-xl transition-all duration-300 touch-manipulation active:scale-[0.99]">
+      <div data-testid="product-card-image" className="relative aspect-square sm:h-48 sm:aspect-auto w-full bg-gray-100 overflow-hidden">
         {hasImage ? (
           <img
             src={image}
@@ -35,7 +35,7 @@ export function ProductCard({ id, title, producer, priceCents, image }: Props) {
 
       <div className="flex flex-col flex-grow p-4">
         <div className="mb-2">
-          <span data-testid="product-card-producer" className="text-xs font-semibold text-emerald-600 uppercase tracking-wider">
+          <span data-testid="product-card-producer" className="text-xs font-semibold text-primary uppercase tracking-wider">
             {producer || 'Παραγωγός'}
           </span>
           <h3 data-testid="product-card-title" className="text-base font-bold text-gray-900 line-clamp-2 mt-1 leading-tight">


### PR DESCRIPTION
## Summary
Mobile-first polish for storefront pages:
- ProductCard: touch-manipulation, responsive image (aspect-square mobile), brand colors
- Products page: responsive heading (text-2xl sm:text-3xl), tighter mobile gap (gap-4)
- Cart page: brand colors (emerald → primary), touch feedback on buttons
- Checkout page: brand colors, touch feedback on buttons

## Files Changed
| File | LOC | Changes |
|------|-----|---------|
| ProductCard.tsx | 6 | Touch patterns, aspect-square mobile, primary color |
| products/page.tsx | 4 | Responsive h1, gap-4 mobile |
| cart/page.tsx | 10 | Responsive h1, primary color, touch |
| checkout/page.tsx | 6 | Responsive h1, primary color, touch |

**Total: 26 lines changed (13+/13-)**

## Mobile-First Patterns Applied
- `touch-manipulation` - Removes 300ms tap delay on mobile Safari
- `active:scale-[0.99]` / `active:opacity-90` - Touch feedback on tap
- `aspect-square sm:h-48` - Square images on mobile, fixed height on larger
- `text-xl sm:text-2xl` / `text-2xl sm:text-3xl` - Responsive headings
- `gap-4 sm:gap-6` - Tighter gap on mobile = more products above fold
- `bg-primary` - Uses design system token (matches Hero, Trust, FeaturedProducts)

## Test Results
- [x] Build passes (`npm run build`)
- [x] Lint passes (warnings only, pre-existing)
- [x] No new type errors

## NOT Changed (scope constraint)
- NO business logic changes
- NO API changes
- UI polish only

## Related
- Follows mobile-first patterns from Hero.tsx (PR #1206)
- Uses tailwind.config.ts brand tokens (primary, primary-light)

🤖 Generated with [Claude Code](https://claude.com/claude-code)