### PR TITLE
fix(auth): add optional Sanctum auth for order creation

### DIFF
--- a/backend/app/Http/Middleware/OptionalSanctumAuth.php
+++ b/backend/app/Http/Middleware/OptionalSanctumAuth.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Optional Sanctum Authentication Middleware
+ *
+ * If a valid Bearer token is present, authenticates the user (fills auth()).
+ * If no token or invalid token, allows request to continue as guest.
+ *
+ * Use case: Public endpoints that should capture user_id when logged in,
+ * but still allow guest access (e.g., order creation).
+ *
+ * @see Pass 52 fix: Orders created by logged-in users now get correct user_id
+ */
+class OptionalSanctumAuth
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Check if Authorization header exists with Bearer token
+        $token = $request->bearerToken();
+
+        if ($token) {
+            // Try to authenticate with Sanctum
+            // This sets auth()->user() if token is valid
+            try {
+                Auth::guard('sanctum')->authenticate();
+            } catch (\Exception $e) {
+                // Invalid token - continue as guest (don't block request)
+                // Log for debugging but don't expose details
+                \Log::debug('OptionalSanctumAuth: Invalid token, continuing as guest');
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -18,6 +18,11 @@ return Application::configure(basePath: dirname(__DIR__))
 
         // API routes should return JSON 401, not redirect to login
         $middleware->redirectGuestsTo(fn () => null);
+
+        // Register custom middleware aliases
+        $middleware->alias([
+            'auth.optional' => \App\Http\Middleware\OptionalSanctumAuth::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         // Return JSON 401 for unauthenticated API requests instead of redirect

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -104,8 +104,9 @@ Route::prefix('v1')->group(function () {
         // Public Orders API (demo access - no PII exposed)
         Route::get('orders', [App\Http\Controllers\Api\V1\OrderController::class, 'index'])->name('api.v1.public.orders.index');
         Route::get('orders/{order}', [App\Http\Controllers\Api\V1\OrderController::class, 'show'])->name('api.v1.public.orders.show');
+        // Pass 52 fix: auth.optional captures user_id when logged in, allows guest checkout
         Route::post('orders', [App\Http\Controllers\Api\V1\OrderController::class, 'store'])->name('api.v1.public.orders.store')
-            ->middleware('throttle:10,1'); // 10 requests per minute for order creation
+            ->middleware(['auth.optional', 'throttle:10,1']);
 
         // Pass 50: Zone-based shipping quote (simpler than /api/shipping/quote)
         Route::post('shipping/quote', [App\Http\Controllers\Api\V1\ShippingQuoteController::class, 'quote'])


### PR DESCRIPTION
## Summary
- Added `OptionalSanctumAuth` middleware for public order creation
- Orders now capture `user_id` when user is logged in
- Guest checkout still works (no blocking)

## Root Cause
Orders created via `POST /api/v1/public/orders` had `user_id=null` even when user was logged in, because the route had no auth middleware. When trying to pay with card, payment checkout failed with **404** because `order.user_id !== auth()->id()` (`null !== 15`).

## Fix
Created `OptionalSanctumAuth` middleware that:
1. If Bearer token exists → authenticates user (fills `auth()`)
2. If no token/invalid token → continues as guest (no blocking)

Applied to `POST /api/v1/public/orders` route.

## Files Changed
| File | Change |
|------|--------|
| `backend/app/Http/Middleware/OptionalSanctumAuth.php` | NEW - middleware |
| `backend/bootstrap/app.php` | Registered `auth.optional` alias |
| `backend/routes/api.php` | Applied to public order creation |

## Test Plan
- [ ] Login as consumer
- [ ] Add item to cart → go to checkout
- [ ] Submit with Card payment
- [ ] Verify NO 404 error (order.user_id matches)
- [ ] Verify Stripe redirect OR expected Stripe error (not ORDER_NOT_FOUND)