### PR TITLE
ops(ci): Pass 29 - fix backend-ci.yml paths/paths-ignore conflict

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,17 +4,10 @@ on:
     paths:
       - 'backend/**'
       - '.github/workflows/backend-ci.yml'
-    paths-ignore:
-      - 'docs/**'
-      - 'backend/docs/**'
-      - '**/*.md'
   pull_request:
     paths:
       - 'backend/**'
-    paths-ignore:
-      - 'docs/**'
-      - 'backend/docs/**'
-      - '**/*.md'
+      - '.github/workflows/backend-ci.yml'
   schedule:
     - cron: '0 3 * * *'  # Daily at 3:00 UTC
   workflow_dispatch:

--- a/docs/AGENT/SUMMARY/Pass-29.md
+++ b/docs/AGENT/SUMMARY/Pass-29.md
@@ -1,0 +1,163 @@
+# Pass 29: backend-ci.yml paths/paths-ignore Conflict Fix
+
+**Date**: 2025-12-23
+**Status**: ✅ COMPLETE
+**Priority**: P1
+
+---
+
+## Objective
+
+Fix backend-ci.yml 0s failures caused by invalid GitHub Actions YAML (both `paths:` and `paths-ignore:` on same event).
+
+---
+
+## Problem
+
+**All backend-ci runs failing instantly** (0s duration, no jobs executed):
+- Run #20472416205: FAILURE, 0s ❌
+- Run #20472002687: FAILURE, 0s ❌
+- Run #20471945532: FAILURE, 0s ❌
+- Pattern: 10/10 recent runs - 100% failure rate
+
+**Symptoms**:
+- `conclusion: "failure"`
+- `jobs: []` (empty array - no jobs ran)
+- `createdAt == updatedAt` (0 seconds duration)
+- No logs available (workflow never started)
+
+---
+
+## Root Cause (Hard Evidence)
+
+**INVALID YAML**: GitHub Actions does not allow both `paths:` and `paths-ignore:` on the same event.
+
+From GitHub Actions documentation:
+> You cannot use both the `paths` and `paths-ignore` filters for the same event in a workflow.
+
+**File**: `.github/workflows/backend-ci.yml`
+
+**Before** (INVALID):
+```yaml
+on:
+  push:
+    paths:                    # ← Filter 1
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+    paths-ignore:             # ← Filter 2 (CONFLICT!)
+      - 'docs/**'
+      - 'backend/docs/**'
+      - '**/*.md'
+  pull_request:
+    paths:                    # ← Filter 1
+      - 'backend/**'
+    paths-ignore:             # ← Filter 2 (CONFLICT!)
+      - 'docs/**'
+      - 'backend/docs/**'
+      - '**/*.md'
+```
+
+GitHub rejects this configuration → workflow fails without running jobs.
+
+---
+
+## Solution
+
+**Removed `paths-ignore:` sections** - kept only `paths:` filters.
+
+**After** (VALID):
+```yaml
+on:
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+  schedule:
+    - cron: '0 3 * * *'  # Daily at 3:00 UTC
+  workflow_dispatch:
+```
+
+**Trade-off**: Workflow now runs on ALL backend changes (including docs/markdown). This is acceptable because:
+- Backend tests are fast (~2-3 min)
+- Catching issues early > saving CI minutes
+- Simpler configuration = less maintenance
+
+---
+
+## Files Changed
+
+1. **`.github/workflows/backend-ci.yml`** - Removed paths-ignore sections (8 lines deleted)
+   - Lines 7-10 (push.paths-ignore) → DELETED
+   - Lines 14-17 (pull_request.paths-ignore) → DELETED
+   - Added '.github/workflows/backend-ci.yml' to pull_request.paths (consistency)
+
+---
+
+## Impact
+
+**Before**: backend-ci 100% failure rate (0s, no jobs run)
+**After**: Workflow executes jobs, tests run, valid pass/fail signal
+
+**Risk**: NONE (workflow syntax fix only, no code changes)
+
+---
+
+## Evidence URLs
+
+### Failed Runs (Before Fix)
+- https://github.com/lomendor/Project-Dixis/actions/runs/20472416205
+- https://github.com/lomendor/Project-Dixis/actions/runs/20472002687
+- https://github.com/lomendor/Project-Dixis/actions/runs/20471945532
+
+All show: `jobs: []`, no logs, 0s duration
+
+### GitHub Actions Documentation
+- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
+
+Quote:
+> "You cannot use both the `paths` and `paths-ignore` filters for the same event in a workflow."
+
+---
+
+## Pattern
+
+**Evidence-first ops fix** - similar to Pass 28 (staging workflows):
+1. Identify symptoms (0s failures)
+2. Collect hard evidence (run metadata, logs)
+3. Find root cause (YAML syntax conflict)
+4. Apply minimal fix (remove paths-ignore)
+5. Verify (next run should execute jobs)
+
+---
+
+## Verification (Post-Fix)
+
+**PR #1860** - backend-ci workflow now EXECUTING JOBS ✅
+
+### Run #20472472011 (After Fix)
+- **Duration**: 38s (was 0s before) ✅
+- **Jobs**: Executed (was empty [] before) ✅
+- **Logs**: Available (was "log not found" before) ✅
+- **URL**: https://github.com/lomendor/Project-Dixis/actions/runs/20472472011
+
+**Proof**: Workflow reached "Migrate & Seed (fresh)" step - jobs are running!
+
+### New Issue Found (Separate from Pass 29)
+PostgreSQL connection error during migration:
+```
+SQLSTATE[08006] [7] connection to server at "127.0.0.1", port 5432 failed:
+fe_sendauth: no password supplied
+```
+
+This is a **legitimate test failure** (DB configuration issue), NOT a YAML syntax error.
+
+**Pass 29 Scope**: Fix YAML syntax → ✅ **COMPLETE**
+**Follow-up**: DB connection issue → tracked separately
+
+---
+
+**Status**: ✅ **COMPLETE** - YAML fixed, workflow executing jobs, verification complete

--- a/docs/AGENT/TASKS/Pass-29-backend-ci-paths-fix.md
+++ b/docs/AGENT/TASKS/Pass-29-backend-ci-paths-fix.md
@@ -1,0 +1,152 @@
+# Pass 29: backend-ci.yml paths/paths-ignore Conflict Fix
+
+**Date**: 2025-12-23
+**Status**: IN PROGRESS
+**Priority**: P1 (blocking all backend CI)
+
+---
+
+## Objective
+
+Fix backend-ci.yml 0s failures caused by invalid YAML (both `paths:` and `paths-ignore:` on same event).
+
+---
+
+## Problem Statement
+
+**All backend-ci.yml runs failing instantly (0s, no jobs run)**:
+- Run #20472416205 (2025-12-23T21:53:36Z): FAILURE, 0s, no jobs ❌
+- Run #20472002687 (2025-12-23T21:29:04Z): FAILURE, 0s, no jobs ❌
+- Pattern: 10/10 recent runs - ALL failures with empty jobs array
+
+**Root Cause**: GitHub Actions does not allow both `paths:` and `paths-ignore:` on the same event.
+
+From GitHub Actions documentation:
+> You cannot use both the `paths` and `paths-ignore` filters for the same event in a workflow.
+
+**File**: `.github/workflows/backend-ci.yml`
+**Lines**:
+- Lines 4-10: `push:` event with BOTH `paths:` and `paths-ignore:`
+- Lines 11-17: `pull_request:` event with BOTH `paths:` and `paths-ignore:`
+
+---
+
+## Root Cause Analysis (Hard Evidence)
+
+### Workflow Configuration (INVALID)
+```yaml
+on:
+  push:
+    paths:                    # ← Filter 1
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+    paths-ignore:             # ← Filter 2 (CONFLICT!)
+      - 'docs/**'
+      - 'backend/docs/**'
+      - '**/*.md'
+  pull_request:
+    paths:                    # ← Filter 1
+      - 'backend/**'
+    paths-ignore:             # ← Filter 2 (CONFLICT!)
+      - 'docs/**'
+      - 'backend/docs/**'
+      - '**/*.md'
+```
+
+**GitHub rejects this configuration** → workflow fails immediately without running jobs.
+
+### Evidence URLs
+- https://github.com/lomendor/Project-Dixis/actions/runs/20472416205
+- https://github.com/lomendor/Project-Dixis/actions/runs/20472002687
+- https://github.com/lomendor/Project-Dixis/actions/runs/20471945532
+
+All runs show:
+- `conclusion: "failure"`
+- `jobs: []` (empty array)
+- `createdAt == updatedAt` (0 seconds)
+- No logs available
+
+---
+
+## Solution Strategy
+
+**Option A (Recommended)**: Remove `paths-ignore:`, use only `paths:` with explicit filters
+```yaml
+on:
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+      - '!backend/docs/**'    # Negation pattern (may not work)
+```
+
+**Option B**: Remove `paths:`, use only `paths-ignore:`
+```yaml
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'backend/docs/**'
+      - '**/*.md'
+      - 'frontend/**'
+```
+
+**Option C (CHOSEN)**: Remove `paths-ignore:` entirely, accept that workflow runs more often
+```yaml
+on:
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+```
+
+**Rationale**: Simplest fix, avoids complexity. Backend tests are fast (~2-3 min), extra runs acceptable.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Fix YAML Syntax
+1. Remove `paths-ignore:` sections (lines 7-10, 14-17)
+2. Keep only `paths:` filters
+3. Test workflow syntax locally (if possible)
+
+### Phase 2: Verify Fix
+1. Commit + push to branch
+2. Check if backend-ci runs (should trigger on workflow file change)
+3. Verify jobs execute (not 0s failure)
+4. Check job logs for actual test results
+
+### Phase 3: Merge + Monitor
+1. Create PR with evidence
+2. Merge to main
+3. Monitor next 3 pushes to confirm backend-ci runs successfully
+
+---
+
+## Definition of Done
+
+- [ ] backend-ci.yml has EITHER `paths:` OR `paths-ignore:` (not both)
+- [ ] Next backend-ci run executes jobs (not 0s failure)
+- [ ] Workflow passes on valid backend changes
+- [ ] Workflow skips on non-backend changes (if paths filter works)
+- [ ] Evidence doc created with before/after run URLs
+
+---
+
+## Constraints
+
+- **Risk**: LOW (workflow syntax fix only, no code changes)
+- **Impact**: Unblocks backend CI (currently 100% failure rate)
+- **Pattern**: Evidence-first ops fix (similar to Pass 28)
+
+---
+
+## References
+
+- GitHub Actions docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
+- Current workflow: `.github/workflows/backend-ci.yml`
+- Recent failed runs: `gh run list --workflow=backend-ci.yml --limit 10`


### PR DESCRIPTION
## Summary
- **Pass 29** - Fix backend-ci.yml 100% failure rate (0s, no jobs run)
- **Root Cause**: GitHub Actions does not allow both `paths:` and `paths-ignore:` on same event
- **Solution**: Removed `paths-ignore:` sections, kept only `paths:`

## Problem (Evidence-Based)

**ALL backend-ci runs failing instantly** (0s duration, no jobs executed):
```json
{
  "conclusion": "failure",
  "jobs": [],  // ← Empty! No jobs ran
  "createdAt": "2025-12-23T21:53:36Z",
  "updatedAt": "2025-12-23T21:53:36Z"  // ← 0 seconds
}
```

**Pattern**: 10/10 recent runs - 100% failure rate ❌

## Root Cause (GitHub Actions Limitation)

**INVALID YAML** - Lines 4-17 in backend-ci.yml:
```yaml
on:
  push:
    paths:                    # ← Filter 1
      - 'backend/**'
    paths-ignore:             # ← Filter 2 (CONFLICT!)
      - 'docs/**'
      - '**/*.md'
  pull_request:
    paths:                    # ← Filter 1
      - 'backend/**'
    paths-ignore:             # ← Filter 2 (CONFLICT!)
      - 'docs/**'
```

From GitHub Actions docs:
> "You cannot use both the `paths` and `paths-ignore` filters for the same event in a workflow."

GitHub rejects this configuration → workflow fails immediately without running jobs.

## Solution

**Removed `paths-ignore:` sections** (8 lines deleted):

**After**:
```yaml
on:
  push:
    paths:
      - 'backend/**'
      - '.github/workflows/backend-ci.yml'
  pull_request:
    paths:
      - 'backend/**'
      - '.github/workflows/backend-ci.yml'
```

**Trade-off**: Workflow now runs on ALL backend changes (including docs/markdown). This is acceptable:
- Backend tests fast (~2-3 min)
- Catching issues early > saving CI minutes
- Simpler config = less maintenance

## Files Changed

1. **`.github/workflows/backend-ci.yml`** - 8 lines deleted
   - Removed `push.paths-ignore` (lines 7-10)
   - Removed `pull_request.paths-ignore` (lines 14-17)
   - Added workflow file to `pull_request.paths` (consistency)

2. **`docs/AGENT/SUMMARY/Pass-29.md`** - Comprehensive evidence doc
3. **`docs/AGENT/TASKS/Pass-29-backend-ci-paths-fix.md`** - Task plan

## Evidence URLs

### Failed Runs (Before Fix)
- https://github.com/lomendor/Project-Dixis/actions/runs/20472416205 (0s, no jobs)
- https://github.com/lomendor/Project-Dixis/actions/runs/20472002687 (0s, no jobs)
- https://github.com/lomendor/Project-Dixis/actions/runs/20471945532 (0s, no jobs)

### GitHub Actions Documentation
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

## Impact

**Before**: backend-ci 100% blocked (all runs 0s failures)
**After**: Workflow executes jobs, tests run, valid CI signal

**Risk**: NONE (workflow syntax fix only, no code changes)

## Test Plan

- [x] YAML syntax fixed (removed paths-ignore)
- [x] Changes committed to branch
- [ ] **VERIFY**: backend-ci runs on this PR (should trigger on workflow file change)
- [ ] **VERIFY**: Jobs execute (not 0s failure)
- [ ] **VERIFY**: Tests run (pass or fail, but jobs must execute)

## Pattern

**Evidence-first ops fix** (similar to Pass 28):
1. Symptoms: 0s failures, no jobs
2. Evidence: Run metadata + GitHub docs
3. Root cause: YAML syntax conflict
4. Minimal fix: Remove paths-ignore
5. Verify: Next run executes jobs

---
**Generated-by**: Claude Code (Pass 29 - backend-ci paths fix)