### PR TITLE
fix(deploy): Create .next dir before copying static assets

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -55,6 +55,7 @@ jobs:
         working-directory: frontend
         run: |
           # Next.js standalone mode requires copying static assets
+          mkdir -p .next/standalone/.next
           cp -r .next/static .next/standalone/.next/static
           cp -r public .next/standalone/public
 


### PR DESCRIPTION
## Problem
**Workflow**: `deploy-frontend.yml`  
**Failure**: Run 20423375129 failed at "Prepare standalone bundle" step

**Error**:
```
cp: cannot create directory '.next/standalone/.next/static': No such file or directory
##[error]Process completed with exit code 1.
```

**Root Cause**: The `cp` command tried to copy `.next/static` to `.next/standalone/.next/static`, but the parent directory `.next/standalone/.next/` doesn't exist.

## Fix
**Added**: `mkdir -p .next/standalone/.next` before the `cp` command (line 58)

```diff
  - name: Prepare standalone bundle
    working-directory: frontend
    run: |
      # Next.js standalone mode requires copying static assets
+     mkdir -p .next/standalone/.next
      cp -r .next/static .next/standalone/.next/static
      cp -r public .next/standalone/public
```

## Evidence
- **Failed workflow**: https://github.com/lomendor/Project-Dixis/actions/runs/20423375129
- **Failure line**: Line 58 in deploy-frontend.yml
- **Exit code**: 1 (cp command failed)
- **Build status**: Build completed successfully, only bundle prep failed

## Impact
**Unblocks**:
- Deployment of PR #1819 (products page revalidate fix)
- Deployment of PR #1818 (product detail + logo.svg)
- PROD updates that have been stuck since 2025-12-21

**Expected Result**:
- Static assets copied successfully to standalone bundle
- SSH deployment to VPS proceeds
- PROD shows latest code (product details work, logo.svg returns 200)

## Testing
- [ ] CI quality-gates pass
- [ ] deploy-frontend.yml completes successfully
- [ ] PROD verification:
  - `curl https://dixis.gr/logo.svg` → 200
  - `/products/1` shows product title (not skeleton)

## References
- Blocks: PR #1819, PR #1818
- Previous failure: Run 20423375129
- Related: Next.js standalone mode static asset handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)