### PR TITLE
fix(ci): correct backend deploy path

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -38,7 +38,8 @@ jobs:
           script: |
             set -euo pipefail
 
-            BACKEND_PATH="/var/www/dixis/current/backend"
+            # Path verified from vps-migrate.yml, vps-fix-backend.yml
+            BACKEND_PATH="/var/www/dixis/backend"
 
             echo "=== PREFLIGHT CHECKS ==="
 


### PR DESCRIPTION
## Summary

Fixes backend deploy path from `/var/www/dixis/current/backend` to `/var/www/dixis/backend`.

**Evidence**: First deploy run failed with:
```
❌ FATAL: Backend directory not found: /var/www/dixis/current/backend
```

**Correct path verified from**:
- `vps-migrate.yml:35` → `cd /var/www/dixis/backend`
- `vps-fix-backend.yml:41` → `cd /var/www/dixis/backend`

## Test plan

- [ ] Deploy workflow passes after this fix