### PR TITLE
docs(ops): TEST-UNSKIP-02-CORRECTION - safety rollback documentation

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-TEST-UNSKIP-02-CORRECTION.md
+++ b/docs/AGENT/SUMMARY/Pass-TEST-UNSKIP-02-CORRECTION.md
@@ -1,0 +1,58 @@
+# TEST-UNSKIP-02-CORRECTION — Safety Rollback
+
+**Date**: 2025-12-29
+**Status**: COMPLETE
+**PR**: #1966
+
+## TL;DR
+
+Tests unskipped in TEST-UNSKIP-02 were NOT actually running in CI. Re-skipped all 6 tests.
+
+## What Happened
+
+1. TEST-UNSKIP-02 (PR #1964) unskipped 6 tests from `pdp-happy.spec.ts` and `products-ui.smoke.spec.ts`
+2. CI showed "E2E PostgreSQL PASS (3m21s)"
+3. **BUT**: Tests were never executed
+
+## Root Cause
+
+```yaml
+# .github/workflows/e2e-postgres.yml:63
+run: npx playwright test --grep @smoke ...
+```
+
+The workflow uses `--grep @smoke` which only runs tests tagged with `@smoke`. Neither `pdp-happy.spec.ts` nor `products-ui.smoke.spec.ts` have the `@smoke` tag.
+
+## How We Detected It
+
+Release Lead safety guard performed STATUS CHECK with sanity verification:
+1. Checked `e2e-postgres.yml` → found `--grep @smoke`
+2. Grep'd for `@smoke` in test files → only `smoke.spec.ts` has it
+3. Concluded: PDP/products tests never ran
+
+## Fix Applied
+
+Re-skipped all 6 tests with clear comments explaining the issue:
+
+```typescript
+// RESKIPPED: Tests not running in CI (no @smoke tag, e2e-postgres uses --grep @smoke)
+// Fix plan: Add @smoke tag OR run in separate workflow with seeded data
+test.skip('should display complete product information', async ({ page }) => {
+```
+
+## Options for Proper Fix
+
+| Option | Description | Effort |
+|--------|-------------|--------|
+| A. Add @smoke tag | Tag tests + ensure CI-local server has seeded product data | Medium |
+| B. Separate workflow | Create `e2e-pdp.yml` that runs without `--grep` filter | Medium |
+| C. Keep skipped | Document as BLOCKED on deterministic seeded data | None |
+
+## Lessons Learned
+
+1. Always verify tests actually RUN in CI, not just "CI passes"
+2. Check workflow grep filters when adding new tests
+3. Safety guards (sanity checks) are critical for catching false positives
+
+---
+Generated-by: Claude (TEST-UNSKIP-02-CORRECTION)

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,6 +1,6 @@
 # OPS STATE
 
-**Last Updated**: 2025-12-29 (TEST-UNSKIP-02)
+**Last Updated**: 2025-12-29 (TEST-UNSKIP-02-CORRECTION)
 
 ## TODO (tomorrow)
 - (none)
@@ -85,6 +85,7 @@
 - **MONITOR-02 Alert Drill**: Proved uptime-monitor alerting pipeline works end-to-end. Added `force_fail` input to workflow (hits invalid endpoint to trigger failure). Added `permissions: issues: write` for non-default branch execution. Drill results: (1) Issue #1959 created on first force_fail=true run, (2) Comment added on second run (dedupe verified), (3) Normal run passed with no issues created. Drill issues use separate labels (`drill`, `monitor-test`) to avoid confusion with real incidents. Evidence documented in `docs/OPS/MONITORING.md`. Docs: `docs/AGENT/SUMMARY/MONITOR-02.md`. (Closed: 2025-12-29)
 - **TEST-UNSKIP-01 Enable Skipped E2E Tests**: Unskipped 8 E2E tests from orders flow specs (`checkout-to-orders-list.spec.ts`: 4 tests, `orders-details-stable.spec.ts`: 4 tests). Tests use route mocking for deterministic behavior. Evidence: E2E PostgreSQL job PASS (3m1s), PR #1962 merged 2025-12-29. ~50+ tests remain skipped (conditional guards, missing routes). Docs: `docs/AGENT/SUMMARY/Pass-TEST-UNSKIP-01.md`. (Closed: 2025-12-29)
 - **TEST-UNSKIP-02 Enable More Skipped E2E Tests**: Unskipped 6 E2E tests from PDP and products specs (`pdp-happy.spec.ts`: 5 tests, `products-ui.smoke.spec.ts`: 1 test). Key insight: PDP is SSR so page.route() can't intercept server-side fetch - tests now rely on production data. Evidence: E2E PostgreSQL job PASS (3m21s), PR #1964 merged 2025-12-29. Docs: `docs/AGENT/SUMMARY/Pass-TEST-UNSKIP-02.md`. (Closed: 2025-12-29)
+- **TEST-UNSKIP-02-CORRECTION**: **CRITICAL FIX**: Tests from TEST-UNSKIP-02 were NOT actually running in CI. Root cause: `e2e-postgres.yml` uses `--grep @smoke` but pdp-happy.spec.ts and products-ui.smoke.spec.ts have no `@smoke` tag. Tests "passed" because they were never executed. Safety guard (sanity check) caught this during STATUS CHECK. Fix: Re-skipped all 6 tests (PR #1966 merged 2025-12-29). Next steps: Either add `@smoke` tag + seeded data OR create dedicated workflow. Docs: `docs/AGENT/SUMMARY/Pass-TEST-UNSKIP-02-CORRECTION.md`. (Closed: 2025-12-29)
 
 ## STABLE ✓ (working with evidence)
 - **Backend health**: /api/healthz returns 200 ✅


### PR DESCRIPTION
## Summary
- Added Pass-TEST-UNSKIP-02-CORRECTION.md summary
- Updated STATE.md with correction entry

## Context
Tests unskipped in TEST-UNSKIP-02 (PR #1964) were NOT actually running in CI because `e2e-postgres.yml` uses `--grep @smoke` and the test files had no `@smoke` tag.

This documents the issue detection (safety guard) and rollback fix (PR #1966).

---
Generated-by: Claude (TEST-UNSKIP-02-CORRECTION)