### PR TITLE
fix(auth): unwrap user from profile API response

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -467,7 +467,9 @@ class ApiClient {
   }
 
   async getProfile(): Promise<User> {
-    return this.request<User>('auth/profile');
+    // Backend returns { user: {...} }, we need to unwrap it
+    const response = await this.request<{ user: User }>('auth/profile');
+    return response.user;
   }
 
   // Cart methods


### PR DESCRIPTION
## Summary
Fix auth profile API response unwrapping - backend returns `{ user: {...} }` but `getProfile()` was returning the raw response.

## Root Cause
```php
// Backend /api/v1/auth/profile returns:
{ "user": { "id": 1, "name": "...", "role": "consumer", ... } }
```

```typescript
// Frontend getProfile() was:
async getProfile(): Promise<User> {
  return this.request<User>('auth/profile'); // Returns { user: {...} }, not User!
}
```

This caused `user.role` to be `undefined` because `user` was actually `{ user: {...} }`.

## Fix
Unwrap the `user` object from the response:
```typescript
async getProfile(): Promise<User> {
  const response = await this.request<{ user: User }>('auth/profile');
  return response.user;
}
```

## Impact
Fixes:
- "role undefined" in auth state
- Card payment option not showing (isAuthenticated check fails when role undefined)
- Potential React #418 hydration errors from inconsistent auth state

## Test Plan
- [ ] Login → verify user.role is defined in DevTools
- [ ] Navigate to /checkout → verify "Κάρτα" option visible
- [ ] Hard refresh → no React errors