### PR TITLE
Pass15: producer ownership enforcement + tests

### DIFF
--- a/backend/app/Http/Controllers/Api/ProducerController.php
+++ b/backend/app/Http/Controllers/Api/ProducerController.php
@@ -15,22 +15,8 @@ class ProducerController extends Controller
      */
     public function toggleProduct(Request $request, Product $product): JsonResponse
     {
-        $user = $request->user();
-
-        // Ensure user is authenticated
-        if (! $user) {
-            return response()->json(['message' => 'Unauthenticated'], 401);
-        }
-
-        // Ensure user has a producer profile
-        if (! $user->producer) {
-            return response()->json(['message' => 'Producer profile not found'], 403);
-        }
-
-        // Ensure product belongs to this producer
-        if ($product->producer_id !== $user->producer->id) {
-            return response()->json(['message' => 'Product not found'], 404);
-        }
+        // Use ProductPolicy for authorization (enforces producer ownership)
+        $this->authorize('update', $product);
 
         // Toggle the active status
         $product->is_active = ! $product->is_active;
@@ -97,22 +83,8 @@ class ProducerController extends Controller
      */
     public function updateStock(Request $request, Product $product, InventoryService $inventoryService): JsonResponse
     {
-        $user = $request->user();
-
-        // Ensure user is authenticated
-        if (! $user) {
-            return response()->json(['message' => 'Unauthenticated'], 401);
-        }
-
-        // Ensure user has a producer profile
-        if (! $user->producer) {
-            return response()->json(['message' => 'Producer profile not found'], 403);
-        }
-
-        // Ensure product belongs to this producer
-        if ($product->producer_id !== $user->producer->id) {
-            return response()->json(['message' => 'Product not found'], 404);
-        }
+        // Use ProductPolicy for authorization (enforces producer ownership)
+        $this->authorize('update', $product);
 
         // Validate request
         $request->validate([


### PR DESCRIPTION
## Summary

**Pass 15**: Enforce producer ownership using ProductPolicy instead of manual authorization checks.

## Changes

### Backend Controller (`app/Http/Controllers/Api/ProducerController.php`)
- **`toggleProduct()`**: Replaced 18 lines of manual auth with `$this->authorize('update', $product)`
- **`updateStock()`**: Replaced 15 lines of manual auth with `$this->authorize('update', $product)`

### Tests (`tests/Feature/ProductsToggleTest.php`)
- **Updated**: `test_producer_cannot_toggle_other_producer_product()` now expects 403 (not 404) to match ProductPolicy behavior
- **Added**: `test_admin_can_toggle_any_product()` to verify admin override works

## Test Results

```
✅ test_producer_can_toggle_own_product
✅ test_producer_cannot_toggle_other_producer_product (now 403)
✅ test_unauthenticated_user_cannot_toggle_product
✅ test_admin_can_toggle_any_product (NEW)

Tests: 4 passed (7 assertions) in 0.81s
```

## Why This Change

**Before**: ProducerController had manual authorization logic:
```php
if ($product->producer_id !== $user->producer->id) {
    return response()->json(['message' => 'Product not found'], 404);
}
```

**After**: Uses ProductPolicy consistently:
```php
$this->authorize('update', $product);
```

**Benefits**:
- ✅ Consistent with V1/ProductController pattern
- ✅ ProductPolicy enforces ownership (line 48)
- ✅ Admin override works automatically (line 42)
- ✅ Correct HTTP status codes (403 Forbidden, not 404)

## Evidence

**Authorization Tests**: backend/tests/Feature/ProductsToggleTest.php:28,65,101,123

**ProductPolicy**: backend/app/Policies/ProductPolicy.php:40

**Audit Doc**: docs/FEATURES/PRODUCER-PERMISSIONS-AUDIT.md

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>