### PR TITLE
fix(auth): handle AuthenticationException in exception handler (v2)

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -20,5 +20,12 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->redirectGuestsTo(fn () => null);
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        // Return JSON 401 for unauthenticated API requests instead of redirect
+        $exceptions->render(function (\Illuminate\Auth\AuthenticationException $e, $request) {
+            if ($request->is('api/*')) {
+                return response()->json([
+                    'message' => 'Unauthenticated.'
+                ], 401);
+            }
+        });
     })->create();


### PR DESCRIPTION
## Summary
Completes the fix for `/api/v1/auth/profile` returning 500 instead of 401 when unauthenticated.

**Root Cause:** PR #1731 fixed redirectGuestsTo but AuthenticationException was still caught by Laravel's exception handler which also tried to redirect to `route('login')`.

## Changes
Added exception handler for `AuthenticationException` to return JSON 401 for all `/api/*` routes:

```php
$exceptions->render(function (\Illuminate\Auth\AuthenticationException $e, $request) {
    if ($request->is('api/*')) {
        return response()->json([
            'message' => 'Unauthenticated.'
        ], 401);
    }
});
```

## Evidence

**PROD Logs After PR #1731:**
```
[2025-12-17 20:54:41] production.ERROR: Route [login] not defined.
at Handler.php:752 (unauthenticated method in exception handler)
```

**Before v2 Fix:**
```bash
curl -I https://dixis.gr/api/v1/auth/profile
# HTTP/1.1 500 Internal Server Error
```

**After v2 Fix (Verified on PROD):**
```bash
curl -I https://dixis.gr/api/v1/auth/profile
# HTTP/1.1 401 Unauthorized
# Content-Type: application/json
```

## Impact
- ✅ API properly returns 401 for unauthenticated requests
- ✅ No more 500 errors from missing login route
- ✅ Unblocks login/register functionality

## Testing
- [x] Deployed to VPS and verified 401 response
- [ ] CI checks passing
- [ ] Ready to merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)