### PR TITLE
test(e2e): Pass 47 TEST-UNSKIP-02 - Unskip 6 PDP and products tests

### DIFF
--- a/frontend/tests/e2e/products-ui.smoke.spec.ts
+++ b/frontend/tests/e2e/products-ui.smoke.spec.ts
@@ -2,7 +2,8 @@ import { test, expect } from '@playwright/test'
 
 const BASE = process.env.BASE_URL || 'http://127.0.0.1:3000'
 
-test.skip('flaky: products page renders grid', async ({ page }) => {
+// Pass 47 (TEST-UNSKIP-02): Unskipped - works against production data
+test('products page renders grid', async ({ page }) => {
   await page.goto(`${BASE}/products`, { waitUntil: 'domcontentloaded' })
   await expect(page.getByRole('heading', { name: 'Προϊόντα' })).toBeVisible()
 


### PR DESCRIPTION
## Summary
- Unskip 6 E2E tests from PDP and products specs
- Tests now use production data instead of route mocking (SSR limitation)
- Target met: ≥5 tests unskipped (actual: 6)

## Tests Unskipped

### pdp-happy.spec.ts (5 tests)
1. `should display complete product information` - rewritten without route mocking
2. `should handle 404 product not found gracefully` - new implementation
3. `should format currency properly with EUR symbol` - new implementation
4. `should handle add to cart flow for authenticated users` - new implementation
5. `should be accessible with proper ARIA labels` - new implementation

### products-ui.smoke.spec.ts (1 test)
1. `products page renders grid` - removed flaky label

## Key Insight

PDP is a Server Component (SSR). `page.route()` only intercepts browser requests, not server-side fetch(). Tests now rely on production data instead of route mocking.

## DoD Verification

- [x] ≥5 tests unskipped (6 enabled)
- [ ] All unskipped tests PASS in CI
- [ ] No new test failures introduced
- [ ] E2E job under 5 minutes

## Test Plan

Wait for E2E CI to pass.

---
Generated-by: Claude (TEST-UNSKIP-02)