### PR TITLE
fix(checkout): restore submit button visibility (Tailwind v4 compat)

### DIFF
--- a/frontend/src/app/(storefront)/checkout/page.tsx
+++ b/frontend/src/app/(storefront)/checkout/page.tsx
@@ -84,7 +84,7 @@ function CheckoutContent() {
       <main className="min-h-screen bg-gray-50 py-8 px-4">
         <div className="max-w-2xl mx-auto bg-white border rounded-xl p-10 text-center">
           <p className="text-gray-600 mb-4">Το καλάθι σας είναι κενό</p>
-          <a href="/products" className="inline-block bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light active:opacity-90 touch-manipulation">
+          <a href="/products" className="inline-block bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 active:opacity-90 touch-manipulation">
             Προβολή Προϊόντων
           </a>
         </div>
@@ -224,7 +224,7 @@ function CheckoutContent() {
             <button
               type="submit"
               disabled={loading}
-              className="w-full h-12 bg-primary hover:bg-primary-light disabled:bg-gray-400 text-white font-medium rounded-lg text-base touch-manipulation active:opacity-90"
+              className="w-full h-12 bg-emerald-600 hover:bg-emerald-700 disabled:bg-gray-400 text-white font-medium rounded-lg text-base touch-manipulation active:opacity-90"
               data-testid="checkout-submit"
             >
               {loading ? 'Επεξεργασία...' : 'Ολοκλήρωση Παραγγελίας'}

--- a/frontend/tests/e2e/checkout-submit.spec.ts
+++ b/frontend/tests/e2e/checkout-submit.spec.ts
@@ -285,4 +285,37 @@ test.describe('AG124: Checkout Submit → Order in Neon', () => {
 
     console.log(`✅ S6: Order created without email: ${orderId}`)
   })
+
+  test('S7: Checkout submit button is visible with proper styling', async ({ page }) => {
+    const helper = new CheckoutTestHelper(page)
+
+    console.log('🧪 S7: Testing checkout submit button visibility (regression)...')
+
+    // Step 1: Add product to cart
+    await helper.addProductsToCart(1)
+
+    // Step 2: Navigate to checkout
+    await helper.goToCheckout()
+
+    // Step 3: Verify submit button is visible
+    const submitButton = page.locator('[data-testid="checkout-submit"]')
+    await expect(submitButton).toBeVisible()
+
+    // Step 4: Verify button has correct background color (bg-emerald-600 = rgb(5, 150, 105))
+    // This catches regressions where custom Tailwind colors don't render
+    const bgColor = await submitButton.evaluate(el => {
+      return window.getComputedStyle(el).backgroundColor
+    })
+    expect(bgColor).not.toBe('rgba(0, 0, 0, 0)') // Not transparent
+    expect(bgColor).not.toBe('transparent')
+    expect(bgColor).not.toBe('rgb(255, 255, 255)') // Not white (invisible)
+
+    // Step 5: Verify button text is visible (has white text on colored bg)
+    const textColor = await submitButton.evaluate(el => {
+      return window.getComputedStyle(el).color
+    })
+    expect(textColor).toBe('rgb(255, 255, 255)') // White text
+
+    console.log(`✅ S7: Button visible with bg=${bgColor}, text=${textColor}`)
+  })
 })


### PR DESCRIPTION
## Summary
- Replace `bg-primary` with `bg-emerald-600` on checkout submit button
- Same fix for empty cart 'Προβολή Προϊόντων' link
- Add regression test S7 to verify button visibility

## Root Cause
Tailwind v4 doesn't recognize `bg-primary` custom color → transparent background → invisible white text

## Test Plan
- [ ] Checkout button visible with green background
- [ ] Button text 'Ολοκλήρωση Παραγγελίας' readable (white on green)
- [ ] E2E test S7 passes

## Size: 35 LOC ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)