### PR TITLE
fix(deploy): Also copy i18n directory to standalone build

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -59,6 +59,7 @@ jobs:
           cp -r .next/static .next/standalone/.next/static
           cp -r public .next/standalone/public
           cp -r messages .next/standalone/messages
+          cp -r i18n .next/standalone/i18n
 
           # Copy prisma client (pnpm puts it in a different location)
           PRISMA_CLIENT=$(find node_modules/.pnpm -type d -name ".prisma" -path "*@prisma+client*" | head -1)


### PR DESCRIPTION
## 🔍 Follow-up Fix to PR #1842

**Status:** PR #1842 partially fixed the issue but one more directory is missing

**Problem:** After deploying PR #1842 (which added `messages/`), the error still persists with same digest `4052371403`

## 🎯 Root Cause (Part 2)

**Missing Directory:** `i18n/`

PR #1842 copied `messages/` but `i18n/` directory is ALSO needed:
- `next.config.ts` line 6: `createNextIntlPlugin('./i18n/request.ts')`  
- Runtime needs `i18n/request.ts` to configure next-intl
- This file loads the messages from `messages/el.json`

**Evidence After PR #1842:**
```bash
# On VPS after PR #1842 deployment:
$ ls /var/www/dixis/current/frontend/messages/
el.json  en.json  ← ✅ NOW EXISTS

$ ls /var/www/dixis/current/frontend/i18n/  
ls: cannot access... No such file or directory  ← ✗ STILL MISSING

# SSR still fails:
$ node prod-product-probe.mjs
{
  "hasErrorEL": true,    ← Still broken
  "apiCalls": [],        ← No API calls (fails before fetch)
}

# systemd logs:
⨯ Error: digest '4052371403'  ← Same error persists
```

## 🔧 Solution

**File Changed:** `.github/workflows/deploy-frontend.yml`

**Fix:** Add one more line to copy i18n directory
```diff
  cp -r .next/static .next/standalone/.next/static
  cp -r public .next/standalone/public
  cp -r messages .next/standalone/messages
+ cp -r i18n .next/standalone/i18n
```

## ✅ Complete Fix Chain

Both directories needed for next-intl to work:
1. ✅ `messages/` - Contains el.json, en.json translation files (PR #1842)
2. ✅ `i18n/` - Contains request.ts config (THIS PR #1843)

## 📊 Testing Plan

**After Merge:**
1. Auto-deploy to PROD
2. Run: `node prod-product-probe.mjs`
3. Expected:
   ```json
   {
     "hasTomatoes": true,
     "hasErrorEL": false,  ← FIXED
     "skeletonCount": 0,
     "apiCalls": [{
       "url": "http://127.0.0.1:8001/api/v1/public/products/1",
       "status": 200
     }]
   }
   ```

**Manual Verification:**
- Visit https://dixis.gr/products/1
- Should show product page with "Organic Tomatoes"
- NO "Σφάλμα φόρτωσης προϊόντος" error

## 🤖 Generated with [Claude Code](https://claude.com/claude-code)