### PR TITLE
feat(notifications): Pass 55 - Weekly producer digest emails

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -70,6 +70,10 @@ MAIL_FROM_NAME="Dixis"
 EMAIL_NOTIFICATIONS_ENABLED=false
 EMAIL_QUEUE_ENABLED=false
 
+# Pass 55: Producer Weekly Digest Feature Flag (default OFF)
+# Set to true to enable weekly digest emails to producers
+PRODUCER_DIGEST_ENABLED=false
+
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1

--- a/backend/app/Console/Commands/SendProducerWeeklyDigest.php
+++ b/backend/app/Console/Commands/SendProducerWeeklyDigest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Mail\ProducerWeeklyDigest;
+use App\Models\OrderItem;
+use App\Models\Producer;
+use App\Models\ProducerDigest;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Pass 55: Weekly producer digest command.
+ *
+ * Usage:
+ *   php artisan producers:digest-weekly          # Send digests
+ *   php artisan producers:digest-weekly --dry-run # Output counts only, no emails
+ */
+class SendProducerWeeklyDigest extends Command
+{
+    protected $signature = 'producers:digest-weekly {--dry-run : Output counts without sending emails}';
+
+    protected $description = 'Send weekly digest emails to producers with order statistics';
+
+    public function handle(): int
+    {
+        $dryRun = $this->option('dry-run');
+
+        // Check feature flag
+        if (!config('notifications.producer_digest_enabled', false)) {
+            $this->info('Pass 55: Producer digest feature is disabled (PRODUCER_DIGEST_ENABLED=false)');
+            Log::debug('Pass 55: Producer digest disabled, skipping');
+            return Command::SUCCESS;
+        }
+
+        // Calculate period: rolling 7 days ending yesterday
+        $periodEnd = Carbon::yesterday()->toDateString();
+        $periodStart = Carbon::yesterday()->subDays(6)->toDateString();
+
+        $this->info("Pass 55: Weekly Producer Digest ({$periodStart} to {$periodEnd})");
+        $this->info($dryRun ? '  Mode: DRY-RUN (no emails will be sent)' : '  Mode: LIVE');
+        $this->newLine();
+
+        // Get all producers with email
+        $producers = Producer::with('user')->get();
+
+        $sent = 0;
+        $skipped = 0;
+        $noEmail = 0;
+        $alreadySent = 0;
+
+        foreach ($producers as $producer) {
+            $email = $producer->user?->email ?? $producer->email ?? null;
+
+            if (!$email) {
+                $noEmail++;
+                if ($dryRun) {
+                    $this->warn("  [{$producer->id}] {$producer->business_name}: No email, skipped");
+                }
+                Log::warning('Pass 55: Producer has no email, skipping digest', [
+                    'producer_id' => $producer->id,
+                ]);
+                continue;
+            }
+
+            // Idempotency check
+            if (ProducerDigest::alreadySent($producer->id, $periodStart)) {
+                $alreadySent++;
+                if ($dryRun) {
+                    $this->comment("  [{$producer->id}] {$producer->business_name}: Already sent for this period");
+                }
+                Log::debug('Pass 55: Digest already sent for period, skipping', [
+                    'producer_id' => $producer->id,
+                    'period_start' => $periodStart,
+                ]);
+                continue;
+            }
+
+            // Build stats for this producer
+            $stats = $this->buildProducerStats($producer->id, $periodStart, $periodEnd);
+            $stats['period_start'] = $periodStart;
+            $stats['period_end'] = $periodEnd;
+
+            if ($dryRun) {
+                $this->info("  [{$producer->id}] {$producer->business_name}:");
+                $this->line("    Orders: {$stats['orders_count']}, Revenue: €" . number_format($stats['gross_revenue'], 2));
+                $this->line("    Pending: {$stats['pending_count']}, Delivered: {$stats['delivered_count']}");
+                if (!empty($stats['top_products'])) {
+                    $topNames = collect($stats['top_products'])->pluck('name')->join(', ');
+                    $this->line("    Top products: {$topNames}");
+                }
+                $sent++;
+                continue;
+            }
+
+            // Send email
+            try {
+                Mail::to($email)->send(new ProducerWeeklyDigest($producer, $stats));
+
+                ProducerDigest::recordSent(
+                    $producer->id,
+                    $periodStart,
+                    $periodEnd,
+                    $email,
+                    $stats['orders_count'],
+                    $stats['gross_revenue']
+                );
+
+                $sent++;
+                $this->info("  [{$producer->id}] Sent to {$this->maskEmail($email)}");
+                Log::info('Pass 55: Producer weekly digest sent', [
+                    'producer_id' => $producer->id,
+                    'email' => $this->maskEmail($email),
+                    'orders_count' => $stats['orders_count'],
+                ]);
+            } catch (\Exception $e) {
+                $skipped++;
+                $this->error("  [{$producer->id}] Failed: {$e->getMessage()}");
+                Log::error('Pass 55: Failed to send producer digest', [
+                    'producer_id' => $producer->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        $this->newLine();
+        $this->info("Summary: Sent={$sent}, Skipped={$skipped}, NoEmail={$noEmail}, AlreadySent={$alreadySent}");
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Build statistics for a producer for the given period.
+     */
+    protected function buildProducerStats(int $producerId, string $periodStart, string $periodEnd): array
+    {
+        // Get order items for this producer in the period
+        $items = OrderItem::where('producer_id', $producerId)
+            ->whereHas('order', function ($query) use ($periodStart, $periodEnd) {
+                $query->whereBetween('created_at', [
+                    Carbon::parse($periodStart)->startOfDay(),
+                    Carbon::parse($periodEnd)->endOfDay(),
+                ]);
+            })
+            ->with('order')
+            ->get();
+
+        // Unique orders
+        $orderIds = $items->pluck('order_id')->unique();
+        $ordersCount = $orderIds->count();
+
+        // Gross revenue (sum of line totals for this producer)
+        $grossRevenue = $items->sum('total_price');
+
+        // Pending vs delivered counts
+        $orders = $items->pluck('order')->unique('id');
+        $pendingCount = $orders->whereIn('status', ['pending', 'confirmed', 'processing'])->count();
+        $deliveredCount = $orders->where('status', 'delivered')->count();
+
+        // Top 3 products by quantity
+        $topProducts = $items->groupBy('product_id')
+            ->map(function ($group) {
+                return [
+                    'name' => $group->first()->product_name ?? 'Unknown',
+                    'quantity' => $group->sum('quantity'),
+                ];
+            })
+            ->sortByDesc('quantity')
+            ->take(3)
+            ->values()
+            ->toArray();
+
+        return [
+            'orders_count' => $ordersCount,
+            'gross_revenue' => (float) $grossRevenue,
+            'pending_count' => $pendingCount,
+            'delivered_count' => $deliveredCount,
+            'top_products' => $topProducts,
+        ];
+    }
+
+    /**
+     * Mask email for logging (privacy).
+     */
+    protected function maskEmail(string $email): string
+    {
+        $parts = explode('@', $email);
+        if (count($parts) !== 2) {
+            return '***';
+        }
+        return substr($parts[0], 0, 2) . '***@' . $parts[1];
+    }
+}

--- a/backend/app/Mail/ProducerWeeklyDigest.php
+++ b/backend/app/Mail/ProducerWeeklyDigest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Producer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Pass 55: Weekly digest email for producers (Greek).
+ */
+class ProducerWeeklyDigest extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public Producer $producer,
+        public array $stats
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        $periodStart = $this->stats['period_start'];
+        $periodEnd = $this->stats['period_end'];
+
+        return new Envelope(
+            subject: "Εβδομαδιαία Αναφορά ({$periodStart} - {$periodEnd}) - Dixis",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.producers.weekly-digest',
+            with: [
+                'producer' => $this->producer,
+                'producerName' => $this->producer->business_name ?? $this->producer->user?->name ?? 'Παραγωγός',
+                'periodStart' => $this->stats['period_start'],
+                'periodEnd' => $this->stats['period_end'],
+                'ordersCount' => $this->stats['orders_count'],
+                'grossRevenue' => number_format($this->stats['gross_revenue'], 2),
+                'pendingCount' => $this->stats['pending_count'],
+                'deliveredCount' => $this->stats['delivered_count'],
+                'topProducts' => $this->stats['top_products'],
+            ],
+        );
+    }
+}

--- a/backend/app/Models/ProducerDigest.php
+++ b/backend/app/Models/ProducerDigest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Pass 55: Idempotency tracking for producer weekly digests.
+ * Prevents double-sends for the same period.
+ */
+class ProducerDigest extends Model
+{
+    protected $fillable = [
+        'producer_id',
+        'period_start',
+        'period_end',
+        'recipient_email',
+        'orders_count',
+        'gross_revenue',
+        'sent_at',
+    ];
+
+    protected $casts = [
+        'period_start' => 'date',
+        'period_end' => 'date',
+        'sent_at' => 'datetime',
+        'gross_revenue' => 'decimal:2',
+    ];
+
+    public function producer(): BelongsTo
+    {
+        return $this->belongsTo(Producer::class);
+    }
+
+    /**
+     * Check if digest already sent for this producer and period.
+     */
+    public static function alreadySent(int $producerId, string $periodStart): bool
+    {
+        return self::where('producer_id', $producerId)
+            ->where('period_start', $periodStart)
+            ->exists();
+    }
+
+    /**
+     * Record that a digest was sent.
+     */
+    public static function recordSent(
+        int $producerId,
+        string $periodStart,
+        string $periodEnd,
+        string $email,
+        int $ordersCount,
+        float $grossRevenue
+    ): self {
+        return self::create([
+            'producer_id' => $producerId,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+            'recipient_email' => $email,
+            'orders_count' => $ordersCount,
+            'gross_revenue' => $grossRevenue,
+            'sent_at' => now(),
+        ]);
+    }
+}

--- a/backend/config/notifications.php
+++ b/backend/config/notifications.php
@@ -40,4 +40,15 @@ return [
     */
     'queue_enabled' => env('EMAIL_QUEUE_ENABLED', false),
     'queue_name' => env('EMAIL_QUEUE_NAME', 'emails'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pass 55: Producer Weekly Digest Feature Flag
+    |--------------------------------------------------------------------------
+    |
+    | When false (default), weekly digest emails are not sent.
+    | Enable separately from transactional emails.
+    |
+    */
+    'producer_digest_enabled' => env('PRODUCER_DIGEST_ENABLED', false),
 ];

--- a/backend/database/migrations/2025_12_28_190000_create_producer_digests_table.php
+++ b/backend/database/migrations/2025_12_28_190000_create_producer_digests_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Pass 55: Idempotency tracking for producer weekly digests.
+ * Prevents double-sends for the same period.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('producer_digests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('producer_id')->constrained()->onDelete('cascade');
+            $table->date('period_start'); // First day of digest period
+            $table->date('period_end');   // Last day of digest period
+            $table->string('recipient_email');
+            $table->integer('orders_count')->default(0);
+            $table->decimal('gross_revenue', 10, 2)->default(0);
+            $table->timestamp('sent_at');
+            $table->timestamps();
+
+            // Unique constraint: one digest per producer per period
+            $table->unique(['producer_id', 'period_start'], 'producer_digests_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('producer_digests');
+    }
+};

--- a/backend/resources/views/emails/producers/weekly-digest.blade.php
+++ b/backend/resources/views/emails/producers/weekly-digest.blade.php
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="el">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Εβδομαδιαία Αναφορά - Dixis</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: #059669; color: white; padding: 20px; text-align: center; border-radius: 8px 8px 0 0; }
+        .content { background: #f9fafb; padding: 20px; border: 1px solid #e5e7eb; }
+        .footer { text-align: center; padding: 20px; color: #6b7280; font-size: 14px; }
+        .stat-box { background: white; border: 1px solid #e5e7eb; border-radius: 8px; padding: 15px; margin: 10px 0; text-align: center; }
+        .stat-value { font-size: 28px; font-weight: bold; color: #059669; }
+        .stat-label { color: #6b7280; font-size: 14px; }
+        .stats-grid { display: flex; flex-wrap: wrap; gap: 10px; }
+        .stats-grid .stat-box { flex: 1; min-width: 120px; }
+        .products-list { background: white; border: 1px solid #e5e7eb; border-radius: 8px; padding: 15px; margin: 15px 0; }
+        .product-item { padding: 8px 0; border-bottom: 1px solid #f3f4f6; }
+        .product-item:last-child { border-bottom: none; }
+        .period { color: #6b7280; font-size: 14px; margin-bottom: 15px; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>Εβδομαδιαία Αναφορά</h1>
+        <p style="margin: 0; opacity: 0.9;">{{ $producerName }}</p>
+    </div>
+
+    <div class="content">
+        <p class="period">Περίοδος: {{ $periodStart }} - {{ $periodEnd }}</p>
+
+        <div class="stats-grid">
+            <div class="stat-box">
+                <div class="stat-value">{{ $ordersCount }}</div>
+                <div class="stat-label">Παραγγελίες</div>
+            </div>
+            <div class="stat-box">
+                <div class="stat-value">€{{ $grossRevenue }}</div>
+                <div class="stat-label">Έσοδα</div>
+            </div>
+        </div>
+
+        <div class="stats-grid">
+            <div class="stat-box">
+                <div class="stat-value">{{ $pendingCount }}</div>
+                <div class="stat-label">Σε αναμονή</div>
+            </div>
+            <div class="stat-box">
+                <div class="stat-value">{{ $deliveredCount }}</div>
+                <div class="stat-label">Παραδοθέντα</div>
+            </div>
+        </div>
+
+        @if(count($topProducts) > 0)
+        <div class="products-list">
+            <h3 style="margin-top: 0;">Κορυφαία Προϊόντα</h3>
+            @foreach($topProducts as $product)
+            <div class="product-item">
+                <strong>{{ $product['name'] }}</strong>
+                <span style="float: right; color: #059669;">{{ $product['quantity'] }} τεμ.</span>
+            </div>
+            @endforeach
+        </div>
+        @endif
+
+        @if($ordersCount == 0)
+        <p style="text-align: center; color: #6b7280; margin-top: 20px;">
+            Δεν υπάρχουν παραγγελίες αυτή την εβδομάδα.
+        </p>
+        @endif
+    </div>
+
+    <div class="footer">
+        <p>Dixis - Φρέσκα προϊόντα από τοπικούς παραγωγούς</p>
+        <p>&copy; {{ date('Y') }} Dixis. Με επιφύλαξη παντός δικαιώματος.</p>
+    </div>
+</body>
+</html>

--- a/backend/routes/console.php
+++ b/backend/routes/console.php
@@ -2,7 +2,26 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+/*
+|--------------------------------------------------------------------------
+| Pass 55: Weekly Producer Digest Schedule
+|--------------------------------------------------------------------------
+|
+| Runs every Monday at 09:00 Europe/Athens time.
+| Requires: PRODUCER_DIGEST_ENABLED=true in .env
+|
+| VPS cron line (if scheduler not set up):
+| * * * * * cd /var/www/dixis/current/backend && php artisan schedule:run >> /dev/null 2>&1
+|
+*/
+Schedule::command('producers:digest-weekly')
+    ->weeklyOn(1, '09:00')  // Monday at 09:00
+    ->timezone('Europe/Athens')
+    ->withoutOverlapping()
+    ->runInBackground();

--- a/backend/tests/Feature/ProducerWeeklyDigestTest.php
+++ b/backend/tests/Feature/ProducerWeeklyDigestTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\ProducerWeeklyDigest;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Producer;
+use App\Models\ProducerDigest;
+use App\Models\Product;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * Pass 55: Producer Weekly Digest Tests.
+ *
+ * Tests:
+ * - Feature flag disables command
+ * - Idempotency prevents double-sends
+ * - Correct aggregates calculated
+ * - Missing email handled gracefully
+ */
+class ProducerWeeklyDigestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Mail::fake();
+    }
+
+    /** @test */
+    public function command_sends_nothing_when_feature_flag_disabled()
+    {
+        Config::set('notifications.producer_digest_enabled', false);
+
+        $producerUser = User::factory()->create(['email' => 'producer@test.com']);
+        $producer = Producer::factory()->create(['user_id' => $producerUser->id]);
+
+        $this->artisan('producers:digest-weekly')
+            ->assertSuccessful();
+
+        Mail::assertNothingSent();
+        $this->assertEquals(0, ProducerDigest::count());
+    }
+
+    /** @test */
+    public function command_sends_digest_when_feature_enabled()
+    {
+        Config::set('notifications.producer_digest_enabled', true);
+
+        $producerUser = User::factory()->create(['email' => 'producer@test.com']);
+        $producer = Producer::factory()->create(['user_id' => $producerUser->id]);
+
+        // Create an order with items for this producer within the last 7 days
+        $product = Product::factory()->create(['producer_id' => $producer->id, 'price' => 10.00]);
+        $order = Order::factory()->create([
+            'created_at' => Carbon::yesterday(),
+            'status' => 'pending',
+        ]);
+        OrderItem::factory()->create([
+            'order_id' => $order->id,
+            'product_id' => $product->id,
+            'producer_id' => $producer->id,
+            'quantity' => 3,
+            'unit_price' => 10.00,
+            'total_price' => 30.00,
+            'product_name' => 'Test Product',
+        ]);
+
+        $this->artisan('producers:digest-weekly')
+            ->assertSuccessful();
+
+        Mail::assertSent(ProducerWeeklyDigest::class, function ($mail) use ($producer) {
+            return $mail->producer->id === $producer->id;
+        });
+
+        $this->assertEquals(1, ProducerDigest::count());
+    }
+
+    /** @test */
+    public function idempotency_prevents_double_send()
+    {
+        Config::set('notifications.producer_digest_enabled', true);
+
+        $producerUser = User::factory()->create(['email' => 'producer@test.com']);
+        $producer = Producer::factory()->create(['user_id' => $producerUser->id]);
+
+        // Run command twice
+        $this->artisan('producers:digest-weekly')->assertSuccessful();
+        $this->artisan('producers:digest-weekly')->assertSuccessful();
+
+        // Only ONE email sent
+        Mail::assertSent(ProducerWeeklyDigest::class, 1);
+        $this->assertEquals(1, ProducerDigest::count());
+    }
+
+    /** @test */
+    public function command_calculates_correct_aggregates()
+    {
+        Config::set('notifications.producer_digest_enabled', true);
+
+        $producerUser = User::factory()->create(['email' => 'producer@test.com']);
+        $producer = Producer::factory()->create(['user_id' => $producerUser->id]);
+
+        // Create product
+        $product = Product::factory()->create(['producer_id' => $producer->id]);
+
+        // Order 1: pending, yesterday
+        $order1 = Order::factory()->create([
+            'created_at' => Carbon::yesterday(),
+            'status' => 'pending',
+        ]);
+        OrderItem::factory()->create([
+            'order_id' => $order1->id,
+            'product_id' => $product->id,
+            'producer_id' => $producer->id,
+            'quantity' => 2,
+            'total_price' => 20.00,
+            'product_name' => 'Product A',
+        ]);
+
+        // Order 2: delivered, 3 days ago
+        $order2 = Order::factory()->create([
+            'created_at' => Carbon::now()->subDays(3),
+            'status' => 'delivered',
+        ]);
+        OrderItem::factory()->create([
+            'order_id' => $order2->id,
+            'product_id' => $product->id,
+            'producer_id' => $producer->id,
+            'quantity' => 5,
+            'total_price' => 50.00,
+            'product_name' => 'Product A',
+        ]);
+
+        $this->artisan('producers:digest-weekly')->assertSuccessful();
+
+        // Verify digest was sent with correct stats
+        Mail::assertSent(ProducerWeeklyDigest::class, function ($mail) {
+            // 2 orders, €70 revenue, 1 pending, 1 delivered
+            return $mail->stats['orders_count'] === 2
+                && $mail->stats['gross_revenue'] === 70.0
+                && $mail->stats['pending_count'] === 1
+                && $mail->stats['delivered_count'] === 1;
+        });
+    }
+
+    /** @test */
+    public function missing_email_handled_gracefully()
+    {
+        Config::set('notifications.producer_digest_enabled', true);
+
+        // Producer without user and without email
+        $producer = Producer::factory()->create(['user_id' => null, 'email' => null]);
+
+        $this->artisan('producers:digest-weekly')
+            ->assertSuccessful();
+
+        // No email sent, no crash
+        Mail::assertNothingSent();
+        $this->assertEquals(0, ProducerDigest::count());
+    }
+
+    /** @test */
+    public function dry_run_outputs_counts_without_sending()
+    {
+        Config::set('notifications.producer_digest_enabled', true);
+
+        $producerUser = User::factory()->create(['email' => 'producer@test.com']);
+        $producer = Producer::factory()->create([
+            'user_id' => $producerUser->id,
+            'business_name' => 'Test Farm',
+        ]);
+
+        $this->artisan('producers:digest-weekly', ['--dry-run' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('DRY-RUN');
+
+        // No email sent in dry-run
+        Mail::assertNothingSent();
+        // No digest record created in dry-run
+        $this->assertEquals(0, ProducerDigest::count());
+    }
+
+    /** @test */
+    public function orders_outside_period_are_excluded()
+    {
+        Config::set('notifications.producer_digest_enabled', true);
+
+        $producerUser = User::factory()->create(['email' => 'producer@test.com']);
+        $producer = Producer::factory()->create(['user_id' => $producerUser->id]);
+        $product = Product::factory()->create(['producer_id' => $producer->id]);
+
+        // Order from 10 days ago (outside 7-day rolling window)
+        $oldOrder = Order::factory()->create([
+            'created_at' => Carbon::now()->subDays(10),
+            'status' => 'delivered',
+        ]);
+        OrderItem::factory()->create([
+            'order_id' => $oldOrder->id,
+            'product_id' => $product->id,
+            'producer_id' => $producer->id,
+            'quantity' => 100,
+            'total_price' => 1000.00,
+        ]);
+
+        $this->artisan('producers:digest-weekly')->assertSuccessful();
+
+        // Digest sent but with 0 orders (old order excluded)
+        Mail::assertSent(ProducerWeeklyDigest::class, function ($mail) {
+            return $mail->stats['orders_count'] === 0
+                && $mail->stats['gross_revenue'] === 0.0;
+        });
+    }
+}

--- a/docs/AGENT/SUMMARY/Pass-55.md
+++ b/docs/AGENT/SUMMARY/Pass-55.md
@@ -1,0 +1,123 @@
+# Pass 55 - Weekly Producer Digest
+
+**Date**: 2025-12-28
+**Status**: COMPLETE
+**PR**: (pending)
+
+## Problem Statement
+
+Producers have no summary of their weekly order activity. They must manually check the dashboard to understand their performance.
+
+## Solution
+
+### Feature Flag
+`PRODUCER_DIGEST_ENABLED=false` (default OFF, separate from transactional emails)
+
+### Artisan Command
+```bash
+# Send digests (live mode)
+php artisan producers:digest-weekly
+
+# Dry-run mode (output counts, no emails)
+php artisan producers:digest-weekly --dry-run
+```
+
+### Schedule
+- Runs: Every Monday at 09:00 Europe/Athens
+- VPS cron: `* * * * * cd /var/www/dixis/current/backend && php artisan schedule:run >> /dev/null 2>&1`
+
+### Digest Contents (Rolling 7 Days)
+- Total orders count
+- Gross revenue (sum of line totals)
+- Top 3 products by quantity
+- Pending orders count
+- Delivered orders count
+
+### Idempotency
+- New `producer_digests` table
+- Unique key: (producer_id, period_start)
+- Prevents double-sends for same period
+
+### Graceful Failure
+- Missing email addresses logged, not thrown
+- Email failures don't crash the command
+- Summary output at end shows sent/skipped/noEmail counts
+
+## Files Changed
+
+| File | Type | Description |
+|------|------|-------------|
+| `database/migrations/2025_12_28_190000_...` | New | Idempotency table |
+| `config/notifications.php` | Modified | Add `producer_digest_enabled` flag |
+| `app/Models/ProducerDigest.php` | New | Idempotency model |
+| `app/Mail/ProducerWeeklyDigest.php` | New | Digest mailable |
+| `resources/views/emails/producers/weekly-digest.blade.php` | New | Email template |
+| `app/Console/Commands/SendProducerWeeklyDigest.php` | New | Artisan command |
+| `routes/console.php` | Modified | Add weekly schedule |
+| `backend/.env.example` | Modified | Add PRODUCER_DIGEST_ENABLED |
+| `tests/Feature/ProducerWeeklyDigestTest.php` | New | 7 tests |
+
+## How to Enable
+
+### Backend (.env)
+```bash
+# Enable weekly producer digest
+PRODUCER_DIGEST_ENABLED=true
+
+# Make sure SMTP is configured
+MAIL_MAILER=smtp
+MAIL_HOST=smtp.example.com
+...
+```
+
+### Manual Run
+```bash
+# Dry-run first to see what would be sent
+php artisan producers:digest-weekly --dry-run
+
+# Then run for real
+php artisan producers:digest-weekly
+```
+
+### VPS Scheduler Setup
+If Laravel scheduler is not yet configured, add this cron:
+```bash
+crontab -e
+# Add:
+* * * * * cd /var/www/dixis/current/backend && php artisan schedule:run >> /dev/null 2>&1
+```
+
+## Testing
+
+### Unit Tests (7 tests, 21 assertions)
+- Flag OFF: command sends nothing
+- Flag ON: digest sent
+- Idempotency prevents double-send
+- Correct aggregates calculated
+- Missing email handled gracefully
+- Dry-run outputs counts without sending
+- Orders outside period excluded
+
+## Email Content (Greek)
+
+### Subject
+"Εβδομαδιαία Αναφορά (2025-12-21 - 2025-12-27) - Dixis"
+
+### Body
+- Producer name
+- Period dates
+- Stats grid: Orders count, Revenue (€)
+- Status counts: Pending, Delivered
+- Top 3 products list
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Double-sends | Idempotency table prevents |
+| Missing emails | Logged warning, skip producer |
+| SMTP not configured | Feature flag OFF by default |
+| Scheduler not running | Document VPS cron line |
+
+---
+Generated-by: Claude (Pass 55)


### PR DESCRIPTION
## Summary
- Add weekly producer digest emails with order statistics (rolling 7 days)
- Feature flag `PRODUCER_DIGEST_ENABLED=false` (default OFF)
- Idempotency table prevents double-sends for same period
- Artisan command with `--dry-run` option for testing
- Scheduled: Every Monday at 09:00 Europe/Athens

## Changes
| File | Type | Description |
|------|------|-------------|
| `database/migrations/2025_12_28_190000_...` | New | Idempotency table |
| `config/notifications.php` | Modified | Add `producer_digest_enabled` flag |
| `app/Models/ProducerDigest.php` | New | Idempotency model |
| `app/Mail/ProducerWeeklyDigest.php` | New | Digest mailable |
| `resources/views/emails/producers/weekly-digest.blade.php` | New | Email template (Greek) |
| `app/Console/Commands/SendProducerWeeklyDigest.php` | New | Artisan command |
| `routes/console.php` | Modified | Add weekly schedule |
| `backend/.env.example` | Modified | Add PRODUCER_DIGEST_ENABLED |
| `tests/Feature/ProducerWeeklyDigestTest.php` | New | 7 tests, 21 assertions |

## Digest Contents
- Total orders count
- Gross revenue (sum of line totals)
- Top 3 products by quantity
- Pending orders count
- Delivered orders count

## How to Enable
```bash
# Backend .env
PRODUCER_DIGEST_ENABLED=true

# Manual run
php artisan producers:digest-weekly --dry-run  # Test first
php artisan producers:digest-weekly            # Send live
```

## Test Plan
- [x] Feature flag OFF: command sends nothing
- [x] Feature flag ON: digest sent
- [x] Idempotency prevents double-send
- [x] Correct aggregates calculated
- [x] Missing email handled gracefully
- [x] Dry-run outputs counts without sending
- [x] Orders outside period excluded

## Evidence
- Tests: 7 tests, 21 assertions PASS

---
Generated-by: Claude (Pass 55)