### PR TITLE
test(producer-kpi): Add authorization tests for dashboard endpoints

### DIFF
--- a/backend/tests/Feature/Api/V1/ProducerKpiAuthTest.php
+++ b/backend/tests/Feature/Api/V1/ProducerKpiAuthTest.php
@@ -37,4 +37,59 @@ class ProducerKpiAuthTest extends TestCase
         $res = $this->getJson('/api/v1/producer/dashboard/kpi', ['Accept' => 'application/json']);
         $res->assertStatus(200)->assertJsonStructure(['total_products', 'active_products', 'total_orders', 'revenue', 'unread_messages']);
     }
+
+    public function test_kpi_with_consumer_token_returns_403(): void
+    {
+        // Create consumer user (no producer profile)
+        $consumer = User::factory()->create([
+            'email' => 'consumer@example.com',
+            'role' => 'consumer',
+        ]);
+
+        Sanctum::actingAs($consumer);
+
+        $res = $this->getJson('/api/v1/producer/dashboard/kpi', ['Accept' => 'application/json']);
+        $res->assertStatus(403)->assertJson(['message' => 'Producer profile not found']);
+    }
+
+    public function test_top_products_requires_authentication_returns_401(): void
+    {
+        $res = $this->getJson('/api/v1/producer/dashboard/top-products', ['Accept' => 'application/json']);
+        $res->assertStatus(401);
+    }
+
+    public function test_top_products_with_producer_token_returns_200(): void
+    {
+        // Create producer user with producer profile
+        $producer = User::factory()->create([
+            'email' => 'producer2@example.com',
+            'role' => 'producer',
+        ]);
+
+        // Create producer profile
+        \App\Models\Producer::factory()->create([
+            'user_id' => $producer->id,
+            'name' => 'Test Producer 2',
+            'business_name' => 'Test Producer Business 2',
+        ]);
+
+        Sanctum::actingAs($producer);
+
+        $res = $this->getJson('/api/v1/producer/dashboard/top-products', ['Accept' => 'application/json']);
+        $res->assertStatus(200)->assertJsonStructure(['top_products']);
+    }
+
+    public function test_top_products_with_consumer_token_returns_403(): void
+    {
+        // Create consumer user (no producer profile)
+        $consumer = User::factory()->create([
+            'email' => 'consumer2@example.com',
+            'role' => 'consumer',
+        ]);
+
+        Sanctum::actingAs($consumer);
+
+        $res = $this->getJson('/api/v1/producer/dashboard/top-products', ['Accept' => 'application/json']);
+        $res->assertStatus(403)->assertJson(['message' => 'Producer profile not found']);
+    }
 }


### PR DESCRIPTION
## Pass 33 — Producer Dashboard KPI Backend Verification

### Objective
Verify producer-authenticated calls to `/api/v1/producer/dashboard/kpi` and `/api/v1/producer/dashboard/top-products` return 200 with valid JSON schema (not 500). Add backend Feature tests for producer access (200), non-producer forbidden (403/404), and schema sanity.

### Changes
- Added 4 new authorization tests in `backend/tests/Feature/Api/V1/ProducerKpiAuthTest.php`:
  1. `test_kpi_with_consumer_token_returns_403` - Consumer cannot access KPI endpoint
  2. `test_top_products_requires_authentication_returns_401` - Unauthenticated access forbidden
  3. `test_top_products_with_producer_token_returns_200` - Producer can access top-products
  4. `test_top_products_with_consumer_token_returns_403` - Consumer cannot access top-products

### Test Results
```
✓ kpi requires authentication returns 401
✓ kpi with producer token returns 200
✓ kpi with consumer token returns 403
✓ top products requires authentication returns 401
✓ top products with producer token returns 200
✓ top products with consumer token returns 403

Tests: 6 passed (14 assertions)
```

### Acceptance Criteria
- [x] Producer-authenticated calls return 200
- [x] Consumer calls return 403 (forbidden)
- [x] Unauthenticated calls return 401
- [x] Response schema validated

### Evidence
- Test file: `backend/tests/Feature/Api/V1/ProducerKpiAuthTest.php` (+55 lines)
- All tests pass locally

---
**Generated by**: Claude Code (Pass 33 - STOP-on-failure mode)