### PR TITLE
docs: E2E-FULL-01 - document nightly regression suite

### DIFF
--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -1,6 +1,6 @@
 # NEXT 7 DAYS
 
-**Last Updated**: 2025-12-29 19:00 UTC
+**Last Updated**: 2026-01-04 20:00 UTC
 
 ## WIP (1 item only)
 - (none)
@@ -9,12 +9,22 @@
 
 1. **Pass 52 — Card Payments Enable** (BLOCKED — READY once user provides Stripe keys, see CREDENTIALS.md)
 2. **Pass 60 — Email Infrastructure Enable** (BLOCKED — READY once user provides SMTP/Resend keys, see CREDENTIALS.md)
-3. **E2E-SEED-03 — Expand CI @smoke Coverage** (actionable - add cart/checkout @smoke tests)
+3. **Monitor nightly e2e-full results** - Check Actions for failures
 
 See `docs/OPS/STATE.md` for full DoD checklists.
 See `docs/AGENT/SOPs/CREDENTIALS.md` for VPS enablement steps.
 
-## Recently Completed (Pass 58-63 + MONITOR + E2E-SEED + CRED)
+## How to Run E2E Full Manually
+
+1. Go to GitHub Actions → "E2E Full (nightly & manual)"
+2. Click "Run workflow"
+3. Optional: Enter grep filter (e.g., `@regression`)
+4. Artifacts: `e2e-full-report-{run_number}` (playwright-report + test-results)
+
+## Recently Completed (Pass 58-63 + SMOKE-STABLE + E2E-FULL)
+
+- **SMOKE-STABLE-01** — E2E Test Policy (PR gate @smoke only, nightly for @regression) ✅
+- **E2E-FULL-01** — Nightly regression suite documentation ✅
 
 - **Pass 58** — Producer Order Status Updates (status buttons on /my/orders) ✅
 - **Pass 59** — Stabilize PROD Smoke reload-and-css ✅

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,6 +1,6 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-04 (SMOKE-STABLE-01 E2E Test Policy)
+**Last Updated**: 2026-01-04 (E2E-FULL-01 Documentation)
 
 ## E2E Test Tagging Policy (SMOKE-STABLE-01)
 
@@ -19,6 +19,23 @@
 - Require full cart + auth setup
 - Test complete user flows
 - Have longer timeouts
+
+## How to Run E2E Full Suite (E2E-FULL-01)
+
+**Nightly**: Runs automatically at 02:00 UTC via `.github/workflows/e2e-full.yml`
+
+**Manual**: GitHub Actions → "E2E Full (nightly & manual)" → Run workflow
+- Optional: Enter grep filter (e.g., `@regression` for only regression tests)
+- Leave empty to run ALL tests
+
+**Artifacts**: On any run, find `e2e-full-report-{run_number}` in Actions artifacts (playwright-report + test-results)
+
+## 2026-01-04 — E2E-FULL-01 Documentation
+- **Context**: SMOKE-STABLE-01 stabilized PR gate with @smoke only. @regression tests now run in nightly e2e-full.
+- **Workflow**: `.github/workflows/e2e-full.yml` (already existed from Pass TEST-UNSKIP-03)
+- **Triggers**: Schedule (02:00 UTC daily), Manual (workflow_dispatch)
+- **Coverage**: All tests including @regression (pass-53-payment-flows, pass-54-shipping-save)
+- **Not a required check**: Does NOT block PRs - runs nightly for monitoring.
 
 ## 2026-01-04 — SMOKE-STABLE-01 E2E Test Stabilization
 - **Problem**: `pass-54-shipping-save.spec.ts` tagged `@smoke` but required complex checkout setup (cart, auth, form fill). Caused CI timeouts.


### PR DESCRIPTION
## Summary
Documentation-only PR. The `e2e-full.yml` workflow already exists from Pass TEST-UNSKIP-03.

## Changes
- `docs/OPS/STATE.md`: Added E2E-FULL-01 section, "How to Run E2E Full Suite" instructions
- `docs/NEXT-7D.md`: Added manual run instructions, updated recently completed

## Workflow Details (existing)
- **File**: `.github/workflows/e2e-full.yml`
- **Triggers**:
  - Schedule: `0 2 * * *` (02:00 UTC daily)
  - Manual: `workflow_dispatch` with optional grep filter
- **Coverage**: All tests including @regression (pass-53, pass-54)
- **Artifacts**: `e2e-full-report-{run_number}` (playwright-report + test-results)
- **NOT a required check**: Does not block PRs

## Test plan
- [x] Docs only - no code changes
- [x] Workflow already exists and works

---
Generated-by: claude-opus-4-5-20251101 | Pass: E2E-FULL-01