### PR TITLE
fix(ci): smoke-production timeout 15s→45s (network resilience)

### DIFF
--- a/frontend/tests/e2e/smoke-commission-preview.spec.ts
+++ b/frontend/tests/e2e/smoke-commission-preview.spec.ts
@@ -7,6 +7,6 @@ import { test, expect } from '@playwright/test';
 test('commission-preview endpoint guarded when flag OFF', async ({ request }) => {
   const base = process.env.BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'https://dixis.gr';
   // Use a benign order id; endpoint should be hidden (404) when flag OFF
-  const res = await request.get(`${base}/api/orders/123/commission-preview`, { timeout: 15000 });
+  const res = await request.get(`${base}/api/orders/123/commission-preview`, { timeout: 45000 });
   expect([401, 403, 404]).toContain(res.status());
 });

--- a/frontend/tests/e2e/smoke-healthz.spec.ts
+++ b/frontend/tests/e2e/smoke-healthz.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test('healthz is healthy', async ({ request }) => {
   const base = process.env.BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'https://dixis.gr';
-  const res = await request.get(`${base}/api/healthz`, { timeout: 15000 });
+  const res = await request.get(`${base}/api/healthz`, { timeout: 45000 });
   expect(res.status(), 'healthz status').toBe(200);
   const json = await res.json();
   // Accept both "ok" and "healthy" status values


### PR DESCRIPTION
**Root Cause:** GitHub Actions runners timing out when reaching dixis.gr (network connectivity issue, NOT a real PROD problem)

**Evidence that PROD is healthy:**
```
healthz=200          ✅
api_products=200     ✅  
products_list=200    ✅
login=307 (redirect) ✅
```

**CI Failure Details:**
- PR #1763 smoke-production check failed with:
  - `smoke-healthz.spec.ts`: TimeoutError after 15000ms
  - `smoke-commission-preview.spec.ts`: TimeoutError after 15000ms
- Both tests trying: `GET https://dixis.gr/*`
- Run: https://github.com/lomendor/Project-Dixis/actions/runs/20379003676/job/58564612112

**Fix:**
- Increase timeout from 15000ms (15s) → 45000ms (45s)
- Handles transient network delays from GitHub Actions runners to production server
- No business logic changes, just CI resilience improvement

**Files Changed:**
- `frontend/tests/e2e/smoke-healthz.spec.ts`
- `frontend/tests/e2e/smoke-commission-preview.spec.ts`

**Risk:** ZERO (test-only change, PROD already verified healthy)