### PR TITLE
ops(monitor-01): add uptime monitoring with GitHub Issue alerts

### DIFF
--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -1,0 +1,115 @@
+# MONITOR-01: Production Uptime Monitor
+#
+# Runs every 10 minutes to check production health.
+# Creates GitHub Issue on failure for fast signal.
+#
+# Endpoints checked:
+# - https://dixis.gr/api/healthz (backend Laravel health)
+#
+# No external services or secrets required - uses GITHUB_TOKEN.
+
+name: uptime-monitor
+
+on:
+  schedule:
+    # Every 10 minutes
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (skip issue creation)'
+        required: false
+        default: 'false'
+        type: boolean
+
+concurrency:
+  group: uptime-monitor
+  cancel-in-progress: true
+
+jobs:
+  check-production:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check production healthz
+        id: healthz
+        run: |
+          echo "🔍 Checking https://dixis.gr/api/healthz..."
+
+          MAX_RETRIES=3
+          RETRY_DELAY=5
+          TIMEOUT=15
+
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            echo "Attempt $attempt/$MAX_RETRIES"
+
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+              --connect-timeout $TIMEOUT \
+              --max-time $TIMEOUT \
+              https://dixis.gr/api/healthz) || HTTP_CODE="000"
+
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "✅ Production healthy (HTTP $HTTP_CODE)"
+              echo "status=healthy" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            echo "⚠️ HTTP $HTTP_CODE - retrying in ${RETRY_DELAY}s..."
+            sleep $RETRY_DELAY
+          done
+
+          echo "❌ Production UNHEALTHY after $MAX_RETRIES attempts (last: HTTP $HTTP_CODE)"
+          echo "status=unhealthy" >> $GITHUB_OUTPUT
+          echo "http_code=$HTTP_CODE" >> $GITHUB_OUTPUT
+          exit 1
+
+      - name: Create issue on failure
+        if: failure() && github.event.inputs.dry_run != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '🚨 Production DOWN - healthz check failed';
+            const body = `## Production Health Check Failed
+
+            **Time**: ${new Date().toISOString()}
+            **Endpoint**: https://dixis.gr/api/healthz
+            **Last HTTP Code**: ${{ steps.healthz.outputs.http_code || 'unknown' }}
+            **Workflow Run**: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}
+
+            ## First Steps
+            1. Check if site is accessible: https://dixis.gr
+            2. SSH to VPS and check services: \`systemctl status dixis-backend dixis-frontend-launcher\`
+            3. Check logs: \`journalctl -u dixis-backend -n 50\`
+            4. See runbook: docs/OPS/MONITORING.md
+
+            ---
+            *Auto-created by uptime-monitor workflow*`;
+
+            // Check for existing open issue to avoid duplicates
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'production-down',
+              per_page: 1
+            });
+
+            if (issues.length > 0) {
+              console.log(`Existing issue #${issues[0].number} already open, adding comment`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues[0].number,
+                body: `⏰ Health check failed again at ${new Date().toISOString()}\n\nWorkflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              });
+            } else {
+              console.log('Creating new issue');
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['production-down', 'urgent']
+              });
+            }

--- a/docs/AGENT/SUMMARY/MONITOR-01.md
+++ b/docs/AGENT/SUMMARY/MONITOR-01.md
@@ -1,0 +1,61 @@
+# MONITOR-01 — Uptime Alerting
+
+**Date**: 2025-12-29
+**Status**: COMPLETE
+**PR**: #TBD
+
+## TL;DR
+
+Added automated uptime monitoring with GitHub Issue creation on failure. No external secrets required.
+
+## What Changed
+
+| File | Type | Description |
+|------|------|-------------|
+| `.github/workflows/uptime-monitor.yml` | New | Uptime monitor with GitHub Issue alerts |
+| `docs/OPS/MONITORING.md` | Modified | Added MONITOR-01 workflow docs, updated runbook to systemd |
+| `docs/OPS/STATE.md` | Modified | Added MONITOR-01 to CLOSED section |
+
+## How It Works
+
+1. **Schedule**: Every 10 minutes via cron (`*/10 * * * *`)
+2. **Check**: Curls `https://dixis.gr/api/healthz` with 3 retries, 5s delay, 15s timeout
+3. **On Success**: Workflow passes, no action
+4. **On Failure**: Creates GitHub Issue with `production-down` label
+5. **Deduplication**: If issue already open, adds comment instead of new issue
+
+## Alert Format
+
+```markdown
+🚨 Production DOWN - healthz check failed
+
+## Production Health Check Failed
+
+**Time**: 2025-12-29T10:30:00.000Z
+**Endpoint**: https://dixis.gr/api/healthz
+**Last HTTP Code**: 502
+**Workflow Run**: [link]
+
+## First Steps
+1. Check if site is accessible: https://dixis.gr
+2. SSH to VPS and check services: `systemctl status dixis-backend dixis-frontend-launcher`
+3. Check logs: `journalctl -u dixis-backend -n 50`
+4. See runbook: docs/OPS/MONITORING.md
+```
+
+## Limitations
+
+- **No external alerting**: Relies on GitHub Issue notifications (no Slack/email)
+- **GitHub dependency**: If GitHub Actions is down, no alerts fire
+- **No latency monitoring**: Only checks up/down, not response time
+- **Staging not monitored**: staging.dixis.io doesn't exist
+
+## Future Improvements
+
+1. Add Slack/email webhook notifications (requires secrets)
+2. Monitor response time (P95 latency)
+3. Add database health check endpoint
+4. Add staging monitoring when it exists
+
+---
+Generated-by: Claude (MONITOR-01)

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,6 +1,6 @@
 # OPS STATE
 
-**Last Updated**: 2025-12-29 (Pass 63)
+**Last Updated**: 2025-12-29 (MONITOR-01)
 
 ## TODO (tomorrow)
 - (none)
@@ -81,6 +81,7 @@
 - **Pass 61 Admin Dashboard Polish**: Connected admin orders dashboard to Laravel API (single source of truth). Backend: Added `GET /api/v1/admin/orders` endpoint with filters (status, q, date range), pagination, and quick stats. Frontend: API route proxies to Laravel when auth token present, demo fallback gated to CI/test only. E2E: 4 tests (page elements, filters, pagination, stats). Files: 8 changed (+420 lines). Evidence: All CI checks PASS, PR #1950 merged 2025-12-29 (commit 66fb4fad). Docs: `docs/AGENT/SUMMARY/Pass-61.md`. (Closed: 2025-12-29)
 - **Pass 62 Orders/Checkout E2E Guardrail**: Added comprehensive E2E regression test to guard the consumer checkout journey from silently breaking. Tests verify: auth → cart → checkout → orders list → order details (with producer info). 11 E2E tests covering full consumer journey with route mocking for deterministic CI behavior. Verifies Laravel API is called (not Prisma /internal). Files: 4 changed (1 new test file +352 lines, 3 docs files). Evidence: All CI checks PASS (E2E PostgreSQL 3m12s ✅), PR #1952 merged 2025-12-29 (commit f0ab0066). Docs: `docs/AGENT/SUMMARY/Pass-62.md`. (Closed: 2025-12-29)
 - **Pass 63 Smoke Readiness Gate**: Stabilized flaky smoke-production/auth-probe CI tests by adding healthz readiness gate with exponential backoff. New `readiness.ts` helper polls `/api/healthz` with backoff (2s, 4s, 8s, 15s...) up to ~60s before running tests. Applied to `auth-probe.spec.ts`, `reload-and-css.smoke.spec.ts`, and `ci-global-setup.ts`. Added 2 retries and increased timeouts (90-120s) for production smoke tests. Prevents cold-start timeouts that caused intermittent CI failures. Files: 4 changed (+277 lines). Evidence: e2e PASS (1m7s), smoke PASS (1m20s), smoke-production PASS (1m11s). PRs: #1954 merged 2025-12-29 (commit fd470679), #1956 merged 2025-12-29 (commit 05100c2f). Docs: `docs/AGENT/SUMMARY/Pass-63.md`. (Closed: 2025-12-29)
+- **MONITOR-01 Uptime Alerting**: Added automated uptime monitoring with GitHub Issue creation on failure. New workflow `.github/workflows/uptime-monitor.yml` checks `/api/healthz` every 10 minutes with 3 retries. On failure, creates GitHub Issue with `production-down` label (or adds comment to existing open issue to avoid duplicates). No external secrets required (uses GITHUB_TOKEN). Updated runbook `docs/OPS/MONITORING.md` with systemd commands and investigation playbook. **RISK**: Prod uptime relies on GitHub Actions; no external alerting (Slack/email) yet. PR: #TBD. Docs: `docs/OPS/MONITORING.md`. (Closed: 2025-12-29)
 
 ## STABLE ✓ (working with evidence)
 - **Backend health**: /api/healthz returns 200 ✅


### PR DESCRIPTION
## Summary
Add automated uptime monitoring with GitHub Issue creation on failure.

## Changes
| File | Description |
|------|-------------|
| `.github/workflows/uptime-monitor.yml` | NEW: Uptime monitor (every 10min, 3 retries, Issue on failure) |
| `docs/OPS/MONITORING.md` | Updated with MONITOR-01 docs, systemd runbook |
| `docs/OPS/STATE.md` | Added MONITOR-01 to CLOSED section |
| `docs/AGENT/SUMMARY/MONITOR-01.md` | NEW: Summary doc |

## How It Works
1. Cron: Every 10 minutes
2. Checks: `https://dixis.gr/api/healthz` (3 retries, 5s delay, 15s timeout)
3. On failure: Creates GitHub Issue with `production-down` label
4. Deduplication: Adds comment to existing open issue (no duplicates)

## Risk Note
Prod uptime relies on GitHub Actions checks; no external alerting (Slack/email) yet.

## Test plan
- [x] Verified healthz endpoint returns 200
- [x] Workflow uses GITHUB_TOKEN (no secrets needed)
- [ ] CI checks pass