### PR TITLE
Pass 2: Producer dashboard scoping (my products only)

### DIFF
--- a/frontend/src/app/api/me/products/route.ts
+++ b/frontend/src/app/api/me/products/route.ts
@@ -1,62 +1,87 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '@/lib/db/client';
 import { requireProducer } from '@/lib/auth/requireProducer';
+import { cookies } from 'next/headers';
 
 /**
  * GET /api/me/products
- * Returns products for the authenticated producer (scoped to producer's phone/session)
- * Query params: ?q=searchterm&category=xyz
+ * Returns products for the authenticated producer (scoped to producer_id)
+ * Query params: ?q=searchterm&category=xyz&status=active|inactive|all
+ *
+ * Pass 2: Proxies to backend scoped endpoint instead of using Prisma directly
  */
 export async function GET(request: NextRequest) {
   try {
-    const producer = await requireProducer();
+    // Get authenticated producer (throws if not auth'd)
+    await requireProducer();
+
+    // Get auth token from cookies
+    const cookieStore = await cookies();
+    const sessionToken = cookieStore.get('dixis_session')?.value;
+
+    if (!sessionToken) {
+      return NextResponse.json({ error: 'Unauthenticated' }, { status: 401 });
+    }
 
     // Parse query params for search/filter
     const { searchParams } = new URL(request.url);
     const q = searchParams.get('q')?.trim() || '';
     const category = searchParams.get('category')?.trim() || '';
+    const status = searchParams.get('status')?.trim() || 'all';
 
-    // Build where clause
-    const where: Record<string, unknown> = {
-      producerId: producer.id
-    };
+    // Build backend API URL
+    const backendUrl = new URL(
+      '/api/v1/producer/products',
+      process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8001'
+    );
 
-    // Add search filter (search in title)
-    if (q) {
-      where.title = { contains: q, mode: 'insensitive' };
-    }
+    // Add query params
+    if (q) backendUrl.searchParams.set('search', q);
+    if (category) backendUrl.searchParams.set('category', category);
+    if (status) backendUrl.searchParams.set('status', status);
 
-    // Add category filter
-    if (category) {
-      where.category = category;
-    }
-
-    // Fetch products scoped to this producer only
-    const products = await prisma.product.findMany({
-      where,
-      orderBy: { createdAt: 'desc' },
-      select: {
-        id: true,
-        title: true,
-        category: true,
-        price: true,
-        unit: true,
-        stock: true,
-        description: true,
-        imageUrl: true,
-        isActive: true,
-        createdAt: true,
-        updatedAt: true
-      }
+    // Call backend scoped endpoint with session token
+    const response = await fetch(backendUrl.toString(), {
+      headers: {
+        'Authorization': `Bearer ${sessionToken}`,
+        'Accept': 'application/json',
+      },
+      cache: 'no-store',
     });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return NextResponse.json(
+        { error: errorData.message || 'Failed to fetch products' },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+
+    // Map backend response to frontend format
+    const products = (data.data || []).map((p: any) => ({
+      id: p.id,
+      title: p.name || p.title,
+      name: p.name,
+      category: p.category,
+      price: parseFloat(p.price),
+      unit: p.unit || 'kg',
+      stock: p.stock || 0,
+      description: p.description,
+      imageUrl: p.image_url || p.imageUrl,
+      isActive: p.is_active !== false,
+      is_active: p.is_active !== false,
+      status: p.status || 'available',
+      createdAt: p.created_at || p.createdAt,
+      updatedAt: p.updated_at || p.updatedAt,
+      currency: 'EUR',
+      created_at: p.created_at,
+      updated_at: p.updated_at,
+    }));
 
     return NextResponse.json({
       products,
       total: products.length,
-      producer: {
-        id: producer.id,
-        name: producer.name
-      }
     });
 
   } catch (error: any) {
@@ -76,39 +101,63 @@ export async function GET(request: NextRequest) {
 /**
  * POST /api/me/products
  * Create a new product for the authenticated producer
+ *
+ * Pass 2: Proxies to backend API (producer_id auto-set server-side)
  */
 export async function POST(request: NextRequest) {
   try {
-    const producer = await requireProducer();
+    await requireProducer();
+
+    const cookieStore = await cookies();
+    const sessionToken = cookieStore.get('dixis_session')?.value;
+
+    if (!sessionToken) {
+      return NextResponse.json({ error: 'Unauthenticated' }, { status: 401 });
+    }
+
     const body = await request.json();
 
-    const { slug, title, category, price, unit, stock, description, imageUrl, isActive } = body;
+    // Map frontend fields to backend API format
+    const backendPayload = {
+      name: body.title || body.name,
+      slug: body.slug,
+      category: body.category,
+      price: parseFloat(body.price),
+      unit: body.unit,
+      stock: parseInt(body.stock, 10),
+      description: body.description || null,
+      image_url: body.imageUrl || null,
+      is_active: body.isActive !== undefined ? Boolean(body.isActive) : true,
+      // Note: producer_id NOT included - backend auto-sets from auth user
+    };
 
-    // Validate required fields
-    if (!slug || !title || !category || price === undefined || !unit || stock === undefined) {
+    // Call backend API
+    const backendUrl = new URL(
+      '/api/v1/products',
+      process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8001'
+    );
+
+    const response = await fetch(backendUrl.toString(), {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${sessionToken}`,
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(backendPayload),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
       return NextResponse.json(
-        { error: 'Υποχρεωτικά πεδία λείπουν' },
-        { status: 400 }
+        { error: errorData.message || 'Failed to create product' },
+        { status: response.status }
       );
     }
 
-    // Create product scoped to this producer (ignore any producerId in body)
-    const product = await prisma.product.create({
-      data: {
-        slug: String(slug).trim(),
-        producerId: producer.id, // Force producer scoping
-        title: String(title).trim(),
-        category: String(category).trim(),
-        price: parseFloat(price),
-        unit: String(unit).trim(),
-        stock: parseInt(stock, 10),
-        description: description ? String(description).trim() : null,
-        imageUrl: imageUrl || null,
-        isActive: isActive !== undefined ? Boolean(isActive) : true
-      }
-    });
+    const data = await response.json();
 
-    return NextResponse.json({ success: true, product }, { status: 201 });
+    return NextResponse.json({ success: true, product: data.data }, { status: 201 });
 
   } catch (error: any) {
     if (error instanceof Response) {


### PR DESCRIPTION
## Summary

Implements **Pass 2 from NEXT-3-PASSES.md**: Producer dashboard scoping - producers see ONLY their own products, never other producers' products.

## Backend: Scoping Verification

**Existing Endpoint (already properly scoped):**
- `GET /api/v1/producer/products` → `Api\ProducerController@getProducts`
- Line 169: `$producer->products()` uses Eloquent relationship
- Auto-scopes queries to `producer_id = authenticated_user.producer.id`

**New Tests Added (4 scoping tests):**

1. ✅ Producer gets only own products
   - Producer A has 2 products, Producer B has 1 product
   - Producer A fetches `/api/v1/producer/products`
   - Response contains ONLY Producer A's 2 products

2. ✅ Producer does NOT see other producer's products
   - Producer A has 1 product, Producer B has 3 products
   - Producer A fetches products
   - Response contains ONLY 1 product (not 4)

3. ✅ Unauthenticated user → 401
   - No auth token sent
   - Response: 401 Unauthorized

4. ✅ Consumer (non-producer) → 403
   - Consumer user tries to access producer endpoint
   - Response: 403 Forbidden ("Producer profile not found")

## Frontend: Wire Dashboard to Backend API

**File:** `frontend/src/app/api/me/products/route.ts`

**Before (SECURITY ISSUE):**
```typescript
// Direct Prisma database access from frontend
const products = await prisma.product.findMany({
  where: { producerId: producer.id }
});
```

**After (SECURE):**
```typescript
// Proxy to backend scoped endpoint
const response = await fetch('http://backend/api/v1/producer/products', {
  headers: { 'Authorization': `Bearer ${sessionToken}` }
});
const data = await response.json();
```

**Changes:**
- GET: Proxies to `/api/v1/producer/products` with JWT auth
- POST: Proxies to `/api/v1/products` (create product)
- Removed all Prisma direct database queries
- Backend is now single source of truth

## Files Changed (2 files, +207/-59 lines)

**Backend:**
- `tests/Feature/AuthorizationTest.php` (+99 lines)
  - 4 new scoping tests with Groups: mvp, scoping

**Frontend:**
- `src/app/api/me/products/route.ts` (+108/-59 lines)
  - Replaced Prisma with backend API proxy
  - Added JWT session token auth
  - Added response mapping (backend → frontend format)

## Test Results

```
Tests:    15 passed (30 assertions)
Duration: 0.75s

✓ producer gets only own products (11 assertions)
✓ producer does not see other producers products
✓ unauthenticated user cannot access producer products
✓ consumer cannot access producer products
```

**Frontend Build:** ✅ Successful (Next.js 15.5.0)

## Acceptance Criteria (from NEXT-3-PASSES.md)

- [x] `/my/products` shows only products with `producer_id = current_producer`
- [x] Producer A cannot see Producer B's products
- [x] Tests verify scoping (Playwright or API snapshot)
- [x] Frontend wired to scoped backend endpoint

## Security Impact

**Severity:** 🟡 **MEDIUM** (proper separation of concerns)

**Before:**
- Frontend had direct Prisma database access
- No single source of truth for scoping

**After:**
- Backend enforces scoping at API level
- Frontend cannot bypass scoping rules
- Proper separation: frontend → backend API → database

## Evidence

**Backend scoping:**
```php
// Line 169 in ProducerController
$query = $producer->products()->orderBy('name', 'asc');
```

**Test proof:**
```php
// Producer A fetches products
$response = $this->actingAs($producerAUser, 'sanctum')
    ->getJson('/api/v1/producer/products');

// Should have exactly 2 products (not 3 from both producers)
$this->assertCount(2, $data);
```

## Related Documentation

- `docs/PRODUCT/OWNERSHIP-FLOWS.md` - Ownership specification
- `docs/OPS/NEXT-3-PASSES.md` - Execution plan
- PR #1741 - Pass 1 (Backend authorization)

## Next Steps

**Pass 3:** Producer-product linkage completeness (API + UI)
- Every product in public API has `producer.name`
- Storefront displays producer names
- Zero products without producer reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)