### PR TITLE
fix(e2e): re-skip PDP/products tests (not running in CI)

### DIFF
--- a/frontend/tests/e2e/pdp-happy.spec.ts
+++ b/frontend/tests/e2e/pdp-happy.spec.ts
@@ -5,9 +5,10 @@ test.describe('Product Detail Page (PDP) - Smoke Tests', () => {
   const PRODUCT_ID = '1';
   const PRODUCT_URL = `/products/${PRODUCT_ID}`;
 
-  // Pass 47 (TEST-UNSKIP-02): Uses production data - no route mocking needed
-  // PDP is SSR so page.route() can't intercept server-side fetch
-  test('should display complete product information', async ({ page }) => {
+  // RESKIPPED: Tests not running in CI (no @smoke tag, e2e-postgres uses --grep @smoke)
+  // Fix plan: Add @smoke tag OR run in separate workflow with seeded data
+  // See: https://github.com/lomendor/Project-Dixis/pull/1964#issuecomment (sanity check)
+  test.skip('should display complete product information', async ({ page }) => {
     await page.goto(PRODUCT_URL);
 
     // Wait for product to load (skeleton should disappear)
@@ -46,8 +47,8 @@ test.describe('Product Detail Page (PDP) - Smoke Tests', () => {
     await expect(page.locator('body')).toBeVisible();
   });
 
-  // Pass 47 (TEST-UNSKIP-02): Test 404 handling for non-existent product
-  test('should handle 404 product not found gracefully', async ({ page }) => {
+  // RESKIPPED: Tests not running in CI (no @smoke tag)
+  test.skip('should handle 404 product not found gracefully', async ({ page }) => {
     // Navigate to a non-existent product ID
     await page.goto('/products/999999999');
 
@@ -68,8 +69,8 @@ test.describe('Product Detail Page (PDP) - Smoke Tests', () => {
     // TODO(Pass 35+): Implement image fallback component with testids
   });
 
-  // Pass 47 (TEST-UNSKIP-02): Verify EUR currency formatting on product page
-  test('should format currency properly with EUR symbol', async ({ page }) => {
+  // RESKIPPED: Tests not running in CI (no @smoke tag)
+  test.skip('should format currency properly with EUR symbol', async ({ page }) => {
     await page.goto(PRODUCT_URL);
 
     // Wait for skeleton to disappear
@@ -84,9 +85,8 @@ test.describe('Product Detail Page (PDP) - Smoke Tests', () => {
     expect(priceText).toMatch(/€\s*\d+([.,]\d{2})?/);
   });
 
-  // Pass 47 (TEST-UNSKIP-02): Test add to cart button exists and is clickable
-  // Auth provided via CI storageState - consumer role
-  test('should handle add to cart flow for authenticated users', async ({ page }) => {
+  // RESKIPPED: Tests not running in CI (no @smoke tag)
+  test.skip('should handle add to cart flow for authenticated users', async ({ page }) => {
     await page.goto(PRODUCT_URL);
 
     // Wait for product to load
@@ -122,8 +122,8 @@ test.describe('Product Detail Page (PDP) - Smoke Tests', () => {
     // TODO(Pass 35+): Add validation + error fallback for malformed API responses
   });
 
-  // Pass 47 (TEST-UNSKIP-02): Basic accessibility check - key elements have accessible names
-  test('should be accessible with proper ARIA labels', async ({ page }) => {
+  // RESKIPPED: Tests not running in CI (no @smoke tag)
+  test.skip('should be accessible with proper ARIA labels', async ({ page }) => {
     await page.goto(PRODUCT_URL);
 
     // Wait for product to load

--- a/frontend/tests/e2e/products-ui.smoke.spec.ts
+++ b/frontend/tests/e2e/products-ui.smoke.spec.ts
@@ -2,8 +2,9 @@ import { test, expect } from '@playwright/test'
 
 const BASE = process.env.BASE_URL || 'http://127.0.0.1:3000'
 
-// Pass 47 (TEST-UNSKIP-02): Unskipped - works against production data
-test('products page renders grid', async ({ page }) => {
+// RESKIPPED: Test not running in CI (no @smoke tag, e2e-postgres uses --grep @smoke)
+// Also depends on seeded products data which CI-local server may not have
+test.skip('products page renders grid', async ({ page }) => {
   await page.goto(`${BASE}/products`, { waitUntil: 'domcontentloaded' })
   await expect(page.getByRole('heading', { name: 'Προϊόντα' })).toBeVisible()
 


### PR DESCRIPTION
## Summary

**CRITICAL FIX**: Tests unskipped in TEST-UNSKIP-02 (PR #1964) were NOT actually running in PR CI.

## Root Cause

1. `e2e-postgres.yml` uses `--grep @smoke` (line 63)
2. `pdp-happy.spec.ts` and `products-ui.smoke.spec.ts` have NO `@smoke` tag
3. Tests "passed" because they were never executed

## Evidence

```yaml
# .github/workflows/e2e-postgres.yml:63
run: npx dotenv-cli -e .env.ci -- npx playwright test --grep @smoke ...
```

Only `smoke.spec.ts` has `@smoke` tag:
```
frontend/tests/e2e/smoke.spec.ts:4:test('@smoke healthz responds', ...)
```

## Fix

Re-skipped 6 tests until proper fix is implemented:

### Option A: Add @smoke tag
- Requires seeded data in CI-local server
- Tests depend on product ID 1 existing

### Option B: Separate workflow  
- Run PDP tests in `e2e-full.yml` (nightly)
- But that workflow needs webServer setup

### Option C: Keep skipped (current)
- Safe default until deterministic fix

## Tests Re-Skipped

- `pdp-happy.spec.ts`: 5 tests
- `products-ui.smoke.spec.ts`: 1 test

---
Generated-by: Claude (TEST-UNSKIP-02 rollback)