### PR TITLE
Pass UI-CATS v0: categories UI + demo fallback (Neon offline-safe)

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -1,35 +1,45 @@
-import { ProductCard } from '@/components/ProductCard'
+import { Suspense } from 'react';
+import { ProductCard } from '@/components/ProductCard';
+import { CategoryStrip } from '@/components/CategoryStrip';
+import { DEMO_PRODUCTS, filterProductsByCategory } from '@/data/demoProducts';
 
 type ApiItem = {
-  id: string | number
-  title: string
-  producerName?: string
-  priceCents: number
-  priceFormatted?: string
-  imageUrl?: string
-}
+  id: string | number;
+  title: string;
+  producerName?: string;
+  priceCents: number;
+  priceFormatted?: string;
+  imageUrl?: string;
+  categorySlug?: string;
+};
 
-async function getData() {
+async function getData(): Promise<{ items: ApiItem[]; total: number; isDemo: boolean }> {
   // Use internal URL for SSR to avoid external round-trip timeout (Pass 26 fix)
   // Same pattern as product detail page (Pass 19)
   const isServer = typeof window === 'undefined';
   const base = isServer
-    ? (process.env.API_INTERNAL_URL || 'http://127.0.0.1:8001/api/v1')
-    : (process.env.NEXT_PUBLIC_API_BASE_URL || 'https://dixis.gr/api/v1');
+    ? process.env.API_INTERNAL_URL || 'http://127.0.0.1:8001/api/v1'
+    : process.env.NEXT_PUBLIC_API_BASE_URL || 'https://dixis.gr/api/v1';
 
   try {
     const res = await fetch(`${base}/public/products`, {
       cache: 'no-store',
-      headers: { 'Content-Type': 'application/json' }
-    })
+      headers: { 'Content-Type': 'application/json' },
+    });
 
     if (!res.ok) {
-      console.error('[Products] API fetch failed:', res.status, res.statusText)
-      return { items: [], total: 0 }
+      console.error('[Products] API fetch failed:', res.status, res.statusText);
+      // Fall back to demo products
+      return { items: mapDemoToApiItems(DEMO_PRODUCTS), total: DEMO_PRODUCTS.length, isDemo: true };
     }
 
-    const json = await res.json()
-    const products = json?.data ?? []
+    const json = await res.json();
+    const products = json?.data ?? [];
+
+    if (products.length === 0) {
+      console.log('[Products] API returned empty, using demo fallback');
+      return { items: mapDemoToApiItems(DEMO_PRODUCTS), total: DEMO_PRODUCTS.length, isDemo: true };
+    }
 
     // Map backend format to frontend format
     const items = products.map((p: any) => ({
@@ -37,27 +47,71 @@ async function getData() {
       title: p.name,
       producerName: p.producer?.name || null,
       priceCents: Math.round(parseFloat(p.price) * 100),
-      imageUrl: p.image_url
-    }))
+      imageUrl: p.image_url,
+      categorySlug: p.category?.slug || null,
+    }));
 
-    return { items, total: items.length }
+    return { items, total: items.length, isDemo: false };
   } catch (err) {
-    console.error('[Products] Fetch error:', err)
-    return { items: [], total: 0 }
+    console.error('[Products] Fetch error (falling back to demo):', err);
+    return { items: mapDemoToApiItems(DEMO_PRODUCTS), total: DEMO_PRODUCTS.length, isDemo: true };
   }
 }
 
-export default async function Page() {
-  const { items = [], total = 0 } = await getData()
+// Convert demo products to API item format
+function mapDemoToApiItems(demoProducts: typeof DEMO_PRODUCTS): ApiItem[] {
+  return demoProducts.map((p) => ({
+    id: p.id,
+    title: p.name,
+    producerName: p.producerName,
+    priceCents: p.priceCents,
+    imageUrl: p.imageUrl,
+    categorySlug: p.categorySlug,
+  }));
+}
+
+// Filter items by category
+function filterByCategory(items: ApiItem[], categorySlug: string | null): ApiItem[] {
+  if (!categorySlug) return items;
+  return items.filter((item) => item.categorySlug === categorySlug);
+}
+
+interface PageProps {
+  searchParams: Promise<{ cat?: string }>;
+}
+
+export default async function Page({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const categoryFilter = params.cat || null;
+
+  const { items: allItems = [], isDemo } = await getData();
+  const items = filterByCategory(allItems, categoryFilter);
+  const total = items.length;
 
   return (
-    <main className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+    <main className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
       <div className="max-w-7xl mx-auto">
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-8">
+        {/* Demo mode banner */}
+        {isDemo && (
+          <div className="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg text-amber-800 text-sm">
+            <span className="font-medium">Λειτουργία demo:</span> Περιορισμένα δεδομένα (DB offline).
+          </div>
+        )}
+
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
           <div>
             <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Προϊόντα</h1>
-            <p className="mt-2 text-sm text-gray-600">Απευθείας από παραγωγούς — {total} συνολικά.</p>
+            <p className="mt-1 text-sm text-gray-600">
+              Απευθείας από παραγωγούς — {total} {categoryFilter ? 'στην κατηγορία' : 'συνολικά'}.
+            </p>
           </div>
+        </div>
+
+        {/* Category Strip */}
+        <div className="mb-6">
+          <Suspense fallback={<div className="h-10 bg-gray-100 rounded animate-pulse" />}>
+            <CategoryStrip selectedCategory={categoryFilter} />
+          </Suspense>
         </div>
 
         {items.length > 0 ? (
@@ -75,10 +129,14 @@ export default async function Page() {
           </div>
         ) : (
           <div className="text-center py-20 bg-white rounded-xl border border-dashed border-gray-300">
-            <p className="text-gray-500 text-lg">Δεν υπάρχουν διαθέσιμα προϊόντα αυτή τη στιγμή.</p>
+            <p className="text-gray-500 text-lg">
+              {categoryFilter
+                ? 'Δεν υπάρχουν προϊόντα σε αυτή την κατηγορία.'
+                : 'Δεν υπάρχουν διαθέσιμα προϊόντα αυτή τη στιγμή.'}
+            </p>
           </div>
         )}
       </div>
     </main>
-  )
+  );
 }

--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { CATEGORIES } from '@/data/categories';
+import {
+  Droplets,
+  Hexagon,
+  Bean,
+  Wheat,
+  Utensils,
+  Croissant,
+  Nut,
+  Leaf,
+  Cherry,
+  Soup,
+  LayoutGrid,
+} from 'lucide-react';
+
+// Map icon names to components
+const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
+  Droplets,
+  Hexagon,
+  Bean,
+  Wheat,
+  Utensils,
+  Croissant,
+  Nut,
+  Leaf,
+  Cherry,
+  Soup,
+};
+
+interface CategoryStripProps {
+  selectedCategory?: string | null;
+}
+
+export function CategoryStrip({ selectedCategory }: CategoryStripProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentCat = selectedCategory ?? searchParams.get('cat');
+
+  const handleCategoryClick = (slug: string | null) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (slug) {
+      params.set('cat', slug);
+    } else {
+      params.delete('cat');
+    }
+    router.push(`/products?${params.toString()}`);
+  };
+
+  return (
+    <div className="w-full overflow-x-auto scrollbar-hide">
+      <div className="flex gap-2 pb-2 min-w-max px-1">
+        {/* "All" option */}
+        <button
+          onClick={() => handleCategoryClick(null)}
+          className={`
+            flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium
+            whitespace-nowrap transition-all duration-200
+            ${
+              !currentCat
+                ? 'bg-green-600 text-white shadow-md'
+                : 'bg-white text-gray-700 border border-gray-200 hover:border-green-400 hover:bg-green-50'
+            }
+          `}
+        >
+          <LayoutGrid className="w-4 h-4" />
+          <span>Όλα</span>
+        </button>
+
+        {/* Category buttons */}
+        {CATEGORIES.map((category) => {
+          const IconComponent = iconMap[category.icon];
+          const isSelected = currentCat === category.slug;
+
+          return (
+            <button
+              key={category.id}
+              onClick={() => handleCategoryClick(category.slug)}
+              className={`
+                flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium
+                whitespace-nowrap transition-all duration-200
+                ${
+                  isSelected
+                    ? 'bg-green-600 text-white shadow-md'
+                    : 'bg-white text-gray-700 border border-gray-200 hover:border-green-400 hover:bg-green-50'
+                }
+              `}
+            >
+              {IconComponent && <IconComponent className="w-4 h-4" />}
+              <span>{category.labelEl}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/data/categories.ts
+++ b/frontend/src/data/categories.ts
@@ -1,0 +1,95 @@
+/**
+ * Categories v0: Static category definitions for demo/fallback mode
+ * When DB is online, these can be replaced with fetched categories
+ */
+
+export interface Category {
+  id: number;
+  slug: string;
+  labelEl: string;
+  labelEn: string;
+  icon: string; // Lucide icon name
+}
+
+export const CATEGORIES: Category[] = [
+  {
+    id: 1,
+    slug: 'olive-oil-olives',
+    labelEl: 'Ελαιόλαδο & Ελιές',
+    labelEn: 'Olive Oil & Olives',
+    icon: 'Droplets',
+  },
+  {
+    id: 2,
+    slug: 'honey-bee',
+    labelEl: 'Μέλι & Κυψέλη',
+    labelEn: 'Honey & Bee Products',
+    icon: 'Hexagon',
+  },
+  {
+    id: 3,
+    slug: 'legumes',
+    labelEl: 'Όσπρια',
+    labelEn: 'Legumes',
+    icon: 'Bean',
+  },
+  {
+    id: 4,
+    slug: 'grains-rice',
+    labelEl: 'Δημητριακά & Ρύζια',
+    labelEn: 'Grains & Rice',
+    icon: 'Wheat',
+  },
+  {
+    id: 5,
+    slug: 'pasta',
+    labelEl: 'Ζυμαρικά',
+    labelEn: 'Pasta',
+    icon: 'Utensils',
+  },
+  {
+    id: 6,
+    slug: 'flours-bakery',
+    labelEl: 'Αλεύρια & Αρτοποιία',
+    labelEn: 'Flours & Bakery',
+    icon: 'Croissant',
+  },
+  {
+    id: 7,
+    slug: 'nuts-dried',
+    labelEl: 'Ξηροί Καρποί & Αποξηραμένα',
+    labelEn: 'Nuts & Dried Fruits',
+    icon: 'Nut',
+  },
+  {
+    id: 8,
+    slug: 'herbs-spices',
+    labelEl: 'Βότανα & Μπαχαρικά',
+    labelEn: 'Herbs & Spices',
+    icon: 'Leaf',
+  },
+  {
+    id: 9,
+    slug: 'sweets-spreads',
+    labelEl: 'Γλυκά, Μαρμελάδες & Αλείμματα',
+    labelEn: 'Sweets, Jams & Spreads',
+    icon: 'Cherry',
+  },
+  {
+    id: 10,
+    slug: 'sauces-preserves',
+    labelEl: 'Σάλτσες, Conserves & Τουρσιά',
+    labelEn: 'Sauces, Preserves & Pickles',
+    icon: 'Soup',
+  },
+];
+
+// Helper to get category by slug
+export function getCategoryBySlug(slug: string): Category | undefined {
+  return CATEGORIES.find((c) => c.slug === slug);
+}
+
+// Helper to get all category slugs
+export function getAllCategorySlugs(): string[] {
+  return CATEGORIES.map((c) => c.slug);
+}

--- a/frontend/src/data/demoProducts.ts
+++ b/frontend/src/data/demoProducts.ts
@@ -1,0 +1,177 @@
+/**
+ * Demo Products: Static product data for when API/DB is unavailable
+ * Used as fallback when Neon quota exceeded or API down
+ */
+
+export interface DemoProduct {
+  id: string;
+  name: string;
+  priceCents: number;
+  unit: string;
+  imageUrl?: string;
+  producerName: string;
+  categorySlug: string;
+}
+
+export const DEMO_PRODUCTS: DemoProduct[] = [
+  // Olive Oil & Olives
+  {
+    id: 'demo-1',
+    name: 'Εξαιρετικό Παρθένο Ελαιόλαδο Καλαμάτας',
+    priceCents: 1850,
+    unit: '750ml',
+    producerName: 'Ελαιώνες Μεσσηνίας',
+    categorySlug: 'olive-oil-olives',
+  },
+  {
+    id: 'demo-2',
+    name: 'Ελιές Καλαμών Βιολογικές',
+    priceCents: 650,
+    unit: '500g',
+    producerName: 'Ελαιώνες Μεσσηνίας',
+    categorySlug: 'olive-oil-olives',
+  },
+  // Honey & Bee
+  {
+    id: 'demo-3',
+    name: 'Μέλι Θυμαρίσιο Κρήτης',
+    priceCents: 1200,
+    unit: '450g',
+    producerName: 'Κρητικά Μελισσοκομεία',
+    categorySlug: 'honey-bee',
+  },
+  {
+    id: 'demo-4',
+    name: 'Μέλι Πεύκου Θάσου',
+    priceCents: 980,
+    unit: '500g',
+    producerName: 'Μέλι Βορείου Ελλάδος',
+    categorySlug: 'honey-bee',
+  },
+  // Legumes
+  {
+    id: 'demo-5',
+    name: 'Φασόλια Γίγαντες Πρεσπών ΠΟΠ',
+    priceCents: 750,
+    unit: '500g',
+    producerName: 'Αγροτικός Συν/μός Πρεσπών',
+    categorySlug: 'legumes',
+  },
+  {
+    id: 'demo-6',
+    name: 'Φακές Εγκλουβής Λευκάδας',
+    priceCents: 480,
+    unit: '500g',
+    producerName: 'Green Farm Co.',
+    categorySlug: 'legumes',
+  },
+  // Grains & Rice
+  {
+    id: 'demo-7',
+    name: 'Ρύζι Καρολίνα Σερρών',
+    priceCents: 420,
+    unit: '1kg',
+    producerName: 'Αγρόκτημα Σερρών',
+    categorySlug: 'grains-rice',
+  },
+  {
+    id: 'demo-8',
+    name: 'Κριθαράκι Ολικής Άλεσης',
+    priceCents: 380,
+    unit: '500g',
+    producerName: 'Ελληνικά Δημητριακά',
+    categorySlug: 'grains-rice',
+  },
+  // Pasta
+  {
+    id: 'demo-9',
+    name: 'Χυλοπίτες Παραδοσιακές',
+    priceCents: 450,
+    unit: '500g',
+    producerName: 'Γιαγιάς Ζυμαρικά',
+    categorySlug: 'pasta',
+  },
+  {
+    id: 'demo-10',
+    name: 'Τραχανάς Ξινός Χειροποίητος',
+    priceCents: 520,
+    unit: '500g',
+    producerName: 'Γιαγιάς Ζυμαρικά',
+    categorySlug: 'pasta',
+  },
+  // Flours & Bakery
+  {
+    id: 'demo-11',
+    name: 'Αλεύρι Ζέας Βιολογικό',
+    priceCents: 580,
+    unit: '1kg',
+    producerName: 'Βιο-Αλεύρια Θεσσαλίας',
+    categorySlug: 'flours-bakery',
+  },
+  // Nuts & Dried
+  {
+    id: 'demo-12',
+    name: 'Φιστίκια Αιγίνης Ωμά',
+    priceCents: 1450,
+    unit: '250g',
+    producerName: 'Φιστικοπαραγωγοί Αιγίνης',
+    categorySlug: 'nuts-dried',
+  },
+  {
+    id: 'demo-13',
+    name: 'Σύκα Αποξηραμένα Εύβοιας',
+    priceCents: 680,
+    unit: '400g',
+    producerName: 'Αγρόκτημα Κύμης',
+    categorySlug: 'nuts-dried',
+  },
+  // Herbs & Spices
+  {
+    id: 'demo-14',
+    name: 'Ρίγανη Βουνού Ταϋγέτου',
+    priceCents: 350,
+    unit: '100g',
+    producerName: 'Βότανα Μάνης',
+    categorySlug: 'herbs-spices',
+  },
+  {
+    id: 'demo-15',
+    name: 'Κρόκος Κοζάνης ΠΟΠ',
+    priceCents: 1200,
+    unit: '1g',
+    producerName: 'Κροκοπαραγωγοί Κοζάνης',
+    categorySlug: 'herbs-spices',
+  },
+  // Sweets & Spreads
+  {
+    id: 'demo-16',
+    name: 'Μαρμελάδα Πορτοκάλι Χίου',
+    priceCents: 480,
+    unit: '380g',
+    producerName: 'Χιώτικα Γλυκά',
+    categorySlug: 'sweets-spreads',
+  },
+  {
+    id: 'demo-17',
+    name: 'Πετιμέζι Παραδοσιακό',
+    priceCents: 550,
+    unit: '500ml',
+    producerName: 'Αμπελώνες Νεμέας',
+    categorySlug: 'sweets-spreads',
+  },
+  // Sauces & Preserves
+  {
+    id: 'demo-18',
+    name: 'Σάλτσα Ντομάτας Σαντορίνης',
+    priceCents: 420,
+    unit: '500g',
+    producerName: 'Σαντορινιά Γεύση',
+    categorySlug: 'sauces-preserves',
+  },
+];
+
+// Helper to filter products by category
+export function filterProductsByCategory(categorySlug: string | null): DemoProduct[] {
+  if (!categorySlug) return DEMO_PRODUCTS;
+  return DEMO_PRODUCTS.filter((p) => p.categorySlug === categorySlug);
+}


### PR DESCRIPTION
## Summary
Frontend-only: 10 categories strip + category filtering + safe demo fallback when products API/DB is down.

## Features
- **10 categories** with Greek labels and Lucide icons
- **CategoryStrip component** - horizontal scrollable pill buttons (Skroutz/Wolt style)
- **Category filtering** via `?cat=<slug>` URL param
- **Demo fallback** - 18 products shown when API fails (Neon quota exceeded)
- **Demo banner** - Shows "Λειτουργία demo: περιορισμένα δεδομένα (DB offline)" when active

## Files Added
- `frontend/src/data/categories.ts` - 10 categories with slugs/icons
- `frontend/src/data/demoProducts.ts` - 18 demo products
- `frontend/src/components/CategoryStrip.tsx` - horizontal category selector

## Files Modified
- `frontend/src/app/(storefront)/products/page.tsx` - CategoryStrip integration + demo fallback

## Testing
- Build passes: `pnpm build` ✅
- Visit `/products` - shows CategoryStrip
- Visit `/products?cat=honey-bee` - filters to honey category
- When API is down, demo products show with amber banner

## Future-Proof
- `categorySlug` field ready for DB category mapping
- Demo fallback only activates on API failure/empty response

---
Generated-by: Claude Code (Pass UI-CATS v0)