### PR TITLE
Pass 32: Fix /logo.svg 404

### DIFF
--- a/frontend/src/app/logo.svg/route.ts
+++ b/frontend/src/app/logo.svg/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+
+export const dynamic = 'force-static';
+
+export async function GET(request: NextRequest) {
+  try {
+    // In standalone mode, public files are at the root level
+    const logoPath = path.join(process.cwd(), 'public', 'logo.svg');
+
+    // Check if file exists
+    if (!fs.existsSync(logoPath)) {
+      console.error('[logo.svg] File not found at:', logoPath);
+      return new NextResponse('Logo not found', { status: 404 });
+    }
+
+    // Read the file
+    const logoBuffer = fs.readFileSync(logoPath);
+
+    // Return the SVG with proper headers
+    return new NextResponse(logoBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/svg+xml',
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      },
+    });
+  } catch (error) {
+    console.error('[logo.svg] Error serving logo:', error);
+    return new NextResponse('Error serving logo', { status: 500 });
+  }
+}

--- a/frontend/tests/e2e/smoke-assets.spec.ts
+++ b/frontend/tests/e2e/smoke-assets.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * Smoke test for static assets (logo.svg, logo.png)
+ * Ensures critical assets are served correctly in standalone mode
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('Static Assets Smoke', () => {
+  test('logo.svg returns 200', async ({ request }) => {
+    const response = await request.get('/logo.svg');
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('image/svg');
+  });
+
+  test('logo.png returns 200', async ({ request }) => {
+    const response = await request.get('/logo.png');
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('image/png');
+  });
+});


### PR DESCRIPTION
Serve /logo.svg from frontend public assets + add smoke guard.