### PR TITLE
fix(backend): use unit_price for Stripe line items

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/PaymentCheckoutController.php
+++ b/backend/app/Http/Controllers/Api/V1/PaymentCheckoutController.php
@@ -79,7 +79,7 @@ class PaymentCheckoutController extends Controller
                         'product_data' => [
                             'name' => $item->product_name ?? 'Προϊόν #' . $item->product_id,
                         ],
-                        'unit_amount' => (int) ($item->price * 100), // Convert to cents
+                        'unit_amount' => (int) ($item->unit_price * 100), // Convert to cents
                     ],
                     'quantity' => $item->quantity,
                 ];


### PR DESCRIPTION
## Summary
- Fixed Stripe Checkout showing €0.00 for products
- `PaymentCheckoutController` was using `$item->price` (doesn't exist)
- Changed to `$item->unit_price` (correct field from OrderItem model)

## Root Cause
The `OrderItem` model defines `unit_price` field, but the payment controller was accessing a non-existent `price` property which returned null → 0 cents.

## Verification
1. Add product to cart
2. Checkout with card payment
3. Stripe Checkout page shows correct product prices (not €0.00)