### PR TITLE
feat(notifications): Pass 54 - Order status update emails (shipped/delivered)

### DIFF
--- a/backend/app/Mail/OrderDelivered.php
+++ b/backend/app/Mail/OrderDelivered.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Order;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Pass 54: Order delivered notification email (Greek).
+ */
+class OrderDelivered extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public Order $order
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "Η παραγγελία #{$this->order->id} παραδόθηκε - Dixis",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.orders.delivered',
+            with: [
+                'order' => $this->order,
+                'orderNumber' => $this->order->id,
+            ],
+        );
+    }
+}

--- a/backend/app/Mail/OrderShipped.php
+++ b/backend/app/Mail/OrderShipped.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Order;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Pass 54: Order shipped notification email (Greek).
+ */
+class OrderShipped extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public Order $order
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "Η παραγγελία #{$this->order->id} στάλθηκε - Dixis",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.orders.shipped',
+            with: [
+                'order' => $this->order,
+                'orderNumber' => $this->order->id,
+                'shippingAddress' => $this->formatShippingAddress(),
+                'shippingMethod' => $this->formatShippingMethod(),
+            ],
+        );
+    }
+
+    private function formatShippingAddress(): string
+    {
+        $address = $this->order->shipping_address;
+        if (is_array($address)) {
+            return implode(', ', array_filter([
+                $address['name'] ?? '',
+                $address['line1'] ?? '',
+                $address['city'] ?? '',
+                $address['postal_code'] ?? '',
+            ]));
+        }
+        return $address ?? '';
+    }
+
+    private function formatShippingMethod(): string
+    {
+        return match ($this->order->shipping_method) {
+            'HOME' => 'Παράδοση στο σπίτι',
+            'PICKUP' => 'Παραλαβή από κατάστημα',
+            'COURIER' => 'Μεταφορική εταιρεία',
+            default => $this->order->shipping_method ?? '',
+        };
+    }
+}

--- a/backend/resources/views/emails/orders/delivered.blade.php
+++ b/backend/resources/views/emails/orders/delivered.blade.php
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="el">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Η παραγγελία σας παραδόθηκε</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: #3b82f6; color: white; padding: 20px; text-align: center; border-radius: 8px 8px 0 0; }
+        .content { background: #f9fafb; padding: 20px; border: 1px solid #e5e7eb; }
+        .footer { text-align: center; padding: 20px; color: #6b7280; font-size: 14px; }
+        .highlight { color: #3b82f6; font-weight: bold; }
+        .cta { display: inline-block; background: #3b82f6; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin: 15px 0; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>Η παραγγελία σας παραδόθηκε!</h1>
+    </div>
+
+    <div class="content">
+        <p>Αγαπητέ/ή πελάτη,</p>
+
+        <p>Η παραγγελία σας <span class="highlight">#{{ $orderNumber }}</span> έχει παραδοθεί με επιτυχία!</p>
+
+        <p>Ελπίζουμε να απολαύσετε τα προϊόντα σας. Αν έχετε οποιαδήποτε ερώτηση ή σχόλιο, μη διστάσετε να επικοινωνήσετε μαζί μας.</p>
+
+        <p>Ευχαριστούμε που επιλέξατε το Dixis!</p>
+    </div>
+
+    <div class="footer">
+        <p>Dixis - Φρέσκα προϊόντα από τοπικούς παραγωγούς</p>
+        <p>&copy; {{ date('Y') }} Dixis. Με επιφύλαξη παντός δικαιώματος.</p>
+    </div>
+</body>
+</html>

--- a/backend/resources/views/emails/orders/shipped.blade.php
+++ b/backend/resources/views/emails/orders/shipped.blade.php
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="el">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Η παραγγελία σας στάλθηκε</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: #10b981; color: white; padding: 20px; text-align: center; border-radius: 8px 8px 0 0; }
+        .content { background: #f9fafb; padding: 20px; border: 1px solid #e5e7eb; }
+        .footer { text-align: center; padding: 20px; color: #6b7280; font-size: 14px; }
+        .info-box { background: white; border: 1px solid #e5e7eb; border-radius: 8px; padding: 15px; margin: 15px 0; }
+        .highlight { color: #10b981; font-weight: bold; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>Η παραγγελία σας στάλθηκε!</h1>
+    </div>
+
+    <div class="content">
+        <p>Αγαπητέ/ή πελάτη,</p>
+
+        <p>Η παραγγελία σας <span class="highlight">#{{ $orderNumber }}</span> έχει αποσταλεί και είναι καθ' οδόν!</p>
+
+        <div class="info-box">
+            <h3>Στοιχεία Αποστολής</h3>
+            <p><strong>Διεύθυνση:</strong> {{ $shippingAddress }}</p>
+            <p><strong>Τρόπος Αποστολής:</strong> {{ $shippingMethod }}</p>
+        </div>
+
+        <p>Θα λάβετε ένα ακόμα email όταν η παραγγελία σας παραδοθεί.</p>
+
+        <p>Ευχαριστούμε που επιλέξατε το Dixis!</p>
+    </div>
+
+    <div class="footer">
+        <p>Dixis - Φρέσκα προϊόντα από τοπικούς παραγωγούς</p>
+        <p>&copy; {{ date('Y') }} Dixis. Με επιφύλαξη παντός δικαιώματος.</p>
+    </div>
+</body>
+</html>

--- a/backend/tests/Feature/OrderStatusEmailNotificationTest.php
+++ b/backend/tests/Feature/OrderStatusEmailNotificationTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\OrderDelivered;
+use App\Mail\OrderShipped;
+use App\Models\Order;
+use App\Models\OrderNotification;
+use App\Models\User;
+use App\Services\OrderEmailService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * Pass 54: Order Status Email Notification Tests.
+ *
+ * Tests:
+ * - Feature flag disables sending
+ * - Shipped status sends email once
+ * - Delivered status sends email once
+ * - Idempotency prevents double-sends
+ */
+class OrderStatusEmailNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Mail::fake();
+    }
+
+    /** @test */
+    public function no_email_sent_when_feature_flag_disabled()
+    {
+        Config::set('notifications.email_enabled', false);
+
+        $user = User::factory()->create(['email' => 'consumer@test.com']);
+        $order = Order::factory()->create(['user_id' => $user->id, 'status' => 'processing']);
+
+        $service = new OrderEmailService();
+        $service->sendOrderStatusNotification($order, 'shipped');
+
+        Mail::assertNothingSent();
+        $this->assertEquals(0, OrderNotification::count());
+    }
+
+    /** @test */
+    public function shipped_status_sends_email()
+    {
+        Config::set('notifications.email_enabled', true);
+
+        $user = User::factory()->create(['email' => 'consumer@test.com']);
+        $order = Order::factory()->create(['user_id' => $user->id, 'status' => 'shipped']);
+
+        $service = new OrderEmailService();
+        $service->sendOrderStatusNotification($order, 'shipped');
+
+        Mail::assertSent(OrderShipped::class, function ($mail) use ($order) {
+            return $mail->order->id === $order->id;
+        });
+
+        $this->assertDatabaseHas('order_notifications', [
+            'order_id' => $order->id,
+            'recipient_type' => 'consumer',
+            'event' => 'order_shipped',
+        ]);
+    }
+
+    /** @test */
+    public function delivered_status_sends_email()
+    {
+        Config::set('notifications.email_enabled', true);
+
+        $user = User::factory()->create(['email' => 'consumer@test.com']);
+        $order = Order::factory()->create(['user_id' => $user->id, 'status' => 'delivered']);
+
+        $service = new OrderEmailService();
+        $service->sendOrderStatusNotification($order, 'delivered');
+
+        Mail::assertSent(OrderDelivered::class, function ($mail) use ($order) {
+            return $mail->order->id === $order->id;
+        });
+
+        $this->assertDatabaseHas('order_notifications', [
+            'order_id' => $order->id,
+            'recipient_type' => 'consumer',
+            'event' => 'order_delivered',
+        ]);
+    }
+
+    /** @test */
+    public function idempotency_prevents_double_send_for_shipped()
+    {
+        Config::set('notifications.email_enabled', true);
+
+        $user = User::factory()->create(['email' => 'consumer@test.com']);
+        $order = Order::factory()->create(['user_id' => $user->id, 'status' => 'shipped']);
+
+        $service = new OrderEmailService();
+        $service->sendOrderStatusNotification($order, 'shipped');
+        $service->sendOrderStatusNotification($order, 'shipped');
+
+        // Only ONE email sent
+        Mail::assertSent(OrderShipped::class, 1);
+
+        // Only ONE notification record
+        $this->assertEquals(1, OrderNotification::where('order_id', $order->id)
+            ->where('event', 'order_shipped')
+            ->count());
+    }
+
+    /** @test */
+    public function idempotency_prevents_double_send_for_delivered()
+    {
+        Config::set('notifications.email_enabled', true);
+
+        $user = User::factory()->create(['email' => 'consumer@test.com']);
+        $order = Order::factory()->create(['user_id' => $user->id, 'status' => 'delivered']);
+
+        $service = new OrderEmailService();
+        $service->sendOrderStatusNotification($order, 'delivered');
+        $service->sendOrderStatusNotification($order, 'delivered');
+
+        // Only ONE email sent
+        Mail::assertSent(OrderDelivered::class, 1);
+
+        // Only ONE notification record
+        $this->assertEquals(1, OrderNotification::where('order_id', $order->id)
+            ->where('event', 'order_delivered')
+            ->count());
+    }
+
+    /** @test */
+    public function other_statuses_do_not_send_email()
+    {
+        Config::set('notifications.email_enabled', true);
+
+        $user = User::factory()->create(['email' => 'consumer@test.com']);
+        $order = Order::factory()->create(['user_id' => $user->id, 'status' => 'processing']);
+
+        $service = new OrderEmailService();
+
+        // These statuses should NOT trigger email
+        $service->sendOrderStatusNotification($order, 'confirmed');
+        $service->sendOrderStatusNotification($order, 'processing');
+        $service->sendOrderStatusNotification($order, 'cancelled');
+
+        Mail::assertNothingSent();
+        $this->assertEquals(0, OrderNotification::count());
+    }
+
+    /** @test */
+    public function missing_email_handled_gracefully()
+    {
+        Config::set('notifications.email_enabled', true);
+
+        // Order without user (guest order) and no email in shipping_address
+        $order = Order::factory()->create([
+            'user_id' => null,
+            'shipping_address' => ['name' => 'Test', 'line1' => '123 St'],
+            'status' => 'shipped',
+        ]);
+
+        $service = new OrderEmailService();
+
+        // Should not throw
+        $service->sendOrderStatusNotification($order, 'shipped');
+
+        // No email sent (no crash)
+        Mail::assertNothingSent();
+    }
+
+    /** @test */
+    public function shipped_and_delivered_are_separate_events()
+    {
+        Config::set('notifications.email_enabled', true);
+
+        $user = User::factory()->create(['email' => 'consumer@test.com']);
+        $order = Order::factory()->create(['user_id' => $user->id, 'status' => 'shipped']);
+
+        $service = new OrderEmailService();
+
+        // Send shipped notification
+        $service->sendOrderStatusNotification($order, 'shipped');
+
+        // Update order status and send delivered notification
+        $order->update(['status' => 'delivered']);
+        $service->sendOrderStatusNotification($order, 'delivered');
+
+        // Both emails should be sent (separate events)
+        Mail::assertSent(OrderShipped::class, 1);
+        Mail::assertSent(OrderDelivered::class, 1);
+
+        // Two notification records
+        $this->assertEquals(2, OrderNotification::where('order_id', $order->id)->count());
+    }
+}

--- a/docs/AGENT/SUMMARY/Pass-54.md
+++ b/docs/AGENT/SUMMARY/Pass-54.md
@@ -1,0 +1,99 @@
+# Pass 54 - Order Status Update Emails
+
+**Date**: 2025-12-28
+**Status**: COMPLETE
+**PR**: (pending)
+
+## Problem Statement
+
+Users receive no notification when their order status changes (e.g., shipped, delivered). This creates uncertainty about delivery progress.
+
+## Solution
+
+### Reuses Pass 53 Infrastructure
+- Same `OrderEmailService` with new method
+- Same idempotency pattern (`order_notifications` table)
+- Same feature flag (`EMAIL_NOTIFICATIONS_ENABLED`)
+
+### Two New Events
+
+1. **Order Shipped** (`OrderShipped`)
+   - Sent when admin updates status to `shipped`
+   - Greek content
+   - Contains: order number, shipping address, shipping method
+
+2. **Order Delivered** (`OrderDelivered`)
+   - Sent when admin updates status to `delivered`
+   - Greek content
+   - Contains: order number, thank you message
+
+### Idempotency
+- Events: `order_shipped`, `order_delivered`
+- Unique key: (order_id, recipient_type, recipient_id, event)
+- Prevents double-sends on retries
+
+### Graceful Failure
+- Missing email addresses logged, not thrown
+- Email failures don't crash status update
+- Status is always updated even if email fails
+
+## Files Changed
+
+| File | Type | Description |
+|------|------|-------------|
+| `app/Mail/OrderShipped.php` | New | Shipped notification mailable |
+| `app/Mail/OrderDelivered.php` | New | Delivered notification mailable |
+| `resources/views/emails/orders/shipped.blade.php` | New | Shipped email template |
+| `resources/views/emails/orders/delivered.blade.php` | New | Delivered email template |
+| `app/Services/OrderEmailService.php` | Modified | Added `sendOrderStatusNotification()` |
+| `app/Http/Controllers/Api/Admin/AdminOrderController.php` | Modified | Hook email service after status update |
+| `tests/Feature/OrderStatusEmailNotificationTest.php` | New | 8 tests |
+
+## How It Works
+
+### Hook Point
+`AdminOrderController::updateStatus()` calls `OrderEmailService::sendOrderStatusNotification()` after successful status update.
+
+### Email Trigger
+```php
+// Only shipped and delivered trigger emails
+if (in_array($newStatus, ['shipped', 'delivered'])) {
+    $this->sendEmail(...);
+}
+```
+
+## Testing
+
+### Unit Tests (8 tests, 16 assertions)
+- Feature flag disables sending
+- Shipped status sends email
+- Delivered status sends email
+- Idempotency prevents double-send (shipped)
+- Idempotency prevents double-send (delivered)
+- Other statuses don't send email
+- Missing email handled gracefully
+- Shipped and delivered are separate events
+
+## Email Content (Greek)
+
+### Shipped Email
+- Subject: "Η παραγγελία #123 στάλθηκε - Dixis"
+- Header: "Η παραγγελία σας στάλθηκε!"
+- Contains: order number, shipping address, shipping method
+
+### Delivered Email
+- Subject: "Η παραγγελία #123 παραδόθηκε - Dixis"
+- Header: "Η παραγγελία σας παραδόθηκε!"
+- Contains: order number, thank you message
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Email provider failure | Graceful failure, status still updated |
+| Double-sends | Idempotency table prevents |
+| Missing emails | Logged warning, no crash |
+| SMTP not configured | Feature flag OFF by default |
+
+---
+Generated-by: Claude (Pass 54)


### PR DESCRIPTION
## Summary
- Add email notifications when order status changes to shipped/delivered
- Reuses Pass 53 infrastructure (OrderEmailService, idempotency table, feature flag)
- Greek content for EL-first market
- Graceful failure: email errors don't crash status update

## Files Changed (8 files, +564 lines)
| File | Type | Description |
|------|------|-------------|
| `app/Mail/OrderShipped.php` | New | Shipped notification mailable |
| `app/Mail/OrderDelivered.php` | New | Delivered notification mailable |
| `resources/views/emails/orders/shipped.blade.php` | New | Shipped email template |
| `resources/views/emails/orders/delivered.blade.php` | New | Delivered email template |
| `app/Services/OrderEmailService.php` | Modified | Added `sendOrderStatusNotification()` |
| `app/Http/Controllers/Api/Admin/AdminOrderController.php` | Modified | Hook email service |
| `tests/Feature/OrderStatusEmailNotificationTest.php` | New | 8 tests, 16 assertions |
| `docs/AGENT/SUMMARY/Pass-54.md` | New | Documentation |

## Test Plan
- [x] 8 unit tests pass (feature flag, idempotency, shipped, delivered)
- [x] Reuses Pass 53 feature flag (EMAIL_NOTIFICATIONS_ENABLED=false default)
- [x] Status update succeeds even if email fails

---
Generated-by: Claude (Pass 54)