### PR TITLE
fix(auth): add redirect pages for /login and /register

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('/auth/login')
+}

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('/auth/register')
+}


### PR DESCRIPTION
## Summary
Adds backward-compatible redirect pages for `/login` and `/register` that redirect to existing `/auth/login` and `/auth/register` pages, improving UX by supporting both URL patterns.

## Changes
- Created `frontend/src/app/login/page.tsx` - redirects to `/auth/login`
- Created `frontend/src/app/register/page.tsx` - redirects to `/auth/register`

## Test Plan
**Pre-deployment verification:**
- ✅ `curl -L https://dixis.gr/login` → 404
- ✅ `curl -L https://dixis.gr/register` → 404

**Post-deployment verification:**
- ✅ `curl -L https://dixis.gr/login` → 200 (redirects to /auth/login)
- ✅ `curl -L https://dixis.gr/register` → 200 (redirects to /auth/register)
- ✅ Existing auth pages still work: `/auth/login` → 200, `/auth/register` → 200

**Evidence:** Already deployed and verified in production

## Acceptance Criteria
- [x] `/login` returns 200 and displays login page
- [x] `/register` returns 200 and displays register page
- [x] Redirects use Next.js 15 App Router server-side redirect
- [x] Only 2 new files added (minimal change)
- [x] No changes to existing auth functionality

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>