### PR TITLE
db(product): add approval fields to Product schema

### DIFF
--- a/frontend/prisma/schema.ci.prisma
+++ b/frontend/prisma/schema.ci.prisma
@@ -37,25 +37,29 @@ model Producer {
 }
 
 model Product {
-  id          String      @id @default(cuid())
-  slug        String      @unique
-  producerId  String
-  title       String
-  category    String
-  price       Float
-  unit        String
-  stock       Int         @default(0)
-  description String?
-  imageUrl    String?
-  isActive    Boolean     @default(true)
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
-  producer    Producer    @relation(fields: [producerId], references: [id], onDelete: Cascade)
-  OrderItem   OrderItem[]
+  id              String      @id @default(cuid())
+  slug            String      @unique
+  producerId      String
+  title           String
+  category        String
+  price           Float
+  unit            String
+  stock           Int         @default(0)
+  description     String?
+  imageUrl        String?
+  isActive        Boolean     @default(true)
+  // Admin approval fields
+  approvalStatus  String      @default("pending") // "pending" | "approved" | "rejected"
+  rejectionReason String?                         // Only set when rejected
+  createdAt       DateTime    @default(now())
+  updatedAt       DateTime    @updatedAt
+  producer        Producer    @relation(fields: [producerId], references: [id], onDelete: Cascade)
+  OrderItem       OrderItem[]
 
   @@index([producerId, createdAt])
   @@index([category])
   @@index([isActive])
+  @@index([approvalStatus])
 }
 
 model Order {

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -33,25 +33,29 @@ model Producer {
 }
 
 model Product {
-  id          String      @id @default(cuid())
-  slug        String      @unique
-  producerId  String
-  title       String
-  category    String
-  price       Float
-  unit        String
-  stock       Int         @default(0)
-  description String?
-  imageUrl    String?
-  isActive    Boolean     @default(true)
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
-  producer    Producer    @relation(fields: [producerId], references: [id], onDelete: Cascade)
-  OrderItem   OrderItem[]
+  id              String      @id @default(cuid())
+  slug            String      @unique
+  producerId      String
+  title           String
+  category        String
+  price           Float
+  unit            String
+  stock           Int         @default(0)
+  description     String?
+  imageUrl        String?
+  isActive        Boolean     @default(true)
+  // Admin approval fields
+  approvalStatus  String      @default("pending") // "pending" | "approved" | "rejected"
+  rejectionReason String?                         // Only set when rejected
+  createdAt       DateTime    @default(now())
+  updatedAt       DateTime    @updatedAt
+  producer        Producer    @relation(fields: [producerId], references: [id], onDelete: Cascade)
+  OrderItem       OrderItem[]
 
   @@index([producerId, createdAt])
   @@index([category])
   @@index([isActive])
+  @@index([approvalStatus])
 }
 
 model Order {


### PR DESCRIPTION
## Summary
Add approval fields to Product model (same pattern as Producer):
- `approvalStatus` String with default "pending"
- `rejectionReason` String? for rejection details
- Index on `approvalStatus`

## Files Changed
- `frontend/prisma/schema.prisma` - Main schema
- `frontend/prisma/schema.ci.prisma` - CI schema

## Migration
Run after merge:
```bash
cd frontend && npx prisma migrate dev --name add_product_approval_fields
```

## Risk
**Low** - Additive change only, no breaking changes

## Test Plan
- [ ] Schema validates (`npx prisma generate`)
- [ ] Migration applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)