### PR TITLE
fix(monitor): Rename workflow to v2 for clean GitHub re-registration

### DIFF
--- a/.github/workflows/monitor-uptime-v2.yml
+++ b/.github/workflows/monitor-uptime-v2.yml
@@ -1,4 +1,4 @@
-name: Monitor Uptime
+name: Monitor Uptime v2
 
 on:
   schedule:


### PR DESCRIPTION
## Fix HTTP 422 workflow_dispatch error

**Problem**: Workflow validation error prevented manual dispatch despite correct YAML syntax.

**Root Cause**: GitHub Actions parser rejected workflow (jobs array empty, validation failure).

**Solution**: Rename workflow for clean re-registration:
- File: monitor-uptime.yml → monitor-uptime-v2.yml
- Name: Monitor Uptime → Monitor Uptime v2

**Verification**:
```bash
gh workflow list | grep -i monitor
gh workflow run <NEW_ID> --ref main
```

**Expected**: New workflow ID, successful manual dispatch, cron schedule activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)