### PR TITLE
docs: Set WIP to Stage 2 Permissions Audit

### DIFF
--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -1,9 +1,17 @@
 # NEXT 7 DAYS
 
-**Last Updated**: 2025-12-19 21:30 UTC
+**Last Updated**: 2025-12-19 21:45 UTC
 
 ## WIP (1 item only)
-**None** - Awaiting next priority
+**Stage 2 Permissions Audit** - Advanced producer isolation & multi-producer scenarios
+- **DoD**:
+  - Verify producer isolation in edge cases (shared products, multi-producer orders)
+  - Test admin override scenarios comprehensively
+  - Document additional security tests needed
+  - Update ProductPolicy if gaps found
+  - Create audit report: `docs/FEATURES/PERMISSIONS-STAGE-2-AUDIT.md`
+- **Estimated effort**: 3-4 hours (deep audit + edge case testing)
+- **Status**: Planning phase
 
 ## NEXT (ordered, max 3)
 

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,6 +1,6 @@
 # OPS STATE
 
-**Last Updated**: 2025-12-19 21:30 UTC
+**Last Updated**: 2025-12-19 21:45 UTC
 
 ## CLOSED ✅ (do not reopen without NEW proof)
 - **SSH/fail2ban**: Canonical SSH config enforced (deploy user + dixis_prod_ed25519 key + IdentitiesOnly yes). fail2ban active with no ignoreip whitelist. Production access stable. (Closed: 2025-12-19)
@@ -24,7 +24,9 @@
 **Evidence**: See `docs/OPS/PROD-FACTS-LAST.md` (auto-updated by `scripts/prod-facts.sh`)
 
 ## IN PROGRESS → (WIP=1 ONLY)
-- **WIP**: None (awaiting next priority)
+- **WIP**: Stage 2 - Advanced permissions & multi-producer scenarios
+  - DoD: Verify producer isolation in edge cases (shared products, multi-producer orders), document additional security tests needed, update ProductPolicy if gaps found
+  - Status: Planning phase
 
 ## BLOCKED ⚠️
 - (none)


### PR DESCRIPTION
## Summary

Updates STATE.md and NEXT-7D.md to set new WIP item after completion of all previous audits.

## Changes

- **STATE.md**: Set WIP to "Stage 2 - Advanced permissions & multi-producer scenarios"
- **NEXT-7D.md**: Set WIP with detailed DoD for Stage 2 Permissions Audit
- Updated timestamps to 2025-12-19 21:45 UTC

## Context

All previous audits completed and closed:
- ✅ SSH/fail2ban hardening
- ✅ Data Dependency Map (PR #1763)  
- ✅ Producer Permissions Audit
- ✅ Producer Product CRUD Audit (PR #1768)
- ✅ Orders MVP Audit (PR #1769)

Next focus: Advanced producer isolation testing & edge cases.

## DoD

- [x] Update STATE.md with new WIP
- [x] Update NEXT-7D.md with new WIP  
- [x] Update timestamps
- [x] Commit with proper message

## Risk Assessment

- **Code Changes**: None (docs-only)
- **Production Impact**: Zero
- **Rollback**: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)