### PR TITLE
docs: E2E-FULL-01 proof run + next pass

### DIFF
--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -36,6 +36,10 @@
 - **Triggers**: Schedule (02:00 UTC daily), Manual (workflow_dispatch)
 - **Coverage**: All tests including @regression (pass-53-payment-flows, pass-54-shipping-save)
 - **Not a required check**: Does NOT block PRs - runs nightly for monitoring.
+- **Proof run**: https://github.com/lomendor/Project-Dixis/actions/runs/20698287265
+  - Result: FAIL (expected - @regression tests need checkout setup work)
+  - Failing: `pass-53-payment-flows`, `pass-54-shipping-save` (checkout form timeout)
+  - **Next pass**: REGRESSION-FIX-01 - Make @regression tests CI-compatible
 
 ## 2026-01-04 — SMOKE-STABLE-01 E2E Test Stabilization
 - **Problem**: `pass-54-shipping-save.spec.ts` tagged `@smoke` but required complex checkout setup (cart, auth, form fill). Caused CI timeouts.


### PR DESCRIPTION
## Summary
Add proof run link to E2E-FULL-01 documentation.

## Proof Run
- **URL**: https://github.com/lomendor/Project-Dixis/actions/runs/20698287265
- **Filter**: `@regression`
- **Result**: FAIL (expected)
- **Failing tests**: `pass-53-payment-flows`, `pass-54-shipping-save`
- **Reason**: Checkout form timeout (tests need CI-compatible setup)

## Next Pass
`REGRESSION-FIX-01` - Make @regression tests CI-compatible

---
Generated-by: claude-opus-4-5-20251101 | Pass: E2E-FULL-01-proof