### PR TITLE
fix(auth): return 401 for unauthenticated profile instead of 500

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -15,6 +15,9 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->api(prepend: [
             \Illuminate\Http\Middleware\HandleCors::class,
         ]);
+
+        // API routes should return JSON 401, not redirect to login
+        $middleware->redirectGuestsTo(fn () => null);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //


### PR DESCRIPTION
## Summary
Fixes production auth regression where `/api/v1/auth/profile` returns 500 instead of 401 when unauthenticated.

**Root Cause:** Laravel's Authenticate middleware was trying to redirect to `route('login')` which doesn't exist, causing `RouteNotFoundException` (500 error).

## Changes
Added `redirectGuestsTo(fn () => null)` configuration in `backend/bootstrap/app.php` so API routes return JSON 401 instead of attempting redirect.

```php
// API routes should return JSON 401, not redirect to login
$middleware->redirectGuestsTo(fn () => null);
```

## Evidence

**PROD Logs:**
```
[2025-12-17 20:46:38] production.ERROR: Route [login] not defined.
Symfony\Component\Routing\Exception\RouteNotFoundException
at Illuminate\Auth\Middleware\Authenticate.php:117
```

**Before Fix:**
```bash
curl -I https://dixis.gr/api/v1/auth/profile
# HTTP/1.1 500 Internal Server Error
```

**After Fix (Expected):**
```bash
curl -I https://dixis.gr/api/v1/auth/profile
# HTTP/1.1 401 Unauthorized
```

## Impact
- Unblocks login/register functionality
- API now properly returns 401 for unauthenticated requests
- No redirect behavior for API routes (JSON only)

## Testing
1. Deploy to production
2. Verify: `curl -I https://dixis.gr/api/v1/auth/profile` returns 401
3. Test auth flow: register → login → profile (should work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)