### PR TITLE
feat(ci): Add dispatch smoke test to diagnose workflow_dispatch issue

### DIFF
--- a/.github/workflows/dispatch-smoke.yml
+++ b/.github/workflows/dispatch-smoke.yml
@@ -1,0 +1,10 @@
+name: Dispatch Smoke
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "dispatch ok"


### PR DESCRIPTION
## Problem

After 5 PRs attempting to fix monitor-uptime-v2.yml HTTP 422 error, investigation revealed:
- GitHub's `workflow view --yaml` shows `workflow_dispatch:` IS present
- But dispatch API endpoint returns HTTP 422 "does not have workflow_dispatch trigger"
- This indicates GitHub cached broken metadata from when workflow was initially registered

## Solution - Step 1: Dispatch Smoke Test

Create minimal workflow to verify GitHub Actions dispatch works correctly:
- Single `workflow_dispatch` trigger
- One echo step
- No complex YAML that could confuse GitHub's parser

**Purpose**: Isolate whether the issue is:
- General dispatch problem (this test would fail)
- Specific to monitor-uptime-v2.yml file (this test will succeed)

## Changes

- **NEW**: `.github/workflows/dispatch-smoke.yml` (10 lines, minimal)

## Next Steps

After this PR merges:
1. Verify dispatch smoke test works: `gh workflow run "Dispatch Smoke" --ref main`
2. If successful → Create monitor-uptime-v3.yml (fresh registration)
3. If fails → Deeper investigation into GitHub Actions API

## Expected Result

```bash
gh workflow run "Dispatch Smoke" -R lomendor/Project-Dixis --ref main
# Expected: Success (not HTTP 422)
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>