### PR TITLE
fix(e2e): strict mode violation in products smoke test

### DIFF
--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -42,7 +42,7 @@ test('@smoke products page renders content', async ({ page }) => {
   // Page should show EITHER products grid OR empty state message
   // This makes the test CI-safe regardless of SSR data availability
   const productGrid = page.locator('main .grid');
-  const emptyState = page.getByText('Δεν υπάρχουν διαθέσιμα προϊόντα');
+  const emptyState = page.getByText('Δεν υπάρχουν διαθέσιμα προϊόντα').first();
 
   // Wait for either condition - at least one should be visible
   await expect(productGrid.or(emptyState)).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
## Summary
Use `.first()` on empty state locator to fix Playwright strict mode violation.

## Root Cause
Multiple elements matched "Δεν υπάρχουν διαθέσιμα προϊόντα" causing:
```
Error: strict mode violation: resolved to 2 elements
```

## Fix
Added `.first()` to the locator.

## Test Plan
- [ ] E2E PostgreSQL passes with 4 @smoke tests