### PR TITLE
fix(checkout): Use public orders endpoint for guest checkout

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -468,7 +468,7 @@ class ApiClient {
     shipping_method: 'HOME' | 'PICKUP';
     notes?: string;
   }): Promise<Order> {
-    return this.request<Order>('orders', {
+    return this.request<Order>('public/orders', {
       method: 'POST',
       body: JSON.stringify(data),
     });


### PR DESCRIPTION
## Summary

Fixes guest checkout Unauthenticated error.

## Root Cause

Frontend apiClient.createOrder() called /api/v1/orders which requires auth:sanctum middleware.

Backend has two routes:
- /api/v1/orders (authenticated, requires auth:sanctum)
- /api/v1/public/orders (public, allows guest orders)

OrderPolicy already allows guest orders, but route middleware was blocking them.

## Fix

Change apiClient.createOrder() to call public/orders instead of orders.

## Impact

- Guest checkout works
- Authenticated checkout continues to work  
- No backend changes needed

## Files Changed

- frontend/src/lib/api.ts (1 line)

Related: PR #1876