### PR TITLE
fix(ci): Fix STAGING_PATH variable expansion in deploy-staging workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -96,21 +96,21 @@ jobs:
 
       - name: Restart PM2 (idempotent)
         run: |
-          ssh -i ~/.ssh/id_ed25519 ${STAGING_USER}@${STAGING_HOST} bash <<'REMOTE_SCRIPT'
+          ssh -i ~/.ssh/id_ed25519 ${STAGING_USER}@${STAGING_HOST} bash <<REMOTE_SCRIPT
           set -euo pipefail
 
           # Discover PORT from nginx config
-          PORT=$(sudo nginx -T 2>/dev/null | grep -A 10 'server_name staging.dixis.io' | grep 'proxy_pass' | grep -oP '127.0.0.1:\K\d+' || echo "3001")
-          echo "🔍 Discovered PORT: $PORT"
+          PORT=\$(sudo nginx -T 2>/dev/null | grep -A 10 'server_name staging.dixis.io' | grep 'proxy_pass' | grep -oP '127.0.0.1:\K\d+' || echo "3001")
+          echo "🔍 Discovered PORT: \$PORT"
 
           # Idempotent restart
           if pm2 list | grep -q dixis-staging; then
             echo "🔄 Reloading existing process..."
             pm2 reload dixis-staging --update-env
           else
-            echo "🚀 Starting new process on port $PORT..."
+            echo "🚀 Starting new process on port \$PORT..."
             cd ${STAGING_PATH}/.next/standalone
-            PORT=$PORT NODE_ENV=production DIXIS_ENV=staging pm2 start server.js --name dixis-staging --time
+            PORT=\$PORT NODE_ENV=production DIXIS_ENV=staging pm2 start server.js --name dixis-staging --time
             pm2 save
           fi
 


### PR DESCRIPTION
## Problem

Staging deployment workflow was failing at PM2 restart step with error:
```
bash: line 13: STAGING_PATH: unbound variable
🚀 Starting new process on port 3001...
##[error]Process completed with exit code 1
```

## Root Cause

Single-quoted heredoc (`<<'REMOTE_SCRIPT'`) prevented GitHub Actions environment variables from expanding. When the remote script ran with `set -euo pipefail`, it immediately failed on the unbound variable `${STAGING_PATH}`.

## Solution

Changed heredoc from single-quoted to unquoted delimiter:
- **Before**: `<<'REMOTE_SCRIPT'` (no variable expansion)
- **After**: `<<REMOTE_SCRIPT` (allows local variable expansion)

Escaped all remote variables with backslash:
- `$PORT` → `\$PORT` (expand on remote VPS)
- `${STAGING_PATH}` → expands locally from GitHub Actions env

## Changes

- `.github/workflows/deploy-staging.yml`: Fixed heredoc variable scoping (5 lines changed)

## Verification

After merge:
1. Trigger: `gh workflow run deploy-staging.yml --ref main`
2. Verify: `curl -fsS https://staging.dixis.io/api/healthz`
3. Expected: 200 OK with `{"status":"ok"}`

## Related

- Original PR: #1676 (AG116 staging CI pipeline)
- Post-merge failure: Run 20216947400

🤖 Generated with Claude Code
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>