### PR TITLE
fix(security): add requireAdmin() to product approval endpoints

### DIFF
--- a/frontend/src/app/admin/products/page.tsx
+++ b/frontend/src/app/admin/products/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, Suspense } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { useToast } from '@/contexts/ToastContext'
 
 interface Product {
   id: string
@@ -47,6 +48,7 @@ function StatusBadge({ status }: { status: string }) {
 function AdminProductsContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const { showSuccess, showError } = useToast()
 
   const [products, setProducts] = useState<Product[]>([])
   const [loading, setLoading] = useState(true)
@@ -88,10 +90,11 @@ function AdminProductsContent() {
     try {
       const res = await fetch(`/api/admin/products/${productId}/approve`, { method: 'POST' })
       if (!res.ok) throw new Error((await res.json()).error || 'Αποτυχία')
+      showSuccess('Το προϊόν εγκρίθηκε επιτυχώς')
       await loadProducts()
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Αποτυχία έγκρισης προϊόντος'
-      alert(message)
+      showError(message)
     } finally {
       setProcessingIds(prev => { const s = new Set(prev); s.delete(productId); return s })
     }
@@ -114,12 +117,13 @@ function AdminProductsContent() {
         body: JSON.stringify({ rejectionReason })
       })
       if (!res.ok) throw new Error((await res.json()).error || 'Αποτυχία')
+      showSuccess('Το προϊόν απορρίφθηκε')
       setRejectModalOpen(false)
       setProductToReject(null)
       await loadProducts()
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Αποτυχία απόρριψης προϊόντος'
-      alert(message)
+      showError(message)
     } finally {
       setSubmitting(false)
       if (productToReject) {

--- a/frontend/src/app/api/admin/products/[id]/approve/route.ts
+++ b/frontend/src/app/api/admin/products/[id]/approve/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db/client'
+import { requireAdmin } from '@/lib/auth/admin'
 
 /**
  * POST /api/admin/products/[id]/approve
@@ -10,6 +11,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await requireAdmin()
     const { id: productId } = await params
 
     if (!productId) {

--- a/frontend/src/app/api/admin/products/[id]/reject/route.ts
+++ b/frontend/src/app/api/admin/products/[id]/reject/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db/client'
+import { requireAdmin } from '@/lib/auth/admin'
 import { z } from 'zod'
 
 const RejectSchema = z.object({
@@ -15,6 +16,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await requireAdmin()
     const { id: productId } = await params
 
     if (!productId) {


### PR DESCRIPTION
## Summary

- Add `requireAdmin()` authentication guards to product approval API endpoints
- Replace `alert()` with toast notifications in admin products page

### Security Fix 🔴

**CRITICAL**: The following endpoints were previously unprotected:
- `/api/admin/products/[id]/approve` - No auth check
- `/api/admin/products/[id]/reject` - No auth check

This allowed **any unauthenticated user** to approve or reject products by calling the API directly.

**After this PR**: Both endpoints now require admin authentication via `requireAdmin()`.

## Files Changed

| File | Change |
|------|--------|
| `api/admin/products/[id]/approve/route.ts` | Add `requireAdmin()` |
| `api/admin/products/[id]/reject/route.ts` | Add `requireAdmin()` |
| `admin/products/page.tsx` | Replace `alert()` with toast |

## Test Plan

- [ ] Verify unauthenticated API calls to `/api/admin/products/[id]/approve` return 401
- [ ] Verify unauthenticated API calls to `/api/admin/products/[id]/reject` return 401
- [ ] Verify admin users can still approve/reject products normally
- [ ] Verify toast notifications appear on success/error

🤖 Generated with [Claude Code](https://claude.com/claude-code)