### PR TITLE
fix(e2e): add missing required fields to checkout test

### DIFF
--- a/frontend/tests/e2e/checkout-mvp.spec.ts
+++ b/frontend/tests/e2e/checkout-mvp.spec.ts
@@ -42,10 +42,13 @@ test.describe('AG121: MVP Checkout (Order Intent)', () => {
     await expect(page.locator('[data-testid="checkout-page"]')).toBeVisible()
     await expect(page.locator('[data-testid="checkout-form"]')).toBeVisible()
 
-    // 7. Fill checkout form
+    // 7. Fill checkout form (all required fields)
     await page.locator('[data-testid="checkout-name"]').fill('Test User')
+    await page.locator('[data-testid="checkout-phone"]').fill('+30 210 1234567')
     await page.locator('[data-testid="checkout-email"]').fill('test@example.com')
     await page.locator('[data-testid="checkout-address"]').fill('Test Address 123')
+    await page.locator('[data-testid="checkout-city"]').fill('Αθήνα')
+    await page.locator('[data-testid="checkout-postcode"]').fill('10671')
 
     // 8. Submit order
     await page.locator('[data-testid="checkout-submit"]').click()


### PR DESCRIPTION
## Summary
The checkout-mvp.spec.ts E2E test was failing because it only filled 3 of 6 required form fields.

**Root Cause**: The checkout API validates with Zod and returns 400 for incomplete submissions.

| Field | Was Filled | Now Filled |
|-------|------------|------------|
| name | ✅ | ✅ |
| phone | ❌ | ✅ |
| email | ✅ | ✅ |
| address | ✅ | ✅ |
| city | ❌ | ✅ |
| postcode | ❌ | ✅ |

## Changes
- Added phone fill: `+30 210 1234567` (Greek format)
- Added city fill: `Αθήνα`
- Added postcode fill: `10671` (5-digit Greek format)

## Test Results
```
Running 1 test using 1 worker
1 passed (18.1s)
```

## Impact
- **Before**: Test always timed out waiting for /thank-you redirect
- **After**: Test passes - full checkout flow verified ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)