### PR TITLE
fix(auth): add credentials: 'include' for Sanctum session auth

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -338,9 +338,10 @@ class ApiClient {
   ): Promise<T> {
     // Handle absolute URLs directly - use new safe URL joining
     const url = endpoint.startsWith('http') ? endpoint : apiUrl(endpoint);
-    
+
     const response = await fetch(url, {
       ...options,
+      credentials: 'include', // Required for Sanctum session cookies (AUTH-CRED-01)
       headers: {
         ...this.getHeaders(),
         ...options.headers,


### PR DESCRIPTION
## Summary
- Adds `credentials: 'include'` to the api.ts request() method for Sanctum cookie-based auth

## Problem
The AuthGuard was logging `role undefined` and redirecting users even when logged in. The header showed "Αποσύνδεση" (logged in) but the user profile couldn't be fetched.

## Root Cause
The `request()` method in `api.ts` was missing `credentials: 'include'`, which prevented session cookies from being sent cross-origin to the Laravel backend. This caused the `/auth/profile` endpoint to return 401 Unauthorized.

## Fix
Added `credentials: 'include'` to the fetch() call in the ApiClient.request() method (line 344).

## Test Plan
- [x] Frontend build passes (TypeScript, no errors)
- [ ] Login as user, verify profile loads correctly
- [ ] Verify "Οι παραγγελίες μου" page works without redirect
- [ ] Verify producer dashboard works without redirect

Fixes AUTH-CRED-01 (continuation)