### PR TITLE
Pass: Fix E2E auth mock endpoints (/api/v1/auth/*)

### DIFF
--- a/frontend/src/mocks/e2e-auth.ts
+++ b/frontend/src/mocks/e2e-auth.ts
@@ -221,13 +221,13 @@ export function getE2EAuthState(): E2EAuthState | null {
  * Use with playwright page.route() for consistent API responses
  */
 export const E2E_API_ROUTES = {
-  '/api/auth/login': {
+  '/api/v1/auth/login': {
     POST: E2E_AUTH_API_RESPONSES.login.success
   },
-  '/api/auth/logout': {
+  '/api/v1/auth/logout': {
     POST: E2E_AUTH_API_RESPONSES.logout.success
   },
-  '/api/auth/me': {
+  '/api/v1/auth/profile': {
     GET: E2E_AUTH_API_RESPONSES.me.authenticated
   }
 };


### PR DESCRIPTION
## Summary
Align E2E mock endpoints with backend v1 auth routes.

## Changes
- `/api/auth/login` → `/api/v1/auth/login`
- `/api/auth/logout` → `/api/v1/auth/logout`
- `/api/auth/me` → `/api/v1/auth/profile`

## Impact
- **E2E tests only** - no production behavior change
- Mocks now match actual backend API routes (backend/routes/api.php:56-66)
- Ensures E2E tests use correct endpoints

## Related
- Follow-up to #1747 (incident postmortem)
- Backend routes exist and work correctly, mocks were out of sync

## Testing
- [x] Minimal change (3 lines)
- [x] E2E mocks only
- [x] No production code affected