### PR TITLE
fix(ci): add readiness gate to reload-and-css.smoke.spec.ts (Pass 63b)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-63.md
+++ b/docs/AGENT/SUMMARY/Pass-63.md
@@ -42,6 +42,7 @@ Added readiness gate pattern:
 |------|------|-------------|
 | `frontend/tests/e2e/helpers/readiness.ts` | New | Readiness helper with exponential backoff |
 | `frontend/tests/e2e/auth-probe.spec.ts` | Modified | Added readiness gate, increased timeouts, 2 retries |
+| `frontend/tests/e2e/reload-and-css.smoke.spec.ts` | Modified | Added readiness gate, increased timeouts, 2 retries |
 | `frontend/tests/e2e/setup/ci-global-setup.ts` | Modified | Added healthz wait before navigation |
 
 ## Backoff Strategy


### PR DESCRIPTION
## Summary
Follow-up to PR #1954 (Pass 63) - adds the same readiness gate pattern to `reload-and-css.smoke.spec.ts`.

## Problem
PR #1954 fixed `auth-probe.spec.ts` but `reload-and-css.smoke.spec.ts` still times out when production is cold-starting.

## Changes
- Added `waitForReadiness()` beforeAll hook (same as auth-probe)
- Increased test timeout to 120s
- Increased gotoWithRetry timeout from 30s to 60s
- Added 2 retries for CI flakiness mitigation
- Updated Pass-63 summary doc

## Test plan
- [x] Type-check passes
- [ ] CI e2e job should pass now