### PR TITLE
feat(db): add producer approval fields

### DIFF
--- a/frontend/prisma/migrations/20251203000000_add_producer_approval_fields/migration.sql
+++ b/frontend/prisma/migrations/20251203000000_add_producer_approval_fields/migration.sql
@@ -1,0 +1,7 @@
+-- Add producer approval fields for admin approval workflow
+-- AlterTable
+ALTER TABLE "Producer" ADD COLUMN "approvalStatus" TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE "Producer" ADD COLUMN "rejectionReason" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Producer_approvalStatus_idx" ON "Producer"("approvalStatus");

--- a/frontend/prisma/schema.ci.prisma
+++ b/frontend/prisma/schema.ci.prisma
@@ -12,24 +12,28 @@ datasource db {
 }
 
 model Producer {
-  id          String    @id @default(cuid())
-  slug        String    @unique
-  name        String
-  region      String
-  category    String
-  description String?
-  phone       String?
-  email       String?
-  products    Int       @default(0)
-  rating      Float?    @default(0)
-  imageUrl    String?
-  isActive    Boolean   @default(true)
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  Product     Product[]
+  id              String    @id @default(cuid())
+  slug            String    @unique
+  name            String
+  region          String
+  category        String
+  description     String?
+  phone           String?
+  email           String?
+  products        Int       @default(0)
+  rating          Float?    @default(0)
+  imageUrl        String?
+  isActive        Boolean   @default(true)
+  // Admin approval fields
+  approvalStatus  String    @default("pending") // "pending" | "approved" | "rejected"
+  rejectionReason String?                       // Only set when rejected
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  Product         Product[]
 
   @@index([region, category])
   @@index([name])
+  @@index([approvalStatus])
 }
 
 model Product {

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -8,24 +8,28 @@ datasource db {
 }
 
 model Producer {
-  id          String    @id @default(cuid())
-  slug        String    @unique
-  name        String
-  region      String
-  category    String
-  description String?
-  phone       String?
-  email       String?
-  products    Int       @default(0)
-  rating      Float?    @default(0)
-  imageUrl    String?
-  isActive    Boolean   @default(true)
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  Product     Product[]
+  id              String    @id @default(cuid())
+  slug            String    @unique
+  name            String
+  region          String
+  category        String
+  description     String?
+  phone           String?
+  email           String?
+  products        Int       @default(0)
+  rating          Float?    @default(0)
+  imageUrl        String?
+  isActive        Boolean   @default(true)
+  // Admin approval fields
+  approvalStatus  String    @default("pending") // "pending" | "approved" | "rejected"
+  rejectionReason String?                       // Only set when rejected
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  Product         Product[]
 
   @@index([region, category])
   @@index([name])
+  @@index([approvalStatus])
 }
 
 model Product {


### PR DESCRIPTION
## Summary
Adds database fields for producer approval workflow:
- `approvalStatus` field (pending/approved/rejected)
- `rejectionReason` field (nullable, for rejection notes)

## Changes
| File | Change |
|------|--------|
| `prisma/schema.prisma` | +4 LOC (2 fields + 1 index) |
| `migrations/20251203000000_add_producer_approval_fields/migration.sql` | +7 LOC |

**Total: ~11 LOC**

## Risk/Impact
- ✅ **LOW RISK**: Additive changes only, backward compatible
- ✅ **No breaking changes**: Default value 'pending' prevents null issues
- ⚠️ **Requires migration**: Run `npx prisma migrate deploy` on production

## Testing
- [x] `npx prisma db push` succeeds locally
- [x] `npm run build` passes (TypeScript compiles)
- [x] Prisma client generates successfully

## Next Steps
- Depends on: None
- Enables: Admin Producer Approval UI PR

---

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>