### PR TITLE
fix(ci): Pass 45 - fix deploy workflow 0s failures

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,6 +12,10 @@ concurrency:
 
 jobs:
   deploy:
+    # DEPRECATED: Use deploy-frontend.yml for production deployments
+    # This workflow is kept for manual-only use (workflow_dispatch)
+    # Guard ensures it never runs on push/PR events (prevents 0s failures)
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,10 +18,11 @@ concurrency:
 jobs:
   deploy:
     name: staging-deploy
-    # Skip if SSH key not available (staging environment optional)
+    # Only run on main branch pushes or manual dispatch
+    # Fork PRs are automatically skipped (no secrets access)
     if: |
       (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') &&
-      secrets.SSH_PRIVATE_KEY != ''
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     environment: staging
     env:


### PR DESCRIPTION
## Summary

- Fix `deploy-staging.yml` invalid job-level `if:` expression (secrets cannot be referenced in job conditions)
- Fix `deploy-prod.yml` by adding workflow_dispatch guard to prevent 0s failures on push events
- Mark `deploy-prod.yml` as DEPRECATED (canonical deploy path is `deploy-frontend.yml`)

## Root Cause Analysis

| Workflow | Problem | Fix |
|----------|---------|-----|
| `deploy-staging.yml` | `secrets.SSH_PRIVATE_KEY != ''` in job-level `if:` (INVALID) | Replace with fork PR guard |
| `deploy-prod.yml` | No guard against non-dispatch events | Add `if: github.event_name == 'workflow_dispatch'` |

## Evidence (Before)

All recent runs showed instant 0s failure with "workflow file issue":
- https://github.com/lomendor/Project-Dixis/actions/runs/20543797484 (deploy-prod)
- https://github.com/lomendor/Project-Dixis/actions/runs/20543797162 (deploy-staging)

## Test Plan

- [ ] PR checks pass (no workflow file issues)
- [ ] After merge: next push to main shows deploy-staging/deploy-prod as SKIPPED (not failed)
- [ ] `deploy-frontend.yml` continues to work as canonical deploy path

## Notes

- `deploy-frontend.yml` remains the canonical deployment workflow
- `deploy-prod.yml` is kept for manual-only use (workflow_dispatch)
- Fork PRs are automatically skipped (no secrets access)

---
Generated-by: Claude (Pass 45)