### PR TITLE
test: Fix ProducerOrderManagementTest (HasOne association)

### DIFF
--- a/backend/tests/Feature/ProducerOrderManagementTest.php
+++ b/backend/tests/Feature/ProducerOrderManagementTest.php
@@ -23,11 +23,11 @@ class ProducerOrderManagementTest extends TestCase
     {
         parent::setUp();
 
-        // Create a producer and user
-        $this->producer = Producer::factory()->create();
+        // Create a user first, then associate producer
         $this->producerUser = User::factory()->create();
-        $this->producerUser->producer()->associate($this->producer);
-        $this->producerUser->save();
+        $this->producer = Producer::factory()->create([
+            'user_id' => $this->producerUser->id,
+        ]);
 
         // Create a product for this producer
         $this->product = Product::factory()->create([
@@ -126,7 +126,7 @@ class ProducerOrderManagementTest extends TestCase
         $response->assertOk()
             ->assertJsonStructure([
                 'success',
-                'order' => ['id', 'status', 'total', 'orderItems'],
+                'order' => ['id', 'status', 'total', 'order_items'],
             ])
             ->assertJsonPath('success', true)
             ->assertJsonPath('order.id', $order->id);


### PR DESCRIPTION
## Summary

Fixes 8 failing tests in ProducerOrderManagementTest caused by incorrect `associate()` usage on a HasOne relation.

## Root Cause

`User->producer()` is a **HasOne** relation, not **BelongsTo**. The `associate()` method only works on BelongsTo relations, causing:

```
BadMethodCallException: Call to undefined method Illuminate\Database\Eloquent\Relations\HasOne::associate()
```

## Fixes Applied

### 1. setUp() Method (Lines 23-30)
**Before** (incorrect):
```php
$this->producer = Producer::factory()->create();
$this->producerUser = User::factory()->create();
$this->producerUser->producer()->associate($this->producer); // ❌ WRONG
$this->producerUser->save();
```

**After** (correct):
```php
$this->producerUser = User::factory()->create();
$this->producer = Producer::factory()->create([
    'user_id' => $this->producerUser->id, // ✅ Correct FK assignment
]);
```

### 2. test_producer_can_view_order_details() (Line 129)
**Before**: `'order' => ['id', 'status', 'total', 'orderItems']`  
**After**: `'order' => ['id', 'status', 'total', 'order_items']` (Laravel snake_case convention)

## Test Results

**Before**: 8 tests FAILED (BadMethodCallException)  
**After**: ✅ **8 tests PASSED** (42 assertions, 0.57s)

```
✓ producer can list their orders
✓ producer cannot see orders without their products
✓ producer can filter orders by status
✓ producer can view order details
✓ producer can update order status with valid transition
✓ producer cannot update status with invalid transition
✓ unauthenticated user cannot access producer orders
✓ user without producer association cannot access producer orders
```

## Verification

- ✅ ProducerOrderManagementTest: All 8 tests passing
- ✅ AuthorizationTest: All 17 tests still passing (no regression)
- ✅ No business logic changes (tests-only)

## Evidence

**Files Changed**: 1 file, 5 insertions(+), 5 deletions(-)  
**Scope**: `backend/tests/Feature/ProducerOrderManagementTest.php` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)