### PR TITLE
fix(workflows): Add curl timeouts to monitor-uptime-v3 to prevent hangs

### DIFF
--- a/.github/workflows/monitor-uptime-v3.yml
+++ b/.github/workflows/monitor-uptime-v3.yml
@@ -10,4 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Healthz
-        run: curl -fsS https://dixis.gr/api/healthz >/dev/null
+        run: curl -fsS https://dixis.gr/api/healthz --connect-timeout 10 --max-time 15 -4 >/dev/null


### PR DESCRIPTION
## Problem

Monitor Uptime v3 workflow **successfully dispatched** (no HTTP 422 error), but **first run failed** with connection timeout after 136 seconds:

```
curl: (28) Failed to connect to dixis.gr port 443 after 136529 ms: Couldn't connect to server
```

## Root Cause

curl command lacked timeout parameters, causing workflow to hang for 2+ minutes before GitHub runner's default timeout.

## Solution

Add aggressive curl timeouts to prevent hangs:
- `--connect-timeout 10` - Max 10 seconds to establish connection
- `--max-time 15` - Max 15 seconds total runtime
- `-4` - Force IPv4 (avoid IPv6/DNS resolution delays)

## Changes

**File**: `.github/workflows/monitor-uptime-v3.yml`
- Line 13: Added timeout parameters to curl command

```diff
- run: curl -fsS https://dixis.gr/api/healthz >/dev/null
+ run: curl -fsS https://dixis.gr/api/healthz --connect-timeout 10 --max-time 15 -4 >/dev/null
```

## Evidence

**Before** (Run ID: 20263912429):
- Status: failure
- Duration: 2m22s
- Error: curl exit code 28 (connection timeout)
- Logs: `Failed to connect to dixis.gr port 443 after 136529 ms`

**Expected After Merge**:
- Workflow completes in <20 seconds
- Clear failure within 15 seconds if endpoint unreachable
- No 2-minute hangs on GitHub runners

## Verification After Merge

```bash
# Dispatch v3 with timeout fix
gh workflow run "Monitor Uptime v3" -R lomendor/Project-Dixis --ref main

# Watch for quick completion
gh run list -R lomendor/Project-Dixis --workflow="Monitor Uptime v3" --limit 1

# Check logs (should see fast timeout or success)
gh run view <run-id> -R lomendor/Project-Dixis --log
```

---

**Context**: This PR completes the monitor-uptime-v3 migration. Dispatch now works (no HTTP 422), and with timeouts, the workflow will never hang.

**Next Step**: Address production bug (products + login/register pages).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>