### PR TITLE
fix(prod): product detail uses API detail endpoint; add logo.svg

### DIFF
--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f5c2e"/>
+      <stop offset="1" stop-color="#0b3f1f"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#g)"/>
+  <path d="M18 34h14v12h-6v-6h-8zM32 18h14v12h-6v-6h-8z" fill="#fff" opacity=".9"/>
+</svg>

--- a/frontend/src/app/(storefront)/products/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/page.tsx
@@ -13,12 +13,10 @@ export const revalidate = 0;
 async function getProductById(id: string) {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'https://dixis.gr/api/v1';
   try {
-    const res = await fetch(`${base}/public/products`, { cache: 'no-store' });
+    const res = await fetch(`${base}/public/products/${id}`, { cache: 'no-store' });
     if (!res.ok) return null;
-    const json = await res.json();
-    const items = Array.isArray(json?.data) ? json.data : [];
-    const raw = items.find((p: any) => String(p.id) === String(id));
-    if (!raw) return null;
+    const raw = await res.json();
+    if (!raw || !raw.id) return null;
 
     // Map backend API format to expected frontend format
     return {


### PR DESCRIPTION
- Change products/[id] to fetch /api/v1/public/products/{id} (DETAIL endpoint)
  instead of fetching all products and filtering client-side
- Remove .find() logic (4 lines → 2 lines)
- Add logo.svg to public/ (copy of favicon.svg) to eliminate 404 errors

Impact: Fixes 'Σφάλμα φόρτωσης προϊόντος' error on product detail pages
