### PR TITLE
fix(deploy): add VPS permission preparation to deploy-frontend

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -68,6 +68,27 @@ jobs:
             echo "Warning: Prisma client not found, Next.js standalone should include it"
           fi
 
+      - name: Prepare VPS directory (fix permissions)
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_KEY }}
+          script: |
+            # Target directory for deploy-frontend
+            TARGET_DIR="/var/www/dixis/current/frontend"
+
+            # Create directory if it doesn't exist
+            mkdir -p "$TARGET_DIR"
+
+            # Fix ownership (deploy user needs write access for rsync --delete)
+            sudo chown -R deploy:deploy "$TARGET_DIR"
+
+            # Fix permissions (rwX for owner/group)
+            sudo chmod -R u+rwX,g+rwX "$TARGET_DIR"
+
+            echo "✅ Permissions fixed for $TARGET_DIR"
+
       - name: Deploy standalone to VPS
         uses: easingthemes/ssh-deploy@main
         with:


### PR DESCRIPTION
## Summary
- Fixes recurring deploy-frontend workflow failures caused by rsync permission errors
- Adds "Prepare VPS directory" step that runs before rsync deployment
- Ensures deploy user has ownership of target directory for --delete operations

## Root Cause
- deploy-frontend.yml uses rsync with --delete flag
- Old files/directories (especially tests/*) owned by root cannot be deleted
- Workflow fails: `rsync: delete_file: unlink(tests/...) failed: Permission denied`

## Solution
- Add ssh-action step before rsync that runs:
  - `sudo chown -R deploy:deploy /var/www/dixis/current/frontend`
  - `sudo chmod -R u+rwX,g+rwX /var/www/dixis/current/frontend`
- Aligns with deploy-prod.yml pattern (PR #1227)

## Testing
- [x] Manual VPS permission fix verified
- [x] deploy-frontend workflow run #19840850720 succeeded after manual fix
- [x] Smoke tests passed (homepage, products, cart icon, static assets)

## Related
- Related to PR #1227 (fixed deploy-prod.yml but wrong workflow)
- Closes issue with deploy-frontend failures on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)