### PR TITLE
Pass 31: fix PROD CSP env + cart route path

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -48,6 +48,9 @@ jobs:
         working-directory: frontend
         env:
           NEXT_PUBLIC_BASE_URL: https://dixis.gr
+          NEXT_PUBLIC_API_BASE_URL: https://dixis.gr/api/v1
+          NEXT_PUBLIC_APP_URL: https://dixis.gr
+          NEXT_PUBLIC_SITE_URL: https://dixis.gr
           PRODUCTS_MODE: demo
         run: pnpm build
 

--- a/frontend/src/app/internal/cart/route.ts
+++ b/frontend/src/app/internal/cart/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from 'next/server';
 
 /**
- * Cart API Stub
+ * Internal Cart API Stub
+ * Path: /internal/cart (moved from /api/cart to avoid nginx /api/* proxy collision)
  * Temporary stub to prevent 404s from client-side cart implementation
  * Returns empty cart - actual cart logic is client-side (localStorage)
+ *
+ * Note: Nginx proxies all /api/* requests to Laravel backend,
+ * so Next.js API routes under /api/* are unreachable.
+ * Using /internal/* prefix instead.
  *
  * TODO: Implement proper server-side cart if needed for:
  * - Cart persistence across devices

--- a/frontend/src/components/cart/CartClient.tsx
+++ b/frontend/src/components/cart/CartClient.tsx
@@ -14,7 +14,7 @@ export default function CartClient({ items }: { items: CartItem[] }) {
 
   const updateQty = (slug: string, qty: number) => {
     startTransition(async () => {
-      await fetch('/api/cart', {
+      await fetch('/internal/cart', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ slug, qty }),
@@ -25,14 +25,14 @@ export default function CartClient({ items }: { items: CartItem[] }) {
 
   const removeItem = (slug: string) => {
     startTransition(async () => {
-      await fetch(`/api/cart?slug=${slug}`, { method: 'DELETE' });
+      await fetch(`/internal/cart?slug=${slug}`, { method: 'DELETE' });
       safeRefresh();
     });
   };
 
   const clearCart = () => {
     startTransition(async () => {
-      await fetch('/api/cart', { method: 'DELETE' });
+      await fetch('/internal/cart', { method: 'DELETE' });
       safeRefresh();
     });
   };

--- a/frontend/src/components/cart/CartIcon.tsx
+++ b/frontend/src/components/cart/CartIcon.tsx
@@ -40,7 +40,7 @@ export default function CartIcon({ className = '', isMobile = false }: CartIconP
 
     async function fetchCartCount() {
       try {
-        const res = await fetch('/api/cart', { cache: 'no-store' });
+        const res = await fetch('/internal/cart', { cache: 'no-store' });
         const data = await res.json();
         setCartItemCount((data?.items?.length) || 0);
       } catch {

--- a/frontend/src/lib/cart/payload.ts
+++ b/frontend/src/lib/cart/payload.ts
@@ -2,17 +2,17 @@
 
 /**
  * @deprecated This localStorage-based cart is DEPRECATED as of AG118.2
- * Use /api/cart cookie-based API instead.
+ * Use /internal/cart cookie-based API instead.
  * This file is kept for backward compatibility only.
  *
- * New cart system: /api/cart (cookie-based, server-side)
- * Components: CartBadge, CartIcon (use /api/cart)
+ * New cart system: /internal/cart (cookie-based, server-side)
+ * Components: CartBadge, CartIcon (use /internal/cart)
  */
 
 type CartItem={ productId:string; qty:number };
 
 export function readCartItems():CartItem[]{
-  console.warn('[DEPRECATED] readCartItems from payload.ts - use /api/cart instead');
+  console.warn('[DEPRECATED] readCartItems from payload.ts - use /internal/cart instead');
   try{
     const s = JSON.parse(localStorage.getItem('dixis_cart_v1')||'{"items":[]}');
     const items = Array.isArray(s.items) ? s.items : [];
@@ -22,6 +22,6 @@ export function readCartItems():CartItem[]{
 }
 
 export function clearCart(){
-  console.warn('[DEPRECATED] clearCart from payload.ts - use DELETE /api/cart instead');
+  console.warn('[DEPRECATED] clearCart from payload.ts - use DELETE /internal/cart instead');
   try{ localStorage.setItem('dixis_cart_v1', JSON.stringify({ items:[] })); }catch{}
 }


### PR DESCRIPTION
## Summary
**Pass 31** - Fix production CSP localhost + cart 404 spam

### Issue 1: **P0 CRITICAL** - Localhost in Production CSP Header 🚨

**Evidence**: Production CSP header (verified with curl)
```
connect-src 'self' http://127.0.0.1:8001 https://o4508541701652480.ingest.de.sentry.io
```

**Root Cause**: GitHub Actions build missing `NEXT_PUBLIC_API_BASE_URL`
- File: `.github/workflows/deploy-frontend.yml:47-52`
- Build runs WITHOUT production env vars
- `next.config.ts:60` falls back to `http://127.0.0.1:8001/api/v1`
- This localhost URL is baked into CSP header at build time (line 81)

**Impact**: Production app tries to call localhost API, breaks all backend calls

**Fix**: Add missing env vars to build step
```yaml
- name: Build Next.js
  env:
    NEXT_PUBLIC_API_BASE_URL: https://dixis.gr/api/v1  # ← ADDED
    NEXT_PUBLIC_APP_URL: https://dixis.gr              # ← ADDED
    NEXT_PUBLIC_SITE_URL: https://dixis.gr             # ← ADDED
```

---

### Issue 2: **P1** - Cart API 404 Spam

**Evidence**: Browser F12 console (user report)
```
GET https://dixis.gr/api/cart 404 (Not Found)
```
(Repeated on every page load)

**Root Cause**: Nginx configuration
- Nginx proxies ALL `/api/*` requests to Laravel backend
- Next.js `/api/cart` route is unreachable (404)
- Components try to fetch cart data → 404 spam

**Fix**: Move cart route to `/internal/cart` (avoid nginx proxy)
- Moved: `frontend/src/app/api/cart/route.ts` → `frontend/src/app/internal/cart/route.ts`
- Updated all client calls (3 files):
  - `CartIcon.tsx:43` - fetch('/internal/cart')
  - `CartClient.tsx:17,28,35` - fetch('/internal/cart')
  - `payload.ts` - updated comments

**Why `/internal/*`**: Nginx only proxies `/api/*`, so Next.js routes under `/internal/*` are reachable

---

## Files Changed

1. **`.github/workflows/deploy-frontend.yml`** - 3 lines added
   - NEXT_PUBLIC_API_BASE_URL
   - NEXT_PUBLIC_APP_URL
   - NEXT_PUBLIC_SITE_URL

2. **`frontend/src/app/internal/cart/route.ts`** - Moved from api/cart
   - Updated comments explaining nginx proxy collision

3. **`frontend/src/components/cart/CartIcon.tsx`** - 1 line
   - `/api/cart` → `/internal/cart`

4. **`frontend/src/components/cart/CartClient.tsx`** - 3 lines
   - All `/api/cart` calls → `/internal/cart`

5. **`frontend/src/lib/cart/payload.ts`** - Comments updated
   - Documentation reflects new path

---

## Test Plan

**Local Build**:
- [x] Build passes with production env vars
- [x] `/internal/cart` route compiled successfully
- [x] No `/api/cart` references remain in src code

**Post-Deploy Verification** (after merge):
- [ ] **CSP header check**: `curl -I https://dixis.gr | grep connect-src`
  - Expected: `connect-src 'self' https://dixis.gr`
  - NOT: `connect-src 'self' http://127.0.0.1:8001`
  
- [ ] **Cart route check**: `curl -I https://dixis.gr/internal/cart`
  - Expected: `HTTP 200` or `401` (but NOT 404)
  
- [ ] **Browser console**: No more `/api/cart 404` errors

---

## Impact

**Before**:
- ❌ CSP allows localhost (security issue)
- ❌ All API calls broken in production (calling localhost)
- ❌ Cart 404 spam on every page load

**After**:
- ✅ CSP shows correct production URL
- ✅ API calls go to https://dixis.gr/api/v1
- ✅ Cart route reachable (no 404s)

**Risk**: LOW
- Ops config change (env vars)
- Path rename (no logic changes)
- Build verified locally

---

## Evidence

**Pass 30 Investigation**:
- CSP header showed localhost: https://github.com/lomendor/Project-Dixis/pull/1862
- Cart 404s confirmed in user F12 logs

**Local Build Proof**:
```bash
NEXT_PUBLIC_API_BASE_URL=https://dixis.gr/api/v1 pnpm build
✅ Build completed successfully
```

---

**Generated-by**: Claude Code (Pass 31 - CSP + cart route fixes)