### PR TITLE
ops: add SSH verification workflow and runbook

### DIFF
--- a/.github/workflows/verify-vps-ssh.yml
+++ b/.github/workflows/verify-vps-ssh.yml
@@ -1,0 +1,26 @@
+name: Verify VPS SSH
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify-ssh:
+    name: Verify SSH Connection
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test SSH Connection
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            echo "=== SSH CONNECTION OK ==="
+            whoami
+            hostname
+            echo "=== CHECKING DEPLOY DIRS ==="
+            test -d /var/www/dixis/current || (echo "MISSING: /var/www/dixis/current" && exit 1)
+            test -d /var/www/dixis/current/frontend || (echo "MISSING: /var/www/dixis/current/frontend" && exit 1)
+            echo "=== PM2 STATUS ==="
+            pm2 list || echo "PM2 not running as this user"
+            echo "=== SSH_VERIFY_OK ==="

--- a/docs/OPS/SSH-DEPLOY-RUNBOOK.md
+++ b/docs/OPS/SSH-DEPLOY-RUNBOOK.md
@@ -1,0 +1,99 @@
+# SSH Deploy Runbook
+
+**Last Updated**: 2026-01-13
+**Purpose**: Canonical SSH access for CI/CD deployments
+
+---
+
+## Canonical Configuration
+
+| Setting | Value |
+|---------|-------|
+| **Host** | `147.93.126.235` |
+| **User** | `deploy` |
+| **Port** | `22` |
+| **Key Name** | `dixis_prod_ed25519` |
+| **Key Fingerprint** | `SHA256:KrAQdzHHlh0/GUvONv3Y/5ULgz04h6C6VrC8cHDyy78` |
+
+---
+
+## GitHub Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `VPS_SSH_KEY` | Private key (`~/.ssh/dixis_prod_ed25519`) |
+| `VPS_USER` | `deploy` |
+| `VPS_HOST` | `147.93.126.235` |
+| `KNOWN_HOSTS` | SSH host key (auto-generated) |
+
+---
+
+## VPS Authorized Keys Path
+
+```
+/home/deploy/.ssh/authorized_keys
+```
+
+**Required permissions:**
+- `/home/deploy/.ssh/` → `700`
+- `/home/deploy/.ssh/authorized_keys` → `600`
+- Owner: `deploy:deploy`
+
+---
+
+## Verification Commands
+
+### 1. Local SSH Test
+```bash
+ssh -i ~/.ssh/dixis_prod_ed25519 deploy@147.93.126.235 "whoami; hostname"
+```
+
+### 2. GitHub Actions Verify Workflow
+```bash
+gh workflow run "Verify VPS SSH"
+gh run list --workflow="Verify VPS SSH" --limit=1
+```
+
+### 3. On-Server Check
+```bash
+# Check authorized_keys
+cat /home/deploy/.ssh/authorized_keys
+
+# Check permissions
+ls -la /home/deploy/.ssh/
+
+# Check sshd config
+grep -E "AllowUsers|PubkeyAuthentication" /etc/ssh/sshd_config
+```
+
+---
+
+## Troubleshooting
+
+### "Permission denied (publickey)"
+
+1. **Check AllowUsers**: VPS has `AllowUsers` directive - ensure `deploy` is listed
+2. **Check permissions**: `.ssh` must be 700, `authorized_keys` must be 600
+3. **Check ownership**: Must be `deploy:deploy`
+4. **Restart sshd**: `systemctl restart sshd`
+
+### "Connection timeout" from GitHub Actions
+
+1. Check VPS firewall allows GitHub Actions IPs
+2. Or use self-hosted runner
+
+---
+
+## Important Notes
+
+- **DO NOT use root** for deployments - `deploy` user only
+- **Single key**: Only `dixis_prod_ed25519` is authorized
+- **PM2 runs as deploy**: All PM2 commands run under deploy user
+
+---
+
+## Related Docs
+
+- `docs/OPS/PROD-ACCESS.md` - Full VPS access documentation
+- `docs/OPS/SECRETS-MAP.md` - All GitHub secrets
+- `.github/workflows/deploy-frontend.yml` - Frontend deployment workflow


### PR DESCRIPTION
## Summary
- Add `verify-vps-ssh.yml` workflow for manual SSH testing
- Add `SSH-DEPLOY-RUNBOOK.md` with canonical configuration

## Root Cause Analysis
SSH was failing because:
1. The `deploy` user was not in `AllowUsers` in sshd_config
2. The public key was not in `/home/deploy/.ssh/authorized_keys`

## Fix Applied
1. Added public key via Browser Terminal
2. Updated GitHub secrets (VPS_SSH_KEY, VPS_USER, KNOWN_HOSTS)
3. Created symlink `/var/www/dixis/frontend` → `/var/www/dixis/current/frontend`
4. Added missing env vars to VPS

## Prevention Checklist
- [x] Single canonical SSH key: `dixis_prod_ed25519`
- [x] Single deploy user: `deploy`
- [x] Documented in `SSH-DEPLOY-RUNBOOK.md`
- [x] Verification workflow added

## Test Results
- Homepage: HTTP 200 ✅
- Products API: HTTP 200 ✅
- Login endpoint: Works (no 404!) ✅