### PR TITLE
fix(ux): replace alert() calls with toast notifications

### DIFF
--- a/frontend/src/app/(storefront)/cart/page.tsx
+++ b/frontend/src/app/(storefront)/cart/page.tsx
@@ -3,9 +3,11 @@ import React, { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useCart, cartCount, cartTotalCents } from '@/lib/cart'
+import { useToast } from '@/contexts/ToastContext'
 
 export default function CartPage() {
   const router = useRouter()
+  const { showError } = useToast()
   const items = useCart(s => s.items)
   const inc = useCart(s => s.inc)
   const dec = useCart(s => s.dec)
@@ -40,7 +42,7 @@ export default function CartPage() {
       router.push(`/checkout?orderId=${data.orderId}`)
     } catch (error) {
       console.error('Checkout error:', error)
-      alert('Σφάλμα κατά τη δημιουργία παραγγελίας. Παρακαλώ δοκιμάστε ξανά.')
+      showError('Σφάλμα κατά τη δημιουργία παραγγελίας. Παρακαλώ δοκιμάστε ξανά.')
       setLoading(false)
     }
   }

--- a/frontend/src/app/admin/orders/[id]/OrderStatusQuickActions.tsx
+++ b/frontend/src/app/admin/orders/[id]/OrderStatusQuickActions.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useToast } from '@/contexts/ToastContext'
 
 interface Props {
   orderId: string
@@ -17,6 +18,7 @@ const statusLabels: Record<string, string> = {
 }
 
 export function OrderStatusQuickActions({ orderId, currentStatus }: Props) {
+  const { showError } = useToast()
   const [loading, setLoading] = useState(false)
   const [status, setStatus] = useState(currentStatus)
 
@@ -39,7 +41,7 @@ export function OrderStatusQuickActions({ orderId, currentStatus }: Props) {
       window.location.reload()
     } catch (e) {
       console.error('Status change error:', e)
-      alert('Σφάλμα κατά την αλλαγή κατάστασης')
+      showError('Σφάλμα κατά την αλλαγή κατάστασης')
     } finally {
       setLoading(false)
     }

--- a/frontend/src/app/admin/orders/[id]/page.tsx
+++ b/frontend/src/app/admin/orders/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React from 'react';
 import { orderNumber } from '../../../../lib/orderNumber';
+import { useToast } from '@/contexts/ToastContext';
 
 type Order = {
   id: string;
@@ -23,6 +24,7 @@ export default function AdminOrderDetail({
   params: { id: string };
 }) {
   const { id } = params;
+  const { showSuccess, showError } = useToast();
   const [data, setData] = React.useState<Order | null>(null);
   const [err, setErr] = React.useState('');
 
@@ -124,9 +126,13 @@ export default function AdminOrderDetail({
               onClick={async ()=>{
                 try {
                   const r = await fetch(`/api/admin/orders/${data?.id}/resend`, { method:'POST' });
-                  alert(r.ok ? 'Το email στάλθηκε ξανά.' : 'Αποτυχία αποστολής.');
+                  if (r.ok) {
+                    showSuccess('Το email στάλθηκε ξανά.');
+                  } else {
+                    showError('Αποτυχία αποστολής.');
+                  }
                 } catch {
-                  alert('Σφάλμα αποστολής.');
+                  showError('Σφάλμα αποστολής.');
                 }
               }}
               className="border px-3 py-1 rounded"


### PR DESCRIPTION
## Summary
- Replaced browser `alert()` dialogs with toast notifications
- Better UX: non-blocking, styled consistently with app design
- Uses existing `useToast` hook from ToastContext

## Files changed
- `frontend/src/app/(storefront)/cart/page.tsx` - Checkout error
- `frontend/src/app/admin/orders/[id]/page.tsx` - Resend receipt success/error
- `frontend/src/app/admin/orders/[id]/OrderStatusQuickActions.tsx` - Status change error

## Test plan
- [ ] Run lint: `npm run lint` - Passed
- [ ] Run build: `npm run build` - Passed
- [ ] Trigger checkout error to see toast notification
- [ ] Test resend receipt in admin to see toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)