### PR TITLE
ci: fix deploy-frontend SSH authentication

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_KEY }}
+          key: ${{ secrets.VPS_SSH_KEY }}
           script: |
             # Target directory for deploy-frontend
             TARGET_DIR="/var/www/dixis/current/frontend"
@@ -93,7 +93,7 @@ jobs:
       - name: Deploy standalone to VPS
         uses: easingthemes/ssh-deploy@main
         with:
-          SSH_PRIVATE_KEY: ${{ secrets.VPS_KEY }}
+          SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}
           REMOTE_HOST: ${{ secrets.VPS_HOST }}
           REMOTE_USER: ${{ secrets.VPS_USER }}
           SOURCE: "frontend/.next/standalone/"
@@ -105,7 +105,7 @@ jobs:
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_KEY }}
+          key: ${{ secrets.VPS_SSH_KEY }}
           envs: DATABASE_URL,RESEND_API_KEY
           script: |
             cd /var/www/dixis/current/frontend


### PR DESCRIPTION
## Problem
**Workflow**: `deploy-frontend.yml`  
**Failure**: All recent runs failed with SSH authentication error

**Error** (Run 20423565056):
```
ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
```

**Root Cause**: Workflow uses **VPS_KEY** secret (created 2025-12-14), but a newer **VPS_SSH_KEY** secret exists (created 2025-12-17).

## Analysis
```bash
$ gh secret list
VPS_KEY         2025-12-14T20:25:58Z  ← OUTDATED
VPS_SSH_KEY     2025-12-17T11:14:46Z  ← CURRENT (3 days newer)
```

The VPS SSH key was rotated on 2025-12-17, but the workflow continued referencing the old secret name.

## Fix
**Replace** `VPS_KEY` → `VPS_SSH_KEY` in all 3 SSH workflow steps:

```diff
- name: Prepare VPS directory (fix permissions)
  uses: appleboy/ssh-action@v1.0.3
  with:
    host: ${{ secrets.VPS_HOST }}
    username: ${{ secrets.VPS_USER }}
-   key: ${{ secrets.VPS_KEY }}
+   key: ${{ secrets.VPS_SSH_KEY }}

- name: Deploy standalone to VPS
  uses: easingthemes/ssh-deploy@main
  with:
-   SSH_PRIVATE_KEY: ${{ secrets.VPS_KEY }}
+   SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}

- name: Configure and start app
  uses: appleboy/ssh-action@v1.0.3
  with:
-   key: ${{ secrets.VPS_KEY }}
+   key: ${{ secrets.VPS_SSH_KEY }}
```

## Impact
**Unblocks**:
- All pending deployments to PROD
- PR #1818 (product detail fix + logo.svg)
- PR #1819 (remove revalidate conflict)
- PR #1820 (standalone bundle mkdir fix)

**Expected Result**:
- SSH authentication succeeds
- Deployment completes end-to-end
- PROD shows latest code

## Evidence
- **Failed run**: https://github.com/lomendor/Project-Dixis/actions/runs/20423565056
- **Auth error line**: Line 649 of logs
- **Bundle prep**: ✅ Succeeded (previous fixes worked)
- **Blocker**: ❌ SSH auth with outdated key

🤖 Generated with [Claude Code](https://claude.com/claude-code)