### PR TITLE
fix(ci): add API_INTERNAL_URL and seed step for @smoke tests

### DIFF
--- a/.github/workflows/e2e-postgres.yml
+++ b/.github/workflows/e2e-postgres.yml
@@ -47,6 +47,13 @@ jobs:
           pnpm run ci:gen || echo "Prisma gen skipped"
           pnpm run ci:migrate || echo "Prisma migrate skipped"
 
+      # Pass E2E-SEED-01: Seed deterministic test data for @smoke tests
+      - name: Seed CI Database
+        run: |
+          echo "🌱 Seeding CI database with deterministic test data..."
+          pnpm run ci:seed
+          echo "✅ CI seed complete"
+
       - name: Build Next.js app
         run: pnpm run build:ci
 

--- a/frontend/.env.ci
+++ b/frontend/.env.ci
@@ -7,7 +7,9 @@ NEXT_PUBLIC_SITE_URL=http://127.0.0.1:3001
 BASE_URL=http://127.0.0.1:3001
 
 # API: Mocked via Playwright route stubs (no real backend in CI)
+# Pass E2E-SEED-01: SSR needs internal URL pointing to Next.js mock API (not Laravel)
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:3001/api/v1
+API_INTERNAL_URL=http://127.0.0.1:3001/api/v1
 
 # Auth (dev)
 OTP_BYPASS=000000


### PR DESCRIPTION
## Summary
Follow-up fix for E2E-SEED-01 (#1970)

### Changes
- Add `API_INTERNAL_URL` to `.env.ci` so SSR calls Next.js mock API
- Add seed step to `e2e-postgres.yml` (PR gate needs seeded data for @smoke tests)

### Root Cause
Products page SSR called port 8001 (Laravel) which doesn't exist in CI,
causing "product-card not found" failures for the new @smoke tests.

## Test plan
- [ ] E2E PostgreSQL passes with seeded data
- [ ] quality-gates passes

Generated-by: Claude (Pass E2E-SEED-01 fix)