### PR TITLE
test(e2e): TEST-UNSKIP-01 - Enable 8 orders flow E2E tests

### DIFF
--- a/frontend/tests/e2e/checkout-to-orders-list.spec.ts
+++ b/frontend/tests/e2e/checkout-to-orders-list.spec.ts
@@ -46,7 +46,7 @@ async function setupConsumerAuth(page: any) {
 }
 
 test.describe('Checkout → Orders List (Split-Brain Fix)', () => {
-  test.skip('order appears in orders list after successful checkout', async ({ page }) => {
+  test('order appears in orders list after successful checkout', async ({ page }) => {
     // SETUP: Add item to cart
     await addItemToCart(page);
 
@@ -172,7 +172,7 @@ test.describe('Checkout → Orders List (Split-Brain Fix)', () => {
     await expect(orderCard.locator(':text("€14.40")')).toBeVisible();
   });
 
-  test.skip('order details page loads after checkout', async ({ page }) => {
+  test('order details page loads after checkout', async ({ page }) => {
     const mockOrderId = 12345;
 
     // SETUP: Consumer auth
@@ -231,7 +231,7 @@ test.describe('Checkout → Orders List (Split-Brain Fix)', () => {
     await expect(page.locator('[data-testid="order-items-section"]')).toBeVisible();
   });
 
-  test.skip('handles empty orders list gracefully', async ({ page }) => {
+  test('handles empty orders list gracefully', async ({ page }) => {
     // SETUP: Consumer auth
     await setupConsumerAuth(page);
 
@@ -257,7 +257,7 @@ test.describe('Checkout → Orders List (Split-Brain Fix)', () => {
     await expect(page.locator('[data-testid="browse-products-link"]')).toBeVisible();
   });
 
-  test.skip('handles order fetch error gracefully', async ({ page }) => {
+  test('handles order fetch error gracefully', async ({ page }) => {
     // SETUP: Consumer auth
     await setupConsumerAuth(page);
 

--- a/frontend/tests/e2e/orders-details-stable.spec.ts
+++ b/frontend/tests/e2e/orders-details-stable.spec.ts
@@ -32,7 +32,7 @@ async function setupConsumerAuth(page: any) {
 }
 
 test.describe('Orders → Details Flow (Crash Prevention)', () => {
-  test.skip('orders list renders without crash when status is undefined', async ({ page }) => {
+  test('orders list renders without crash when status is undefined', async ({ page }) => {
     // SETUP: Mock auth
     await setupConsumerAuth(page);
 
@@ -83,7 +83,7 @@ test.describe('Orders → Details Flow (Crash Prevention)', () => {
     await expect(orderCard.locator('text=—')).toBeVisible();
   });
 
-  test.skip('order details page renders without crash when data is incomplete', async ({ page }) => {
+  test('order details page renders without crash when data is incomplete', async ({ page }) => {
     const mockOrderId = 888;
 
     // SETUP: Consumer auth
@@ -167,7 +167,7 @@ test.describe('Orders → Details Flow (Crash Prevention)', () => {
     await expect(page.locator('[data-testid="item-total"]').first()).toContainText('€—');
   });
 
-  test.skip('order details shows 404 error gracefully when order not found', async ({ page }) => {
+  test('order details shows 404 error gracefully when order not found', async ({ page }) => {
     const nonExistentOrderId = 99999;
 
     // SETUP: Consumer auth
@@ -199,7 +199,7 @@ test.describe('Orders → Details Flow (Crash Prevention)', () => {
     await expect(page.locator('[data-testid="view-all-orders-link"]')).toBeVisible();
   });
 
-  test.skip('verifies orders list calls Laravel API and renders page', async ({ page }) => {
+  test('verifies orders list calls Laravel API and renders page', async ({ page }) => {
     let calledLaravelApi = false;
 
     // Monitor API calls


### PR DESCRIPTION
## Summary

Unskips 8 E2E tests from `checkout-to-orders-list.spec.ts` and `orders-details-stable.spec.ts` as per DoD.

### Unskipped Tests (8 total)

**checkout-to-orders-list.spec.ts** (4 tests):
1. `order appears in orders list after successful checkout`
2. `order details page loads after checkout`
3. `handles empty orders list gracefully`
4. `handles order fetch error gracefully`

**orders-details-stable.spec.ts** (4 tests):
1. `orders list renders without crash when status is undefined`
2. `order details page renders without crash when data is incomplete`
3. `order details shows 404 error gracefully when order not found`
4. `verifies orders list calls Laravel API and renders page`

### Why Safe to Unskip

- All tests use Playwright route mocking (no external dependencies)
- Tests verify UI with mocked API responses
- testids exist in production code
- No authentication dependencies (mocked locally)

### Remaining Skips (tracked for future)

~50+ tests still skipped for various reasons:
- `flow route not present` - missing checkout flow route
- `No products available` - data-dependent conditional skips
- `admin list not available locally` - admin route guards
- `SMOKE_CHECKOUT` env flag required

## Test Plan
- [x] 8 tests unskipped (removes `test.skip()` markers)
- [ ] CI E2E PostgreSQL job passes
- [ ] E2E job under 5 minutes

---
Generated-by: Claude (TEST-UNSKIP-01)