### PR TITLE
fix(deploy): use standalone server for PM2 (CRITICAL)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -86,7 +86,12 @@ jobs:
 
             # Write env files
             rm -f prisma/.env
-            printf "DATABASE_URL=%s\n" "$DATABASE_URL" > .env
+            cat > .env << 'ENVEOF'
+DATABASE_URL=$DATABASE_URL
+NEXT_PUBLIC_API_BASE_URL=https://dixis.gr/api/v1
+ENVEOF
+            # Replace the DATABASE_URL placeholder with actual value
+            sed -i "s|DATABASE_URL=\$DATABASE_URL|DATABASE_URL=$DATABASE_URL|g" .env
             cp .env .env.production
 
             pnpm install --frozen-lockfile
@@ -94,10 +99,19 @@ jobs:
             export NEXT_CACHE_DIR="$NEXT_CACHE_DIR"
             pnpm build
 
-            # Kill any existing process on port 3000 and restart
-            pkill -f "next start" || true
+            # Copy .env and static assets to standalone directory
+            mkdir -p .next/standalone
+            cp .env .next/standalone/.env
+            cp -r public .next/standalone/ 2>/dev/null || true
+            cp -r .next/static .next/standalone/.next/ 2>/dev/null || true
+
+            # Kill any existing process and restart with standalone server
+            pkill -f "node.*server.js" || pkill -f "next start" || true
             sleep 2
-            pm2 restart dixis-frontend --update-env || pm2 start npm --name dixis-frontend -- start
+            cd .next/standalone
+            pm2 restart dixis-frontend --update-env || pm2 start server.js --name dixis-frontend
+            cd ../..
+            sleep 3
             curl -sI http://127.0.0.1:3000/api/healthz | head -n1 || true
           '\'''
 


### PR DESCRIPTION
## 🚨 CRITICAL: Production Deploy Fix

### Problem
**Current deploy workflow breaks production** by using `npm start` which runs `next start`.

This fails with Next.js `output: 'standalone'` configuration because:
- ❌ Prisma client located in `.next/standalone/node_modules/.pnpm/...`
- ❌ `next start` looks for it in `node_modules/.prisma/` (doesn't exist)
- ❌ All Prisma queries fail silently, returning empty arrays
- ❌ Products API returns 0 items despite having 10 in database

**Impact**: Next deploy will revert manual VPS fix and break the site again.

---

### Solution
✅ Change PM2 to run `node .next/standalone/server.js`
✅ Copy .env to standalone directory  
✅ Copy static assets (public/, .next/static/) to standalone
✅ Update pkill pattern to match new process name

---

### Changes
**File**: `.github/workflows/deploy-prod.yml` (lines 102-115)

**Before**:
```bash
pm2 restart dixis-frontend --update-env || pm2 start npm --name dixis-frontend -- start
```

**After**:
```bash
# Copy .env and static assets to standalone directory
mkdir -p .next/standalone
cp .env .next/standalone/.env
cp -r public .next/standalone/ 2>/dev/null || true
cp -r .next/static .next/standalone/.next/ 2>/dev/null || true

# Kill any existing process and restart with standalone server
pkill -f "node.*server.js" || pkill -f "next start" || true
sleep 2
cd .next/standalone
pm2 restart dixis-frontend --update-env || pm2 start server.js --name dixis-frontend
cd ../..
sleep 3
curl -sI http://127.0.0.1:3000/api/healthz | head -n1 || true
```

---

### Testing
- ✅ Manual test on VPS confirms standalone server works
- ✅ Products API returns 10 items (was 0 with `next start`)
- ✅ PM2 process running successfully for 2+ hours

---

### Priority
**P0 CRITICAL** - Must merge before any other deploys to prevent production breakage.

---

### Related
- Emergency fix applied manually on VPS (2025-12-01 20:08 UTC)
- PM2 process `dixis-frontend` already running standalone server in production
- Fixes issue discovered during PR #1210 deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)