### PR TITLE
docs(ops): add production VPS access and secrets documentation

### DIFF
--- a/docs/OPS/PROD-ACCESS.md
+++ b/docs/OPS/PROD-ACCESS.md
@@ -1,0 +1,169 @@
+# 🔐 PRODUCTION VPS ACCESS
+
+**Last Updated**: 2025-12-17
+**Purpose**: Canonical production server access documentation (NO SECRETS)
+
+---
+
+## 📋 CONNECTION DETAILS
+
+```bash
+Host:     147.93.126.235 (srv709397)
+User:     deploy
+Port:     22
+Protocol: SSH (ed25519 key only)
+```
+
+---
+
+## 🔑 SSH ACCESS
+
+### Canonical SSH Command
+```bash
+ssh -o IdentitiesOnly=yes -i ~/.ssh/dixis_prod_ed25519 deploy@147.93.126.235
+```
+
+### Access Policy
+- ✅ **Primary**: GitHub Actions workflows (automated deployment)
+- ⚠️ **Emergency only**: Interactive SSH (manual fixes)
+- ❌ **Never**: Direct root access
+
+**SSH Key**: `dixis_prod_ed25519` (ed25519, stored in GitHub Secrets as `VPS_SSH_KEY`)
+
+---
+
+## 🚀 DEPLOYED SERVICES
+
+### PM2 Processes
+```bash
+pm2 list
+# Expected processes:
+# - dixis-backend   (Laravel API)
+# - dixis-frontend  (Next.js production)
+# - dixis-staging   (Next.js staging)
+```
+
+### Ports (Local)
+```
+8001  → Laravel backend (PHP 8.2 + artisan serve)
+3000  → Next.js frontend (production)
+3001  → Next.js staging
+```
+
+### Ports (Public)
+```
+80    → Nginx HTTP (redirects to 443)
+443   → Nginx HTTPS
+      ├─ /api/*     → proxy to 127.0.0.1:8001 (backend)
+      ├─ /sanctum/* → proxy to 127.0.0.1:8001 (backend)
+      └─ /*         → proxy to 127.0.0.1:3000 (frontend)
+```
+
+---
+
+## 📂 DIRECTORY STRUCTURE
+
+```
+/var/www/dixis/
+├── backend/              # Laravel 11 API
+│   ├── .env             # Production secrets (NOT in repo)
+│   ├── vendor/          # Composer dependencies
+│   └── artisan          # Laravel CLI
+├── frontend/            # Next.js 15 app
+│   └── .env.production  # Frontend env (used as .env template)
+└── current/             # Symlinks to active versions
+```
+
+---
+
+## 🛠️ COMMON OPERATIONS
+
+### Check Service Status
+```bash
+ssh deploy@147.93.126.235 "pm2 status && ss -lntp | grep -E ':(80|443|3000|8001)'"
+```
+
+### View Backend Logs
+```bash
+ssh deploy@147.93.126.235 "pm2 logs dixis-backend --lines 50"
+```
+
+### Restart Backend
+```bash
+ssh deploy@147.93.126.235 "pm2 restart dixis-backend"
+```
+
+### Test Endpoints
+```bash
+# Local (from VPS)
+curl http://127.0.0.1:8001/api/health
+curl http://127.0.0.1:3000/
+
+# Public (from anywhere)
+curl https://dixis.gr/api/health
+curl https://dixis.gr/api/v1/public/products
+```
+
+---
+
+## 🚨 EMERGENCY PROCEDURES
+
+### Backend Down
+```bash
+# 1. Check PM2 status
+pm2 status dixis-backend
+
+# 2. View crash logs
+pm2 logs dixis-backend --lines 100 --nostream
+
+# 3. Common fixes:
+# - Missing vendor/: composer install --no-dev
+# - Missing .env: restore from /var/www/dixis/frontend/.env.production
+# - Crash loop: check config/cors.php (avoid app()->environment())
+
+# 4. Restart
+pm2 restart dixis-backend
+```
+
+### Frontend Down
+```bash
+pm2 restart dixis-frontend
+```
+
+### Nginx Down
+```bash
+sudo systemctl status nginx
+sudo systemctl start nginx
+```
+
+### Database Connection Issues
+```bash
+# Check .env database credentials
+grep '^DB_' /var/www/dixis/backend/.env
+
+# Test DB connection
+cd /var/www/dixis/backend
+php artisan tinker --execute="DB::connection()->getPdo();"
+```
+
+---
+
+## ⚠️ SECURITY NOTES
+
+1. **Never commit** `/var/www/dixis/backend/.env` to repo
+2. **Single SSH key**: Use `dixis_prod_ed25519` only (no multiple keys)
+3. **GitHub Secrets**: All prod credentials stored as secrets (see `SECRETS-MAP.md`)
+4. **No password auth**: SSH key-based authentication only
+5. **Firewall**: VPS firewall must allow GitHub Actions IPs for workflows
+
+---
+
+## 🔗 RELATED DOCS
+
+- `docs/OPS/SECRETS-MAP.md` - Required GitHub Secrets
+- `docs/OPS/BACKEND-REVIVE-QUICKREF.md` - Backend troubleshooting
+- `.github/workflows/deploy-prod.yml` - Production deployment workflow
+
+---
+
+**Key Takeaway**: Prefer GitHub Actions workflows over manual SSH. Interactive SSH should only be used for emergency diagnostics.

--- a/docs/OPS/SECRETS-MAP.md
+++ b/docs/OPS/SECRETS-MAP.md
@@ -1,0 +1,116 @@
+# 🔐 GITHUB SECRETS MAP
+
+**Last Updated**: 2025-12-17
+**Purpose**: Required GitHub Secrets for production deployment (NO ACTUAL VALUES)
+
+---
+
+## 📋 REQUIRED SECRETS
+
+### VPS SSH Access
+
+| Secret Name | Type | Used By | Description |
+|-------------|------|---------|-------------|
+| `VPS_SSH_KEY` | SSH Private Key (ed25519) | All VPS workflows | Private key matching `dixis_prod_ed25519.pub` on VPS `/home/deploy/.ssh/authorized_keys` |
+| `VPS_HOST` | String | All VPS workflows | VPS IP address: `147.93.126.235` |
+| `VPS_USER` | String | All VPS workflows | SSH user: `deploy` |
+| `KNOWN_HOSTS` | String (optional) | All VPS workflows | SSH known_hosts entry for VPS (fallback: auto-scan) |
+
+---
+
+## 🔧 BACKEND SECRETS
+
+| Secret Name | Type | Used By | Description |
+|-------------|------|---------|-------------|
+| `BACKEND_ENV_PRODUCTION` | Multi-line String | `deploy-backend.yml` | Complete Laravel `.env` file content for production |
+| `APP_KEY` | String | Backend deploy | Laravel encryption key (generate: `php artisan key:generate --show`) |
+| `DB_HOST` | String | Backend deploy | Neon PostgreSQL host |
+| `DB_PORT` | String | Backend deploy | PostgreSQL port (default: `5432`) |
+| `DB_DATABASE` | String | Backend deploy | Database name: `dixis_prod` |
+| `DB_USERNAME` | String | Backend deploy | Database user |
+| `DB_PASSWORD` | String | Backend deploy | Database password |
+
+---
+
+## 🎨 FRONTEND SECRETS
+
+| Secret Name | Type | Used By | Description |
+|-------------|------|---------|-------------|
+| `FRONTEND_ENV_PRODUCTION` | Multi-line String | `deploy-frontend.yml` | Complete Next.js `.env.production` file |
+| `NEXT_PUBLIC_API_BASE_URL` | String | Frontend deploy | Backend API URL: `https://dixis.gr/api/v1` |
+| `NEXT_PUBLIC_APP_URL` | String | Frontend deploy | Frontend URL: `https://dixis.gr` |
+| `NEXT_PUBLIC_SITE_URL` | String | Frontend deploy | Site canonical URL: `https://dixis.gr` |
+
+---
+
+## 🔗 CORS & SESSION SECRETS
+
+| Secret Name | Type | Used By | Description |
+|-------------|------|---------|-------------|
+| `CORS_ALLOWED_ORIGINS` | String (comma-separated) | Backend | Allowed origins: `https://dixis.gr,https://www.dixis.gr` |
+| `SANCTUM_STATEFUL_DOMAINS` | String (comma-separated) | Backend | Stateful domains: `dixis.gr,www.dixis.gr` |
+| `SESSION_DOMAIN` | String | Backend | Cookie domain: `.dixis.gr` |
+
+---
+
+## 📝 HOW TO ADD SECRETS
+
+### Via GitHub CLI
+```bash
+# Single secret
+gh secret set VPS_HOST --body "147.93.126.235"
+
+# From file
+gh secret set VPS_SSH_KEY < ~/.ssh/dixis_prod_ed25519
+
+# Multi-line (e.g., .env file)
+gh secret set BACKEND_ENV_PRODUCTION < /path/to/production.env
+```
+
+### Via GitHub Web UI
+1. Go to: `https://github.com/lomendor/Project-Dixis/settings/secrets/actions`
+2. Click "New repository secret"
+3. Enter name and value
+4. Click "Add secret"
+
+---
+
+## ✅ VERIFICATION
+
+Check all secrets are set:
+```bash
+gh secret list
+```
+
+Expected output should include:
+```
+VPS_SSH_KEY              Updated 2025-12-17
+VPS_HOST                 Updated 2025-12-17
+VPS_USER                 Updated 2025-12-17
+APP_KEY                  Updated 2025-12-17
+DB_HOST                  Updated 2025-12-17
+DB_PASSWORD              Updated 2025-12-17
+...
+```
+
+---
+
+## 🚨 SECURITY POLICY
+
+1. **Never commit** secrets to repo (even in `.env.example`)
+2. **Rotate keys** if exposed (regenerate SSH key, Laravel APP_KEY, DB password)
+3. **Limit access**: Only repo admins should manage secrets
+4. **Audit regularly**: Review secret usage in workflow runs
+5. **Use environment-specific**: Separate secrets for staging vs production
+
+---
+
+## 🔗 RELATED DOCS
+
+- `docs/OPS/PROD-ACCESS.md` - VPS connection details
+- `.github/workflows/deploy-backend.yml` - Backend deployment (uses secrets)
+- `.github/workflows/vps-backend-env-fix.yml` - Emergency backend fix workflow
+
+---
+
+**Key Takeaway**: All production credentials live in GitHub Secrets. No secrets in repo files. No manual secret management on VPS.


### PR DESCRIPTION
- Add PROD-ACCESS.md: canonical VPS connection details, ports, services
- Add SECRETS-MAP.md: required GitHub Secrets (no actual values)
- Ensures reproducible access without manual SSH key confusion
- All workflows use consistent secret names (VPS_SSH_KEY, VPS_HOST, VPS_USER)

Purpose: Lock VPS access metadata in repo, prevent key confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
