### PR TITLE
fix(ci): Replace expired domain health check with VPS localhost check

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -122,6 +122,24 @@ jobs:
         run: |
           echo "🩺 Staging health check..."
           sleep 3
-          curl -fsS https://staging.dixis.io/api/healthz || \
-            curl -fsS http://staging.dixis.io/api/healthz
+          ssh -i ~/.ssh/id_ed25519 ${STAGING_USER}@${STAGING_HOST} bash <<HEALTH_CHECK
+          set -euo pipefail
+
+          # Discover PORT from PM2
+          PORT=\$(pm2 jlist | grep -A 5 'dixis-staging' | grep -oP '"PORT":\s*"\K\d+' || echo "3001")
+          echo "🔍 Health check on port \$PORT"
+
+          # Call healthz endpoint
+          RESPONSE=\$(curl -fsS http://localhost:\$PORT/api/healthz 2>&1)
+          echo "📋 Response: \$RESPONSE"
+
+          # Validate JSON response contains "status":"ok"
+          if echo "\$RESPONSE" | grep -q '"status":"ok"'; then
+            echo "✅ Health check PASSED"
+            exit 0
+          else
+            echo "❌ Health check FAILED - invalid response"
+            exit 1
+          fi
+          HEALTH_CHECK
           echo "✅ Staging deployment successful!"


### PR DESCRIPTION
## Summary

Fixes AG116 staging smoke test false positive by replacing expired domain health check with VPS localhost verification.

## Problem

Previous health check was hitting `staging.dixis.io` which is expired and returns Hostinger "Your domain is expired" HTML page. The workflow mistakenly counted this as successful deployment.

## Solution

- SSH to VPS and check `localhost:PORT/api/healthz` directly
- Auto-discover PORT from PM2 process info (`pm2 jlist`)
- Validate JSON response contains `"status":"ok"`
- FAIL explicitly if response is HTML or invalid

## Changes

**File**: `.github/workflows/deploy-staging.yml` (lines 121-145)

**Before**:
```yaml
- name: Health check
  run: |
    curl -fsS https://staging.dixis.io/api/healthz
```

**After**:
```yaml
- name: Health check
  run: |
    ssh -i ~/.ssh/id_ed25519 ${STAGING_USER}@${STAGING_HOST} bash <<HEALTH_CHECK
    set -euo pipefail
    PORT=\$(pm2 jlist | grep -A 5 'dixis-staging' | grep -oP '"PORT":\s*"\K\d+' || echo "3001")
    RESPONSE=\$(curl -fsS http://localhost:\$PORT/api/healthz 2>&1)
    if echo "\$RESPONSE" | grep -q '"status":"ok"'; then
      echo "✅ Health check PASSED"
      exit 0
    else
      echo "❌ Health check FAILED - invalid response"
      exit 1
    fi
    HEALTH_CHECK
```

## Verification

After merge, the health check will:
1. Actually test the deployed staging application (not expired domain)
2. Fail if health endpoint returns non-JSON response
3. Fail if JSON doesn't contain `"status":"ok"`

## Related

- PR #1676 - Initial AG116 staging CI deploy pipeline
- PR #1678 - Fixed heredoc variable scoping for PM2 restart

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>