### PR TITLE
fix(deploy): Include i18n messages in standalone build

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -58,6 +58,7 @@ jobs:
           mkdir -p .next/standalone/.next
           cp -r .next/static .next/standalone/.next/static
           cp -r public .next/standalone/public
+          cp -r messages .next/standalone/messages
 
           # Copy prisma client (pnpm puts it in a different location)
           PRISMA_CLIENT=$(find node_modules/.pnpm -type d -name ".prisma" -path "*@prisma+client*" | head -1)


### PR DESCRIPTION
## 🎯 Root Cause Analysis

**Problem:** `/products/[id]` shows "Σφάλμα φόρτωσης προϊόντος" error on PROD (dixis.gr)

**Real Root Cause (After Deep Investigation):**
- SSR code calls `await getTranslations()` (page.tsx:82)  
- `i18n/request.ts` imports `messages/el.json`
- Deployment workflow copies `.next/static` and `public` to standalone
- **BUT**: `messages/` directory was NOT copied → import fails → SSR crashes

**Evidence Chain:**
1. ✅ Backend API returns 200 with "Organic Tomatoes" (curl from VPS works)
2. ✅ API_INTERNAL_URL env var set correctly in systemd  
3. ✅ Code has correct API_INTERNAL_URL logic (PR #1836)
4. ❌ Playwright: hasTomatoes=true (in JSON-LD) + hasErrorEL=true (error boundary)
5. ❌ systemd logs: `Error: digest '4052371403'` at page.js:1:45906
6. ❌ nginx logs: NO API calls (error happens BEFORE fetch)
7. ❌ VPS: `ls /var/www/dixis/current/frontend/messages` → **NOT FOUND**

**Why Diagnosis Was Hard:**
- API works when curled directly → misleading
- Playwright found "Organic Tomatoes" text → but only in hidden JSON-LD
- Error digest had no actual error message → Next.js swallowed it
- SSR error happened BEFORE API fetch → no network traces

## 🔧 Solution

**File Changed:** `.github/workflows/deploy-frontend.yml`

**Fix:** Add one line to copy messages directory to standalone build
```diff
  cp -r .next/static .next/standalone/.next/static
  cp -r public .next/standalone/public
+ cp -r messages .next/standalone/messages
```

## ✅ Testing Plan

**After Merge:**
1. Workflow auto-deploys to PROD
2. Run: `node prod-product-probe.mjs`  
3. Expected results:
   - `hasTomatoes: true`
   - `hasErrorEL: false` ← **CRITICAL**
   - `skeletonCount: 0`
   - `apiCalls: [{url: "http://127.0.0.1:8001/api/v1/public/products/1", status: 200}]`

**Manual Verification:**
- Visit https://dixis.gr/products/1
- Should show product page with "Organic Tomatoes" title
- NO error message visible

## 📊 Impact

- ✅ Product detail pages render successfully with SSR
- ✅ next-intl translations work correctly  
- ✅ No more "Σφάλμα φόρτωσης προϊόντος" error
- ✅ Works on both dixis.gr and www.dixis.gr

## 🤖 Generated with [Claude Code](https://claude.com/claude-code)