### PR TITLE
feat(shipping): Pass 50 - Zone-based shipping pricing

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/ShippingQuoteController.php
+++ b/backend/app/Http/Controllers/Api/V1/ShippingQuoteController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\ShippingZone;
+use App\Models\ShippingRate;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Pass 50: Shipping quote API for zone-based pricing
+ */
+class ShippingQuoteController extends Controller
+{
+    // Fallback prices if zone lookup fails (backwards compatible with Pass 48)
+    private const FALLBACK_PRICES = [
+        'HOME' => 3.50,
+        'COURIER' => 4.50,
+        'PICKUP' => 0.00,
+    ];
+
+    // Free shipping threshold (€)
+    private const FREE_SHIPPING_THRESHOLD = 35.00;
+
+    // Default weight if not provided (kg)
+    private const DEFAULT_WEIGHT_KG = 1.0;
+
+    /**
+     * POST /api/v1/shipping/quote
+     *
+     * Request body:
+     * - postal_code: string (5 digits)
+     * - method: string (HOME|COURIER|PICKUP)
+     * - weight_kg?: number (optional, defaults to 1.0)
+     * - subtotal?: number (optional, for free shipping check)
+     */
+    public function quote(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'postal_code' => 'required|string|regex:/^\d{5}$/',
+            'method' => 'required|string|in:HOME,COURIER,PICKUP',
+            'weight_kg' => 'nullable|numeric|min:0|max:100',
+            'subtotal' => 'nullable|numeric|min:0',
+        ]);
+
+        $postalCode = $validated['postal_code'];
+        $method = $validated['method'];
+        $weightKg = $validated['weight_kg'] ?? self::DEFAULT_WEIGHT_KG;
+        $subtotal = $validated['subtotal'] ?? 0;
+
+        // PICKUP is always free
+        if ($method === 'PICKUP') {
+            return response()->json([
+                'price_eur' => 0.00,
+                'zone_name' => null,
+                'method' => 'PICKUP',
+                'free_shipping' => true,
+                'source' => 'pickup',
+            ]);
+        }
+
+        // Check free shipping threshold
+        if ($subtotal >= self::FREE_SHIPPING_THRESHOLD) {
+            return response()->json([
+                'price_eur' => 0.00,
+                'zone_name' => null,
+                'method' => $method,
+                'free_shipping' => true,
+                'free_shipping_reason' => 'threshold',
+                'threshold' => self::FREE_SHIPPING_THRESHOLD,
+                'source' => 'threshold',
+            ]);
+        }
+
+        // Try zone-based pricing
+        try {
+            $zone = ShippingZone::findByPostalCode($postalCode);
+
+            if ($zone) {
+                $rate = ShippingRate::findRate($zone->id, $method, $weightKg);
+
+                if ($rate) {
+                    // Log successful quote (no PII)
+                    Log::info('Shipping quote computed', [
+                        'zone_id' => $zone->id,
+                        'method' => $method,
+                        'source' => 'zone',
+                    ]);
+
+                    return response()->json([
+                        'price_eur' => (float) $rate->price_eur,
+                        'zone_name' => $zone->name,
+                        'zone_id' => $zone->id,
+                        'method' => $method,
+                        'weight_kg' => $weightKg,
+                        'free_shipping' => false,
+                        'source' => 'zone',
+                    ]);
+                }
+            }
+        } catch (\Exception $e) {
+            // Log error but don't expose details
+            Log::warning('Shipping quote zone lookup failed', [
+                'error' => $e->getMessage(),
+                'method' => $method,
+            ]);
+        }
+
+        // Fallback to hardcoded prices (backwards compatible)
+        $fallbackPrice = self::FALLBACK_PRICES[$method] ?? self::FALLBACK_PRICES['COURIER'];
+
+        Log::info('Shipping quote using fallback', [
+            'method' => $method,
+            'source' => 'fallback',
+        ]);
+
+        return response()->json([
+            'price_eur' => $fallbackPrice,
+            'zone_name' => null,
+            'method' => $method,
+            'free_shipping' => false,
+            'source' => 'fallback',
+        ]);
+    }
+}

--- a/backend/app/Models/ShippingRate.php
+++ b/backend/app/Models/ShippingRate.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Pass 50: Shipping rate model for zone/method/weight pricing
+ */
+class ShippingRate extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'zone_id',
+        'method',
+        'weight_min_kg',
+        'weight_max_kg',
+        'price_eur',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'weight_min_kg' => 'decimal:2',
+        'weight_max_kg' => 'decimal:2',
+        'price_eur' => 'decimal:2',
+        'is_active' => 'boolean',
+    ];
+
+    public function zone(): BelongsTo
+    {
+        return $this->belongsTo(ShippingZone::class, 'zone_id');
+    }
+
+    /**
+     * Find rate for zone, method, and weight
+     */
+    public static function findRate(int $zoneId, string $method, float $weightKg): ?self
+    {
+        return static::where('zone_id', $zoneId)
+            ->where('method', $method)
+            ->where('is_active', true)
+            ->where('weight_min_kg', '<=', $weightKg)
+            ->where('weight_max_kg', '>=', $weightKg)
+            ->first();
+    }
+}

--- a/backend/app/Models/ShippingZone.php
+++ b/backend/app/Models/ShippingZone.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Pass 50: Shipping zone model for Greek market pricing
+ */
+class ShippingZone extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'postal_prefixes',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'postal_prefixes' => 'array',
+        'is_active' => 'boolean',
+    ];
+
+    public function rates(): HasMany
+    {
+        return $this->hasMany(ShippingRate::class, 'zone_id');
+    }
+
+    /**
+     * Find zone by postal code prefix match
+     */
+    public static function findByPostalCode(string $postalCode): ?self
+    {
+        $prefix = substr($postalCode, 0, 2);
+
+        return static::where('is_active', true)
+            ->get()
+            ->first(function ($zone) use ($prefix) {
+                return in_array($prefix, $zone->postal_prefixes ?? []);
+            });
+    }
+}

--- a/backend/database/migrations/2025_12_28_120000_create_shipping_zones_table.php
+++ b/backend/database/migrations/2025_12_28_120000_create_shipping_zones_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     * Pass 50: Shipping zones for Greek market pricing
+     */
+    public function up(): void
+    {
+        Schema::create('shipping_zones', function (Blueprint $table) {
+            $table->id();
+            $table->string('name'); // e.g. "Athens Metro", "Thessaloniki", "Rest of Greece"
+            $table->json('postal_prefixes'); // e.g. ["10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('shipping_zones');
+    }
+};

--- a/backend/database/migrations/2025_12_28_120001_create_shipping_rates_table.php
+++ b/backend/database/migrations/2025_12_28_120001_create_shipping_rates_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     * Pass 50: Shipping rates per zone/method/weight
+     */
+    public function up(): void
+    {
+        Schema::create('shipping_rates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('zone_id')->constrained('shipping_zones')->onDelete('cascade');
+            $table->string('method'); // HOME, COURIER (PICKUP is always free)
+            $table->decimal('weight_min_kg', 5, 2)->default(0);
+            $table->decimal('weight_max_kg', 5, 2)->default(999.99);
+            $table->decimal('price_eur', 8, 2);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->index(['zone_id', 'method', 'is_active']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('shipping_rates');
+    }
+};

--- a/backend/database/seeders/ShippingZoneSeeder.php
+++ b/backend/database/seeders/ShippingZoneSeeder.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\ShippingZone;
+use App\Models\ShippingRate;
+use Illuminate\Database\Seeder;
+
+/**
+ * Pass 50: Seed Greek shipping zones and rates
+ */
+class ShippingZoneSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // Zone 1: Athens Metro (postal prefixes 10-19)
+        $athens = ShippingZone::create([
+            'name' => 'Αττική',
+            'postal_prefixes' => ['10', '11', '12', '13', '14', '15', '16', '17', '18', '19'],
+            'is_active' => true,
+        ]);
+
+        // Zone 2: Thessaloniki (postal prefixes 54-57)
+        $thessaloniki = ShippingZone::create([
+            'name' => 'Θεσσαλονίκη',
+            'postal_prefixes' => ['54', '55', '56', '57'],
+            'is_active' => true,
+        ]);
+
+        // Zone 3: Rest of mainland Greece
+        $mainland = ShippingZone::create([
+            'name' => 'Ηπειρωτική Ελλάδα',
+            'postal_prefixes' => [
+                '20', '21', '22', '23', '24', '25', '26', '27', '28', '29',
+                '30', '31', '32', '33', '34', '35', '36', '37', '38', '39',
+                '40', '41', '42', '43', '44', '45', '46', '47', '48', '49',
+                '50', '51', '52', '53', '58', '59',
+                '60', '61', '62', '63', '64', '65', '66', '67', '68', '69',
+            ],
+            'is_active' => true,
+        ]);
+
+        // Zone 4: Islands (Crete, Cyclades, Dodecanese, etc.)
+        $islands = ShippingZone::create([
+            'name' => 'Νησιά',
+            'postal_prefixes' => [
+                '70', '71', '72', '73', '74', // Crete
+                '80', '81', '82', '83', '84', '85', // Aegean islands
+            ],
+            'is_active' => true,
+        ]);
+
+        // Create rates for each zone
+        // Default weight bucket: 0-30kg (covers most orders)
+        $rates = [
+            // Athens - cheapest
+            ['zone_id' => $athens->id, 'method' => 'HOME', 'price_eur' => 3.50],
+            ['zone_id' => $athens->id, 'method' => 'COURIER', 'price_eur' => 4.50],
+
+            // Thessaloniki - slightly more
+            ['zone_id' => $thessaloniki->id, 'method' => 'HOME', 'price_eur' => 4.00],
+            ['zone_id' => $thessaloniki->id, 'method' => 'COURIER', 'price_eur' => 5.00],
+
+            // Mainland - moderate
+            ['zone_id' => $mainland->id, 'method' => 'HOME', 'price_eur' => 5.00],
+            ['zone_id' => $mainland->id, 'method' => 'COURIER', 'price_eur' => 6.00],
+
+            // Islands - highest
+            ['zone_id' => $islands->id, 'method' => 'HOME', 'price_eur' => 7.00],
+            ['zone_id' => $islands->id, 'method' => 'COURIER', 'price_eur' => 8.50],
+        ];
+
+        foreach ($rates as $rate) {
+            ShippingRate::create([
+                'zone_id' => $rate['zone_id'],
+                'method' => $rate['method'],
+                'weight_min_kg' => 0,
+                'weight_max_kg' => 30.00,
+                'price_eur' => $rate['price_eur'],
+                'is_active' => true,
+            ]);
+        }
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -106,6 +106,11 @@ Route::prefix('v1')->group(function () {
         Route::get('orders/{order}', [App\Http\Controllers\Api\V1\OrderController::class, 'show'])->name('api.v1.public.orders.show');
         Route::post('orders', [App\Http\Controllers\Api\V1\OrderController::class, 'store'])->name('api.v1.public.orders.store')
             ->middleware('throttle:10,1'); // 10 requests per minute for order creation
+
+        // Pass 50: Zone-based shipping quote (simpler than /api/shipping/quote)
+        Route::post('shipping/quote', [App\Http\Controllers\Api\V1\ShippingQuoteController::class, 'quote'])
+            ->name('api.v1.public.shipping.quote')
+            ->middleware('throttle:60,1'); // 60 quote requests per minute
     });
 
     // Cart (authenticated)

--- a/backend/tests/Feature/ShippingZoneQuoteTest.php
+++ b/backend/tests/Feature/ShippingZoneQuoteTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ShippingZone;
+use App\Models\ShippingRate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Pass 50: Tests for zone-based shipping quote API
+ */
+class ShippingZoneQuoteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Seed test zones
+        $athens = ShippingZone::create([
+            'name' => 'Αττική',
+            'postal_prefixes' => ['10', '11', '12'],
+            'is_active' => true,
+        ]);
+
+        $islands = ShippingZone::create([
+            'name' => 'Νησιά',
+            'postal_prefixes' => ['84', '85'],
+            'is_active' => true,
+        ]);
+
+        // Seed rates
+        ShippingRate::create([
+            'zone_id' => $athens->id,
+            'method' => 'HOME',
+            'weight_min_kg' => 0,
+            'weight_max_kg' => 30,
+            'price_eur' => 3.50,
+            'is_active' => true,
+        ]);
+
+        ShippingRate::create([
+            'zone_id' => $athens->id,
+            'method' => 'COURIER',
+            'weight_min_kg' => 0,
+            'weight_max_kg' => 30,
+            'price_eur' => 4.50,
+            'is_active' => true,
+        ]);
+
+        ShippingRate::create([
+            'zone_id' => $islands->id,
+            'method' => 'HOME',
+            'weight_min_kg' => 0,
+            'weight_max_kg' => 30,
+            'price_eur' => 7.00,
+            'is_active' => true,
+        ]);
+
+        ShippingRate::create([
+            'zone_id' => $islands->id,
+            'method' => 'COURIER',
+            'weight_min_kg' => 0,
+            'weight_max_kg' => 30,
+            'price_eur' => 8.50,
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_quote_returns_athens_price_for_athens_postal(): void
+    {
+        $response = $this->postJson('/api/v1/public/shipping/quote', [
+            'postal_code' => '10564',
+            'method' => 'HOME',
+        ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'price_eur' => 3.50,
+            'zone_name' => 'Αττική',
+            'method' => 'HOME',
+            'source' => 'zone',
+            'free_shipping' => false,
+        ]);
+    }
+
+    public function test_quote_returns_islands_price_for_cyclades_postal(): void
+    {
+        $response = $this->postJson('/api/v1/public/shipping/quote', [
+            'postal_code' => '84600', // Mykonos
+            'method' => 'HOME',
+        ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'price_eur' => 7.00,
+            'zone_name' => 'Νησιά',
+            'method' => 'HOME',
+            'source' => 'zone',
+        ]);
+    }
+
+    public function test_quote_returns_courier_price_when_courier_selected(): void
+    {
+        $response = $this->postJson('/api/v1/public/shipping/quote', [
+            'postal_code' => '10564',
+            'method' => 'COURIER',
+        ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'price_eur' => 4.50,
+            'method' => 'COURIER',
+            'source' => 'zone',
+        ]);
+    }
+
+    public function test_pickup_is_always_free(): void
+    {
+        $response = $this->postJson('/api/v1/public/shipping/quote', [
+            'postal_code' => '10564',
+            'method' => 'PICKUP',
+        ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'price_eur' => 0.00,
+            'free_shipping' => true,
+            'source' => 'pickup',
+        ]);
+    }
+
+    public function test_free_shipping_for_orders_over_threshold(): void
+    {
+        $response = $this->postJson('/api/v1/public/shipping/quote', [
+            'postal_code' => '10564',
+            'method' => 'HOME',
+            'subtotal' => 40.00, // Over €35 threshold
+        ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'price_eur' => 0.00,
+            'free_shipping' => true,
+            'source' => 'threshold',
+        ]);
+    }
+
+    public function test_fallback_price_for_unknown_zone(): void
+    {
+        $response = $this->postJson('/api/v1/public/shipping/quote', [
+            'postal_code' => '99999', // No zone matches this
+            'method' => 'HOME',
+        ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'price_eur' => 3.50, // Fallback price
+            'zone_name' => null,
+            'source' => 'fallback',
+        ]);
+    }
+
+    public function test_validation_rejects_invalid_postal(): void
+    {
+        $response = $this->postJson('/api/v1/public/shipping/quote', [
+            'postal_code' => '123', // Too short
+            'method' => 'HOME',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_validation_rejects_invalid_method(): void
+    {
+        $response = $this->postJson('/api/v1/public/shipping/quote', [
+            'postal_code' => '10564',
+            'method' => 'INVALID',
+        ]);
+
+        $response->assertStatus(422);
+    }
+}

--- a/docs/AGENT/SUMMARY/Pass-50.md
+++ b/docs/AGENT/SUMMARY/Pass-50.md
@@ -1,0 +1,118 @@
+# Pass 50 - Zone-Based Shipping Pricing
+
+**Date**: 2025-12-28
+**Status**: IN_PROGRESS
+**PRs**: (pending)
+
+## Problem Statement
+
+Shipping costs were hardcoded in frontend (HOME=€3.50, COURIER=€4.50). Real Greek marketplace needs zone-based pricing where:
+- Athens metro has cheaper shipping
+- Islands have higher shipping costs
+- Different methods (HOME/COURIER) have different prices per zone
+
+## Solution
+
+### Backend: Zone Pricing Model
+
+**New Tables** (Laravel migrations):
+- `shipping_zones`: id, name, postal_prefixes (JSON), is_active
+- `shipping_rates`: zone_id, method, weight_min_kg, weight_max_kg, price_eur
+
+**New Models**:
+- `ShippingZone` - finds zone by postal code prefix match
+- `ShippingRate` - finds rate by zone/method/weight
+
+**API Endpoint**:
+`POST /api/v1/public/shipping/quote`
+```json
+// Request
+{
+  "postal_code": "10564",
+  "method": "HOME",
+  "subtotal": 30.00,
+  "weight_kg": 1.0
+}
+
+// Response
+{
+  "price_eur": 3.50,
+  "zone_name": "Αττική",
+  "zone_id": 1,
+  "method": "HOME",
+  "free_shipping": false,
+  "source": "zone"
+}
+```
+
+### Seeded Zones (Greek Market)
+
+| Zone | Postal Prefixes | HOME | COURIER |
+|------|-----------------|------|---------|
+| Αττική | 10-19 | €3.50 | €4.50 |
+| Θεσσαλονίκη | 54-57 | €4.00 | €5.00 |
+| Ηπειρωτική Ελλάδα | 20-69 | €5.00 | €6.00 |
+| Νησιά | 70-85 | €7.00 | €8.50 |
+
+### Frontend: Dynamic Quote
+
+- When user enters postal code (5 digits), fetch quote from API
+- Display zone name under shipping selector ("Ζώνη: Αττική")
+- Update shipping cost dynamically based on zone
+- **Fallback**: If API fails, use hardcoded prices (backwards compatible)
+
+### Rollout Safety
+
+- API failure → fallback to hardcoded prices (€3.50 HOME, €4.50 COURIER)
+- Free shipping threshold (€35) still works
+- PICKUP always free
+- No PII in logs (only zone_id, method, source)
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `backend/database/migrations/2025_12_28_120000_create_shipping_zones_table.php` | New |
+| `backend/database/migrations/2025_12_28_120001_create_shipping_rates_table.php` | New |
+| `backend/app/Models/ShippingZone.php` | New |
+| `backend/app/Models/ShippingRate.php` | New |
+| `backend/database/seeders/ShippingZoneSeeder.php` | New |
+| `backend/app/Http/Controllers/Api/V1/ShippingQuoteController.php` | New |
+| `backend/routes/api.php` | +4 lines |
+| `frontend/src/lib/api.ts` | +20 lines |
+| `frontend/src/app/(storefront)/checkout/CheckoutClient.tsx` | +45 lines |
+| `backend/tests/Feature/ShippingZoneQuoteTest.php` | New (8 tests) |
+| `frontend/tests/e2e/pass-50-shipping-zones.spec.ts` | New (5 tests) |
+| `docs/NEXT-7D.md` | Updated |
+
+## Evidence
+
+### Tests
+- Backend: 8 unit tests (zone resolution, price lookup, fallback, validation)
+- E2E: 5 Playwright tests (Athens zone, islands zone, free shipping, PICKUP, fallback)
+
+### CI Results
+- Pending
+
+## DoD Checklist
+
+- [x] Backend: shipping_zones + shipping_rates tables
+- [x] Backend: Zone lookup by postal prefix
+- [x] Backend: Quote API with fallback
+- [x] Frontend: Fetch quote on postal/method change
+- [x] Frontend: Display zone name
+- [x] Frontend: Fallback to hardcoded on API failure
+- [x] Backend tests: 8 tests
+- [x] E2E tests: 5 tests
+- [x] TypeScript passes
+- [ ] CI green
+- [ ] PR merged
+- [ ] Docs updated
+
+## Next Passes
+
+- **Pass 51**: Payment provider integration
+- **Pass 52**: Email notifications
+
+---
+Generated-by: Claude (Pass 50)

--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -1,17 +1,25 @@
 # NEXT 7 DAYS
 
-**Last Updated**: 2025-12-27 12:00 UTC
+**Last Updated**: 2025-12-28 14:00 UTC
 
 ## WIP (1 item only)
-- (none - ready for next item from NEXT queue)
+- **Pass 50 — Zone-Based Shipping Pricing** (in PR)
 
 ## NEXT (ordered, max 3)
 
-1. **Pass 45 — Deploy Workflow Investigation** (P2 Ops Hygiene)
-2. **Pass 46 — CI E2E Auth Setup + Unskip Critical Tests**
-3. **Pass 47 — Shipping Cost v1 + Address/Shipping Fee Display**
+1. **Pass 51 — Payment Provider Integration** (Viva Wallet or Stripe)
+2. **Pass 52 — Email Notifications** (Order confirmation, shipping updates)
+3. **Pass 53 — Producer Dashboard Improvements** (Order management UI)
 
 See `docs/OPS/STATE.md` for full DoD checklists.
+
+## Recently Completed (Pass 45-49)
+
+- **Pass 45** — Deploy Workflow Hardening ✅
+- **Pass 46** — CI E2E Auth Setup ✅
+- **Pass 47** — Production Healthz & Smoke-Matrix Policy ✅
+- **Pass 48** — Shipping Display in Checkout & Order Details ✅
+- **Pass 49** — Greek Market Validation ✅
 
 ## DONE (this week)
 - Bootstrap OPS state management system (2025-12-19) - PR #1761 merged ✅

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -623,6 +623,28 @@ class ApiClient {
       }
     );
   }
+
+  // Pass 50: Get zone-based shipping quote (new V1 endpoint)
+  async getZoneShippingQuote(data: {
+    postal_code: string;
+    method: 'HOME' | 'COURIER' | 'PICKUP';
+    weight_kg?: number;
+    subtotal?: number;
+  }): Promise<{
+    price_eur: number;
+    zone_name: string | null;
+    zone_id?: number;
+    method: string;
+    free_shipping: boolean;
+    free_shipping_reason?: 'threshold' | 'pickup';
+    threshold?: number;
+    source: 'zone' | 'fallback' | 'threshold' | 'pickup';
+  }> {
+    return this.request('public/shipping/quote', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
 }
 
 export const apiClient = new ApiClient();

--- a/frontend/tests/e2e/pass-50-shipping-zones.spec.ts
+++ b/frontend/tests/e2e/pass-50-shipping-zones.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * Pass 50 - E2E Tests for Zone-Based Shipping Pricing
+ *
+ * Tests the zone-based shipping quote API and UI integration.
+ * Uses route mocking for deterministic API responses.
+ */
+import { test, expect } from '@playwright/test';
+
+// Helper: Add item to cart via localStorage
+async function addItemToCart(page: any) {
+  await page.addInitScript(() => {
+    const cartState = {
+      state: {
+        items: {
+          '1': {
+            id: '1',
+            title: 'Ελληνικό Μέλι',
+            priceCents: 1500, // €15.00
+            qty: 2
+          }
+        }
+      },
+      version: 0
+    };
+    localStorage.setItem('dixis:cart:v1', JSON.stringify(cartState));
+  });
+}
+
+test.describe('Pass 50: Zone-Based Shipping', () => {
+
+  test('Athens postal shows Athens zone price', async ({ page }) => {
+    await addItemToCart(page);
+
+    // Mock the zone shipping quote API
+    await page.route('**/api/v1/public/shipping/quote', async (route) => {
+      const body = JSON.parse(route.request().postData() || '{}');
+
+      // Athens zone response
+      if (body.postal_code?.startsWith('10') || body.postal_code?.startsWith('11')) {
+        await route.fulfill({
+          status: 200,
+          json: {
+            price_eur: 3.50,
+            zone_name: 'Αττική',
+            zone_id: 1,
+            method: body.method,
+            free_shipping: false,
+            source: 'zone',
+          }
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto('/checkout');
+    await page.waitForLoadState('networkidle');
+
+    // Fill postal code for Athens
+    await page.getByTestId('checkout-postal').fill('10564');
+
+    // Wait for quote to be fetched
+    await page.waitForTimeout(500);
+
+    // Verify zone info is displayed
+    const zoneInfo = page.getByTestId('zone-info');
+    await expect(zoneInfo).toBeVisible();
+    await expect(zoneInfo).toContainText('Αττική');
+  });
+
+  test('Islands postal shows higher price', async ({ page }) => {
+    await addItemToCart(page);
+
+    // Mock the zone shipping quote API
+    await page.route('**/api/v1/public/shipping/quote', async (route) => {
+      const body = JSON.parse(route.request().postData() || '{}');
+
+      // Islands zone response (Mykonos 84600)
+      if (body.postal_code?.startsWith('84') || body.postal_code?.startsWith('85')) {
+        await route.fulfill({
+          status: 200,
+          json: {
+            price_eur: 7.00,
+            zone_name: 'Νησιά',
+            zone_id: 4,
+            method: body.method,
+            free_shipping: false,
+            source: 'zone',
+          }
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto('/checkout');
+    await page.waitForLoadState('networkidle');
+
+    // Fill postal code for Mykonos (island)
+    await page.getByTestId('checkout-postal').fill('84600');
+
+    // Wait for quote
+    await page.waitForTimeout(500);
+
+    // Verify islands zone is shown
+    const zoneInfo = page.getByTestId('zone-info');
+    await expect(zoneInfo).toBeVisible();
+    await expect(zoneInfo).toContainText('Νησιά');
+  });
+
+  test('free shipping over threshold still works', async ({ page }) => {
+    // Add items worth more than €35
+    await page.addInitScript(() => {
+      const cartState = {
+        state: {
+          items: {
+            '1': {
+              id: '1',
+              title: 'Premium Olive Oil',
+              priceCents: 4000, // €40.00 - over threshold
+              qty: 1
+            }
+          }
+        },
+        version: 0
+      };
+      localStorage.setItem('dixis:cart:v1', JSON.stringify(cartState));
+    });
+
+    // Mock API to return free shipping
+    await page.route('**/api/v1/public/shipping/quote', async (route) => {
+      await route.fulfill({
+        status: 200,
+        json: {
+          price_eur: 0.00,
+          zone_name: null,
+          method: 'HOME',
+          free_shipping: true,
+          free_shipping_reason: 'threshold',
+          threshold: 35,
+          source: 'threshold',
+        }
+      });
+    });
+
+    await page.goto('/checkout');
+    await page.waitForLoadState('networkidle');
+
+    // Fill valid postal
+    await page.getByTestId('checkout-postal').fill('10564');
+
+    // Verify free shipping message is shown
+    const freeShippingMsg = page.getByTestId('free-shipping-message');
+    await expect(freeShippingMsg).toBeVisible();
+    await expect(freeShippingMsg).toContainText('Δωρεάν');
+  });
+
+  test('PICKUP remains free regardless of postal code', async ({ page }) => {
+    await addItemToCart(page);
+
+    await page.goto('/checkout');
+    await page.waitForLoadState('networkidle');
+
+    // Select PICKUP
+    await page.getByTestId('shipping-option-PICKUP').click();
+
+    // Verify PICKUP shows free
+    const shippingCostDisplay = page.getByTestId('shipping-cost-display');
+    await expect(shippingCostDisplay).toContainText('Δωρεάν');
+  });
+
+  test('graceful fallback when API fails', async ({ page }) => {
+    await addItemToCart(page);
+
+    // Mock API to fail
+    await page.route('**/api/v1/public/shipping/quote', async (route) => {
+      await route.abort('failed');
+    });
+
+    await page.goto('/checkout');
+    await page.waitForLoadState('networkidle');
+
+    // Fill valid postal
+    await page.getByTestId('checkout-postal').fill('10564');
+
+    // Wait a bit for the failed request
+    await page.waitForTimeout(500);
+
+    // Verify shipping cost still shows (fallback value)
+    const shippingCostDisplay = page.getByTestId('shipping-cost-display');
+    await expect(shippingCostDisplay).toBeVisible();
+    // Should show hardcoded fallback price €3.50
+    await expect(shippingCostDisplay).toContainText('3');
+  });
+});


### PR DESCRIPTION
## Summary
- Add zone-based shipping pricing for Greek market
- Backend: `shipping_zones` + `shipping_rates` tables with Laravel migrations
- New API: `POST /api/v1/public/shipping/quote` with postal code → zone → price lookup
- Frontend: Dynamic quote fetching with graceful fallback to hardcoded prices
- 4 Greek zones seeded: Αττική, Θεσσαλονίκη, Ηπειρωτική Ελλάδα, Νησιά

## Test Plan
- [x] Backend: 8 PHPUnit tests (zone resolution, price lookup, fallback, validation)
- [x] E2E: 5 Playwright tests (Athens zone, islands zone, free shipping, PICKUP, fallback)
- [x] TypeScript passes

## Rollout Safety
- API failure → fallback to hardcoded prices (€3.50 HOME, €4.50 COURIER)
- Free shipping threshold (€35) still works
- PICKUP always free
- No PII in logs (only zone_id, method, source)

## Files Changed (13 files, ~967 lines)
| File | Changes |
|------|---------|
| `backend/database/migrations/2025_12_28_120000_create_shipping_zones_table.php` | New |
| `backend/database/migrations/2025_12_28_120001_create_shipping_rates_table.php` | New |
| `backend/app/Models/ShippingZone.php` | New |
| `backend/app/Models/ShippingRate.php` | New |
| `backend/database/seeders/ShippingZoneSeeder.php` | New |
| `backend/app/Http/Controllers/Api/V1/ShippingQuoteController.php` | New |
| `backend/routes/api.php` | +4 lines |
| `frontend/src/lib/api.ts` | +20 lines |
| `frontend/src/app/(storefront)/checkout/CheckoutClient.tsx` | +45 lines |
| `backend/tests/Feature/ShippingZoneQuoteTest.php` | New (8 tests) |
| `frontend/tests/e2e/pass-50-shipping-zones.spec.ts` | New (5 tests) |
| `docs/NEXT-7D.md` | Updated |
| `docs/AGENT/SUMMARY/Pass-50.md` | New |

---
Generated-by: Claude (Pass 50)