### PR TITLE
fix(storefront): product detail uses robust JSON parsing (defensive API resilience)

### DIFF
--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -3,7 +3,17 @@
 **Last Updated**: 2025-12-21 18:00 UTC
 
 ## WIP (1 item only)
-(none currently)
+### Pass 17 - Product Detail Endpoint Robust Parsing
+- **Scope**: Add defensive JSON parsing to product detail page to handle both API response formats
+- **File**: `frontend/src/app/(storefront)/products/[id]/page.tsx` (lines 18-19)
+- **Change**: `const json = await res.json(); const raw = json?.data ?? json;`
+- **Rationale**: API resilience - handles both direct object `{ id, name, ... }` and wrapped `{ data: { ... } }` responses
+- **DoD**:
+  - PROD `/products/1` returns 200 and contains "Organic Tomatoes"
+  - PROD `/api/v1/public/products/1` returns 200
+  - Build: PASS ✅
+  - PR merged with passing CI
+- **Status**: PR pending (2025-12-22)
 
 ## NEXT (ordered, max 3)
 

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -49,7 +49,7 @@
 **MVP Core Features Summary**: See `docs/FEATURES/MVP-CORE-VERIFICATION.md` (140+ tests, 838+ assertions, all PASS)
 
 ## IN PROGRESS → (WIP=1 ONLY)
-- (none currently)
+- **Pass 17 Product Detail Endpoint Robust Parsing**: Fix product detail page (`/products/[id]`) to use defensive JSON parsing that handles both direct object response (`{ id, name, ... }`) and wrapped response (`{ data: { id, name, ... } }`). Change: `const json = await res.json(); const raw = json?.data ?? json;` (line 18-19). Already uses DETAIL endpoint (`${base}/public/products/${id}`), already has `force-dynamic` and `cache: 'no-store'`. Build: PASS ✅. PR #TBD. DoD: `curl https://dixis.gr/products/1` returns 200 and contains "Organic Tomatoes"; `curl https://dixis.gr/api/v1/public/products/1` returns 200. (WIP: 2025-12-22)
 
 ## BLOCKED ⚠️
 - (none)

--- a/frontend/src/app/(storefront)/products/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/page.tsx
@@ -15,7 +15,8 @@ async function getProductById(id: string) {
   try {
     const res = await fetch(`${base}/public/products/${id}`, { cache: 'no-store' });
     if (!res.ok) return null;
-    const raw = await res.json();
+    const json = await res.json();
+    const raw = json?.data ?? json;
     if (!raw || !raw.id) return null;
 
     // Map backend API format to expected frontend format


### PR DESCRIPTION
- Add defensive parsing: const json = await res.json(); const raw = json?.data ?? json
- Handles both direct object ({ id, name, ... }) and wrapped ({ data: { ... } }) responses
- Already uses DETAIL endpoint, force-dynamic, and no-store (no changes to those)
- Build: PASS
- DoD: /products/1 returns 200 with Organic Tomatoes, /api/v1/public/products/1 returns 200
