### PR TITLE
fix(logo): serve logo via API route for standalone mode

### DIFF
--- a/frontend/src/app/logo.png/route.ts
+++ b/frontend/src/app/logo.png/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+
+export const dynamic = 'force-static';
+
+export async function GET(request: NextRequest) {
+  try {
+    // In standalone mode, public files are at the root level
+    const logoPath = path.join(process.cwd(), 'public', 'logo.png');
+
+    // Check if file exists
+    if (!fs.existsSync(logoPath)) {
+      console.error('[logo.png] File not found at:', logoPath);
+      return new NextResponse('Logo not found', { status: 404 });
+    }
+
+    // Read the file
+    const logoBuffer = fs.readFileSync(logoPath);
+
+    // Return the image with proper headers
+    return new NextResponse(logoBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/png',
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      },
+    });
+  } catch (error) {
+    console.error('[logo.png] Error serving logo:', error);
+    return new NextResponse('Error serving logo', { status: 500 });
+  }
+}


### PR DESCRIPTION
## Root Cause Analysis

**Problem**: `/logo.png` returns 404 in production even though the file exists in git and is deployed.

**Root Cause**: Next.js standalone mode doesn't automatically serve files from the `public/` directory in the same way as development mode. The deployment workflow correctly copies `public/` to `.next/standalone/public/`, but the standalone server.js doesn't serve these files at the root path.

## Solution

Create an API route at `/logo.png` that reads and serves the logo file directly from `public/logo.png` using Node.js `fs` module.

### Why This Works

1. **API routes always work in standalone mode** - They're served by Next.js, not affected by static file serving issues
2. **Guaranteed to be served** - Bypasses nginx static file configuration
3. **Proper headers** - Sets `Content-Type: image/png` and cache headers
4. **Error logging** - Helps debug if file not found

## Changes

**Added:**
- `frontend/src/app/logo.png/route.ts` - API route handler for /logo.png

**Technical Details:**
```typescript
- Reads file from public/logo.png using fs.readFileSync()
- Returns image with proper Content-Type header
- Adds Cache-Control for performance (1 year immutable)
- Logs errors for debugging
- Marked as force-static for build-time generation
```

## Evidence

**Before (current production):**
```bash
$ curl -I https://dixis.gr/logo.png
HTTP/1.1 404 Not Found
```

**After (with this fix):**
- API route will serve the 377KB optimized logo
- Proper Content-Type and caching headers
- Logo component will display correctly

## Test Plan

- [ ] Build succeeds locally
- [ ] After deploy: Verify `/logo.png` returns 200
- [ ] After deploy: Verify logo displays in UI  
- [ ] After deploy: Run prod-facts.sh to confirm all endpoints healthy

## Context

**Part of Pass 32** - Logo deployment fix

This is the third attempt to fix the logo 404:
1. PR #1865 - Added logo.png (2.9MB, wrong file)
2. PR #1867 - Replaced with optimized icon (377KB)  
3. **PR #1868 (this)** - Fix standalone mode serving issue

The logo file exists and is deployed correctly, but standalone mode doesn't serve it. This API route bypasses the issue entirely.

---

**Generated-by**: Claude Code (Pass 32 - ultrathink solution)