### PR TITLE
fix(ci): Fix staging health check PORT discovery + curl timeout

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -157,19 +157,26 @@ jobs:
         run: |
           echo "🩺 Staging health check..."
           sleep 3
-          ssh -i ~/.ssh/id_ed25519 ${STAGING_USER}@${STAGING_HOST} bash <<HEALTH_CHECK
+          ssh -i ~/.ssh/id_ed25519 ${STAGING_USER}@${STAGING_HOST} bash <<'HEALTH_CHECK'
           set -euo pipefail
 
-          # Discover PORT from PM2
-          PORT=\$(pm2 jlist | grep -A 5 'dixis-staging' | grep -oP '"PORT":\s*"\K\d+' || echo "3001")
-          echo "🔍 Health check on port \$PORT"
+          # Discover PORT from PM2 (take first match only)
+          PORT=$(pm2 jlist | grep -A 5 'dixis-staging' | grep -oP '"PORT":\s*"\K\d+' | head -1)
+          if [ -z "$PORT" ]; then
+            echo "⚠️  No PORT found in PM2, defaulting to 3001"
+            PORT="3001"
+          fi
+          echo "🔍 Health check on port $PORT"
 
-          # Call healthz endpoint
-          RESPONSE=\$(curl -fsS http://localhost:\$PORT/api/healthz 2>&1)
-          echo "📋 Response: \$RESPONSE"
+          # Call healthz endpoint with timeout
+          if ! RESPONSE=$(curl -fsS -m 30 http://localhost:$PORT/api/healthz 2>&1); then
+            echo "❌ Health check FAILED - curl error: $RESPONSE"
+            exit 1
+          fi
+          echo "📋 Response: $RESPONSE"
 
           # Validate JSON response contains "status":"ok"
-          if echo "\$RESPONSE" | grep -q '"status":"ok"'; then
+          if echo "$RESPONSE" | grep -q '"status":"ok"'; then
             echo "✅ Health check PASSED"
             exit 0
           else


### PR DESCRIPTION
## Problem (Exit 255 / Broken Pipe)

After PR #1681 fixed ssh-keyscan, staging deploy now fails at **Health Check** step:
- ❌ Health check hangs for ~5 minutes
- ❌ SSH connection breaks: `client_loop: send disconnect: Broken pipe`  
- ❌ Exit code: 255

**Previous Run**: https://github.com/lomendor/Project-Dixis/actions/runs/20229113654

## Root Cause

### Issue 1: PORT Discovery Returns Multiline String
```bash
PORT=$(pm2 jlist | grep -A 5 'dixis-staging' | grep -oP '"PORT":\s*"\K\d+' || echo "3001")
# Output: "3000\n3001\n3001" (3 lines, not 1 value!)
```

Logs showed:
```
🔍 Health check on port 3000
3000
3001
3001
[5min hang]
client_loop: send disconnect: Broken pipe
```

### Issue 2: No curl Timeout
`curl -fsS http://localhost:$PORT/api/healthz` had no timeout, waiting 5+ minutes before SSH connection broke.

## Solution

**Changes:**
1. ✅ Added `| head -1` to PORT discovery → take first match only  
2. ✅ Added PORT validation: if empty, default to 3001  
3. ✅ Added `curl -m 30` timeout (30 seconds max)  
4. ✅ Improved error handling with explicit curl exit code check  
5. ✅ Changed heredoc to single-quoted (`<<'HEALTH_CHECK'`) to prevent variable expansion issues

## Testing

Will verify in next deployment run (after merge):
- Health check completes in <30 seconds  
- PORT discovery returns single value  
- Deployment succeeds end-to-end

## Related

- PR #1681: Fixed ssh-keyscan (merged)
- Run 20229113654: Failed with exit 255 at Health Check

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)