### PR TITLE
feat(ops): VPS diagnostic workflow for production debugging

### DIFF
--- a/.github/workflows/vps-diagnose.yml
+++ b/.github/workflows/vps-diagnose.yml
@@ -1,0 +1,69 @@
+name: VPS Diagnostic
+
+on:
+  workflow_dispatch:
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
+
+      - name: Add known host
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Remote diagnostic (ports, processes, nginx)
+        run: |
+          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" 'bash -c "
+            set -euo pipefail
+            echo \"=== SYSTEM INFO ===\"
+            whoami
+            hostname
+            uptime
+            echo \"\"
+
+            echo \"=== NGINX STATUS ===\"
+            systemctl status nginx --no-pager || true
+            echo \"\"
+
+            echo \"=== PM2 PROCESSES ===\"
+            pm2 list || true
+            echo \"\"
+
+            echo \"=== LISTENING PORTS ===\"
+            ss -lntp | grep -E \":(80|443|3000|8001)\b\" || true
+            echo \"\"
+
+            echo \"=== LOCAL HEALTH CHECKS ===\"
+            curl -sS -o /dev/null -w \"local3000=%{http_code}\n\" http://127.0.0.1:3000/ || echo \"local3000=FAIL\"
+            curl -sS -o /dev/null -w \"local8001=%{http_code}\n\" http://127.0.0.1:8001/ || echo \"local8001=FAIL\"
+            curl -sS -o /dev/null -w \"healthz=%{http_code}\n\" https://dixis.gr/api/healthz || echo \"healthz=FAIL\"
+            echo \"\"
+
+            echo \"=== NGINX CONFIG (grep 8001) ===\"
+            grep -R \"8001\" -n /etc/nginx 2>/dev/null | head -80 || echo \"No 8001 references in nginx config\"
+            echo \"\"
+
+            echo \"=== PM2 LOGS DIRECTORY ===\"
+            ls -la /home/*/.pm2/logs 2>/dev/null | head -80 || echo \"No PM2 logs found\"
+            ls -la /root/.pm2/logs 2>/dev/null | head -80 || echo \"No PM2 logs in /root\"
+            echo \"\"
+
+            echo \"=== BACKEND PROCESS CHECK ===\"
+            ps aux | grep -E \"(php|artisan|serve)\" | grep -v grep || echo \"No PHP backend process found\"
+            echo \"\"
+
+            echo \"=== FRONTEND PM2 LOG (last 30 lines) ===\"
+            LATEST_LOG=\$(ls -t /home/*/.pm2/logs/*error*.log 2>/dev/null | head -1) || true
+            if [ -n \"\$LATEST_LOG\" ]; then
+              echo \"Reading: \$LATEST_LOG\"
+              tail -30 \"\$LATEST_LOG\" || true
+            else
+              echo \"No PM2 error logs found\"
+            fi
+          "'


### PR DESCRIPTION
## Problem

Production broken: Frontend loads but shows "Δεν υπάρχουν διαθέσιμα προϊόντα". Previous logs show:
- `ECONNREFUSED 127.0.0.1:8001` (backend API not reachable)
- Health check returns `"db":"error"`
- Products page empty

## Root Cause (Suspected)

Backend Laravel API never deployed OR not running:
- No PHP process on port 8001
- Nginx may not proxy `/api/v1/` correctly
- Backend `.env` missing (only `.env.example` exists)

## Solution

Add VPS diagnostic workflow for evidence-based debugging:

### What This Workflow Does

1. **System Info**: whoami, hostname, uptime
2. **Port Checks**: Which ports 80, 443, 3000, 8001 are listening
3. **Process Checks**: nginx status, PM2 list, PHP backend process
4. **Health Endpoints**:
   - `http://127.0.0.1:3000/` (frontend local)
   - `http://127.0.0.1:8001/` (backend local)
   - `https://dixis.gr/api/healthz` (external)
5. **Config Analysis**: grep nginx for port 8001 references
6. **Log Extraction**: PM2 error logs (last 30 lines)

### Why This Approach

- **No interactive SSH**: Runs via GitHub Actions
- **No secrets printed**: Only HTTP status codes, not .env values
- **Repeatable**: Can re-run on demand via workflow_dispatch
- **Evidence-based**: Shows which ports/processes are down

## Next Steps After Merge

1. Merge this PR → main
2. Trigger workflow: Actions → "VPS Diagnostic" → Run workflow
3. Review logs to identify:
   - Is port 8001 listening? (backend running)
   - Does nginx route `/api/v1/` to 8001?
   - Are PM2 logs showing errors?
4. Apply minimal fix based on evidence

## Files Changed

- `.github/workflows/vps-diagnose.yml` (NEW, 69 lines)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
