### PR TITLE
fix(ci): Use KNOWN_HOSTS secret in backend revive workflow

### DIFF
--- a/.github/workflows/vps-backend-revive.yml
+++ b/.github/workflows/vps-backend-revive.yml
@@ -13,9 +13,24 @@ jobs:
           ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
 
       - name: Add known host
+        env:
+          KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
         run: |
           mkdir -p ~/.ssh
-          ssh-keyscan -H "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts
+
+          # Use pre-configured known_hosts if available, fallback to ssh-keyscan
+          if [ -n "$KNOWN_HOSTS" ]; then
+            echo "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+            echo "✅ Using pre-configured known_hosts"
+          else
+            echo "⚠️  KNOWN_HOSTS secret not set, trying ssh-keyscan..."
+            ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts || {
+              echo "❌ ssh-keyscan failed - ensure VPS_HOST is reachable"
+              exit 1
+            }
+          fi
+          chmod 644 ~/.ssh/known_hosts
 
       - name: Find and start Laravel backend
         run: |


### PR DESCRIPTION
## Summary
Fix SSH connection reliability in VPS backend revive workflow.

## Problem
- Previous run failed with ssh-keyscan timeout (5s)
- `vps-diagnose` workflow succeeded with same method 2h earlier
- Indicates transient network issue

## Solution
Use the more resilient pattern from `deploy-staging.yml`:
1. **Prefer KNOWN_HOSTS secret** (pre-configured, instant)
2. **Fallback to ssh-keyscan** with proper error handling
3. **Set correct permissions** on known_hosts file

## Changes
- Add `KNOWN_HOSTS` secret env var
- Add conditional check: use secret if available
- Add error handling for ssh-keyscan fallback
- Add `chmod 644 ~/.ssh/known_hosts`

## Test Plan
- [x] Code review (pattern from working deploy-staging.yml)
- [ ] Merge to main
- [ ] Re-trigger VPS Backend Revive workflow
- [ ] Verify backend starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)