### PR TITLE
fix(workflows): Fix backtick indentation in monitor-uptime-v2.yml causing HTTP 422

### DIFF
--- a/.github/workflows/monitor-uptime-v2.yml
+++ b/.github/workflows/monitor-uptime-v2.yml
@@ -95,8 +95,7 @@ Workflow Run: https://github.com/${{ github.repository }}/actions/runs/${{ githu
 2. Check nginx status: 'ssh deploy@STAGING_HOST "sudo systemctl status nginx"'
 3. Check PM2 logs: 'ssh deploy@STAGING_HOST "pm2 logs dixis-frontend --lines 50"'
 4. Verify DNS: 'nslookup dixis.gr'
-
-`;
+            `;
 
             await github.rest.issues.create({
               owner: context.repo.owner,
@@ -181,8 +180,7 @@ Workflow Run: https://github.com/${{ github.repository }}/actions/runs/${{ githu
 3. Check PM2 logs: 'pm2 logs dixis-staging --lines 50'
 4. Manual health check: 'curl http://localhost:3001/api/healthz'
 5. Check nginx config: 'sudo nginx -T | grep -A 10 "staging.dixis.io"'
-
-`;
+            `;
 
             await github.rest.issues.create({
               owner: context.repo.owner,


### PR DESCRIPTION
## Problem

After PR #1694 removed decorative lines, the `monitor-uptime-v2.yml` workflow **STILL fails** with HTTP 422 error when attempting manual trigger. The root cause was **improper indentation of closing backticks** in JavaScript template literals inside the workflow's `script:` blocks.

**Error**:
```
could not create workflow dispatch event: HTTP 422: Workflow does not have 'workflow_dispatch' trigger
```

**Root Cause**: The closing backticks (`` `; ``) of JavaScript template literals on lines 99 and 185 were at column 1, which confuses GitHub's YAML parser even though they're inside a YAML literal scalar block (`script: |`).

## Solution

This PR fixes the backtick indentation by adding proper spacing (12 spaces) to align with the JavaScript code:

**Before (lines 99 and 185)**:
```javascript
4. Verify DNS: 'nslookup dixis.gr'

`;  // ❌ Column 1 - breaks YAML parsing
```

**After**:
```javascript
4. Verify DNS: 'nslookup dixis.gr'
            `;  // ✅ Column 13 - properly indented
```

## Changes

- **Line 98**: Added indentation to production alert template literal closing backtick
- **Line 183**: Added indentation to staging alert template literal closing backtick

## Verification

GitHub's workflow validator will be the authoritative test. After merge:

```bash
# Attempt manual trigger - should succeed:
gh workflow run monitor-uptime-v2.yml --ref main

# Expected: Workflow dispatched successfully (not HTTP 422)
```

## Expected Result

After merge, the workflow should:
1. Accept manual triggers via `gh workflow run monitor-uptime-v2.yml --ref main` (no HTTP 422)
2. Execute successfully (not fail in 0s with "workflow file issue")
3. Generate proper logs
4. Run on the 10-minute cron schedule

---

**Related**: PR #1690 (fixed production backticks), PR #1693 (fixed staging backticks), PR #1694 (removed decorative lines)
