### PR TITLE
docs: add REGRESSION-FIX-01 proof run link

### DIFF
--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -46,7 +46,8 @@
 - **Fix**: Added `waitForCheckoutOrSkip()` helper with 15s timeout + `test.skip()` if not reachable.
 - **Files**: `pass-54-shipping-save.spec.ts` (+helper function, +testInfo param)
 - **Result**: e2e-full completes fast; tests skip with explicit reason instead of hanging.
-- **Proof run**: (pending - link after PR merge)
+- **Proof run**: https://github.com/lomendor/Project-Dixis/actions/runs/20698663073
+  - Result: SUCCESS (2 skipped with explicit reason, no timeouts)
 
 ## 2026-01-04 — SMOKE-STABLE-01 E2E Test Stabilization
 - **Problem**: `pass-54-shipping-save.spec.ts` tagged `@smoke` but required complex checkout setup (cart, auth, form fill). Caused CI timeouts.


### PR DESCRIPTION
Add proof run URL showing SUCCESS (2 skipped, no timeouts)

Proof: https://github.com/lomendor/Project-Dixis/actions/runs/20698663073

---
Generated-by: claude-opus-4-5-20251101