### PR TITLE
fix(ci): stabilize smoke-production with healthz readiness gate (Pass 63)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-63.md
+++ b/docs/AGENT/SUMMARY/Pass-63.md
@@ -1,0 +1,69 @@
+# Pass 63 — Smoke Readiness Gate
+
+**Date**: 2025-12-29
+**Status**: IN REVIEW
+**PR**: #TBD
+
+## TL;DR
+
+Stabilized flaky smoke-production/auth-probe CI tests by adding healthz readiness gate with exponential backoff. Tests now wait for production to be ready before running, preventing cold-start timeouts.
+
+## Problem
+
+The `smoke.yml` workflow running `auth-probe.spec.ts` against `https://dixis.gr` was failing intermittently:
+- `ci-global-setup.ts` timed out (30s) navigating to production
+- `healthz returns 200` test timed out (10s)
+- `landing renders & shows brand text` test failed with `net::ERR_ABORTED`
+
+Root cause: Production cold-starts or transient slowness caused tests to fail before the site was ready.
+
+## Solution
+
+Added readiness gate pattern:
+1. **New helper**: `frontend/tests/e2e/helpers/readiness.ts`
+   - `waitForReadiness()`: Polls `/api/healthz` with exponential backoff (2s, 4s, 8s, 15s, 15s, 15s = ~60s total)
+   - Logs progress and continues gracefully if production remains unavailable
+
+2. **Updated `auth-probe.spec.ts`**:
+   - `test.beforeAll()` waits for production readiness before any tests
+   - Increased test timeout: 60s → 90s
+   - Increased healthz request timeout: 10s → 30s
+   - Increased navigation timeout: default → 45s
+   - Added `test.describe.configure({ retries: 2 })` for this spec only
+
+3. **Updated `ci-global-setup.ts`**:
+   - Added `waitForHealthz()` function with same backoff pattern
+   - Waits for production before attempting navigation
+   - Increased navigation timeout: 30s → 60s
+
+## What Changed
+
+| File | Type | Description |
+|------|------|-------------|
+| `frontend/tests/e2e/helpers/readiness.ts` | New | Readiness helper with exponential backoff |
+| `frontend/tests/e2e/auth-probe.spec.ts` | Modified | Added readiness gate, increased timeouts, 2 retries |
+| `frontend/tests/e2e/setup/ci-global-setup.ts` | Modified | Added healthz wait before navigation |
+
+## Backoff Strategy
+
+```
+Attempt 1: wait 2s, request (15s timeout)
+Attempt 2: wait 4s, request (15s timeout)
+Attempt 3: wait 8s, request (15s timeout)
+Attempt 4: wait 15s, request (15s timeout)
+Attempt 5: wait 15s, request (15s timeout)
+Attempt 6: no wait, request (15s timeout)
+Total: ~60s max wait time
+```
+
+## Risks Mitigated
+
+| Risk | Mitigation |
+|------|------------|
+| Cold-start timeout | Readiness gate warms up site before tests |
+| Transient network issues | Exponential backoff with retries |
+| CI flakiness | 2 retries for auth-probe spec only |
+| Still fails if truly down | Clear error messages, doesn't block merges (Pass 47 policy) |
+
+---
+Generated-by: Claude (Pass 63)

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,6 +1,6 @@
 # OPS STATE
 
-**Last Updated**: 2025-12-29 (Pass 62)
+**Last Updated**: 2025-12-29 (Pass 63)
 
 ## TODO (tomorrow)
 - (none)
@@ -107,7 +107,7 @@
 - Cart persistence verified across domains
 
 ## IN PROGRESS → (WIP=1 ONLY)
-- (none)
+- **Pass 63 — Smoke Readiness Gate**: Stabilizing smoke-production/auth-probe flakiness by adding healthz readiness check with exponential backoff before running tests. Branch: `fix/pass63-smoke-readiness-gate`. PR: pending.
 
 ## BLOCKED ⚠️
 - (none)

--- a/frontend/tests/e2e/auth-probe.spec.ts
+++ b/frontend/tests/e2e/auth-probe.spec.ts
@@ -1,20 +1,55 @@
+/**
+ * Pass 63: Smoke tests with readiness gate
+ *
+ * Waits for production /api/healthz before running tests.
+ * Prevents flaky failures when production is cold-starting.
+ */
 import { test, expect, request } from '@playwright/test';
+import { waitForReadiness } from './helpers/readiness';
 
 const BASE =
   process.env.PLAYWRIGHT_BASE_URL ||
   process.env.BASE_URL ||
   'http://localhost:3000';
 
-test.setTimeout(60_000);
+// Generous timeout for smoke tests against production
+test.setTimeout(90_000);
+
+// Configure retries for this spec only (CI flakiness mitigation)
+test.describe.configure({ retries: 2 });
+
+// Wait for production to be ready before running any tests
+test.beforeAll(async () => {
+  const result = await waitForReadiness({
+    baseUrl: BASE,
+    maxAttempts: 6,      // ~60s total with backoff
+    initialDelayMs: 2000,
+    maxDelayMs: 15000,
+    timeoutMs: 15000,    // Per-request timeout
+  });
+
+  if (!result.ready) {
+    console.warn(`⚠️ Production may be unavailable: ${result.lastError}`);
+    // Don't fail here - let individual tests fail with clearer errors
+  }
+});
 
 test('healthz returns 200', async () => {
   const ctx = await request.newContext();
-  const res = await ctx.get(`${BASE}/api/healthz`, { timeout: 10_000 });
+  // Increased timeout: production may be slow after cold start
+  const res = await ctx.get(`${BASE}/api/healthz`, { timeout: 30_000 });
   expect(res.ok()).toBeTruthy();
+  await ctx.dispose();
 });
 
 test('landing renders & shows brand text', async ({ page }) => {
-  const resp = await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded' });
+  // Increased timeout for production navigation
+  const resp = await page.goto(`${BASE}/`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 45_000,
+  });
   expect(resp?.ok()).toBeTruthy();
-  await expect(page.locator('body')).toContainText(/Dixis|Φρέσκα|Fresh Products/i);
+  await expect(page.locator('body')).toContainText(/Dixis|Φρέσκα|Fresh Products/i, {
+    timeout: 15_000,
+  });
 });

--- a/frontend/tests/e2e/helpers/readiness.ts
+++ b/frontend/tests/e2e/helpers/readiness.ts
@@ -1,0 +1,89 @@
+/**
+ * Pass 63: Readiness helper for smoke tests
+ *
+ * Polls /api/healthz with exponential backoff before running smoke tests.
+ * Prevents flaky failures when production is cold-starting or temporarily slow.
+ */
+import { request } from '@playwright/test';
+
+interface ReadinessOptions {
+  baseUrl: string;
+  maxAttempts?: number;      // Default: 6 (~60s total with backoff)
+  initialDelayMs?: number;   // Default: 2000
+  maxDelayMs?: number;       // Default: 15000
+  timeoutMs?: number;        // Per-request timeout. Default: 10000
+}
+
+interface ReadinessResult {
+  ready: boolean;
+  attempts: number;
+  totalTimeMs: number;
+  lastError?: string;
+}
+
+/**
+ * Wait for production to be ready by polling /api/healthz
+ * Uses exponential backoff: 2s, 4s, 8s, 15s, 15s, 15s (max ~60s total)
+ */
+export async function waitForReadiness(options: ReadinessOptions): Promise<ReadinessResult> {
+  const {
+    baseUrl,
+    maxAttempts = 6,
+    initialDelayMs = 2000,
+    maxDelayMs = 15000,
+    timeoutMs = 10000,
+  } = options;
+
+  const healthzUrl = `${baseUrl}/api/healthz`;
+  const startTime = Date.now();
+  let attempts = 0;
+  let lastError: string | undefined;
+
+  console.log(`🔍 Readiness check: ${healthzUrl}`);
+
+  for (let i = 0; i < maxAttempts; i++) {
+    attempts++;
+    const delay = Math.min(initialDelayMs * Math.pow(2, i), maxDelayMs);
+
+    try {
+      const ctx = await request.newContext();
+      const res = await ctx.get(healthzUrl, { timeout: timeoutMs });
+
+      if (res.ok()) {
+        const totalTimeMs = Date.now() - startTime;
+        console.log(`✅ Production ready after ${attempts} attempt(s), ${totalTimeMs}ms`);
+        await ctx.dispose();
+        return { ready: true, attempts, totalTimeMs };
+      }
+
+      lastError = `HTTP ${res.status()}`;
+      await ctx.dispose();
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+
+    // Don't wait after last attempt
+    if (i < maxAttempts - 1) {
+      console.log(`   Attempt ${attempts}/${maxAttempts} failed (${lastError}), retrying in ${delay}ms...`);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  const totalTimeMs = Date.now() - startTime;
+  console.log(`❌ Production not ready after ${attempts} attempts, ${totalTimeMs}ms`);
+  return { ready: false, attempts, totalTimeMs, lastError };
+}
+
+/**
+ * Simple readiness check with generous timeout (for globalSetup)
+ */
+export async function checkHealthz(baseUrl: string, timeoutMs = 15000): Promise<boolean> {
+  try {
+    const ctx = await request.newContext();
+    const res = await ctx.get(`${baseUrl}/api/healthz`, { timeout: timeoutMs });
+    await ctx.dispose();
+    return res.ok();
+  } catch {
+    return false;
+  }
+}

--- a/frontend/tests/e2e/setup/ci-global-setup.ts
+++ b/frontend/tests/e2e/setup/ci-global-setup.ts
@@ -1,24 +1,66 @@
-import { chromium } from '@playwright/test';
+import { chromium, request } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 
 /**
  * Pass 46: CI-specific globalSetup for deterministic E2E auth
+ * Pass 63: Added readiness gate to prevent cold-start timeouts
  *
  * Creates a mock authenticated state that works with the test API server.
  * This enables running auth-dependent E2E tests in CI without real Laravel.
  *
  * Strategy:
+ * - Wait for production to be ready (healthz check with retries)
  * - Launch browser to establish origin context
  * - Set localStorage auth tokens (recognized by AuthContext MSW bridge)
  * - Save storageState for use by authenticated test projects
  */
+
+/**
+ * Wait for production healthz with exponential backoff
+ */
+async function waitForHealthz(baseUrl: string): Promise<boolean> {
+  const healthzUrl = `${baseUrl}/api/healthz`;
+  const maxAttempts = 6;
+  const initialDelayMs = 2000;
+  const maxDelayMs = 15000;
+
+  console.log(`🔍 Checking production readiness: ${healthzUrl}`);
+
+  for (let i = 0; i < maxAttempts; i++) {
+    const delay = Math.min(initialDelayMs * Math.pow(2, i), maxDelayMs);
+
+    try {
+      const ctx = await request.newContext();
+      const res = await ctx.get(healthzUrl, { timeout: 15000 });
+      await ctx.dispose();
+
+      if (res.ok()) {
+        console.log(`✅ Production ready after ${i + 1} attempt(s)`);
+        return true;
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (i < maxAttempts - 1) {
+        console.log(`   Attempt ${i + 1}/${maxAttempts} failed (${msg}), retrying in ${delay}ms...`);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  console.log(`⚠️ Production may be slow, proceeding anyway...`);
+  return false;
+}
+
 async function ciGlobalSetup() {
   const baseURL = process.env.BASE_URL || process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000';
   const storageStatePath = path.join(__dirname, '../../../test-results/storageState.json');
 
   console.log('🔐 Pass 46: CI Global Setup - Creating mock auth state');
   console.log(`   Base URL: ${baseURL}`);
+
+  // Pass 63: Wait for production to be ready before attempting navigation
+  await waitForHealthz(baseURL);
 
   // Ensure test-results directory exists
   const testResultsDir = path.dirname(storageStatePath);
@@ -32,8 +74,9 @@ async function ciGlobalSetup() {
 
   try {
     // Navigate to establish origin (required for localStorage access)
+    // Pass 63: Increased timeout after readiness gate should have warmed up the site
     console.log('   Navigating to establish origin context...');
-    await page.goto(baseURL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.goto(baseURL, { waitUntil: 'domcontentloaded', timeout: 60000 });
 
     // Set mock authentication state in localStorage
     // These keys are recognized by AuthContext's MSW bridge (see AuthContext.tsx:38)


### PR DESCRIPTION
## Summary
- Adds healthz readiness gate to prevent smoke test failures during production cold-starts
- Polls `/api/healthz` with exponential backoff (2s, 4s, 8s, 15s...) up to ~60s total
- Increases test timeouts and adds 2 retries for auth-probe spec only

## Changes
| File | Description |
|------|-------------|
| `frontend/tests/e2e/helpers/readiness.ts` | NEW: Readiness helper with exponential backoff |
| `frontend/tests/e2e/auth-probe.spec.ts` | Added readiness gate, increased timeouts, 2 retries |
| `frontend/tests/e2e/setup/ci-global-setup.ts` | Added healthz wait before navigation |
| `docs/OPS/STATE.md` | Updated with Pass 63 |
| `docs/AGENT/SUMMARY/Pass-63.md` | NEW: Pass summary |

## Problem Solved
The `smoke.yml` workflow was failing intermittently with:
- `ci-global-setup.ts` timing out (30s) navigating to production
- `healthz returns 200` timing out (10s)
- `landing renders & shows brand text` failing with `net::ERR_ABORTED`

Root cause: Production cold-starts or transient slowness.

## Test plan
- [x] Type-check passes
- [ ] smoke.yml workflow should now wait for production before tests
- [ ] CI checks pass