### PR TITLE
fix(deploy): pass INTERNAL_API_URL to PM2 start command

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -211,7 +211,8 @@ jobs:
             PORT=3000 HOSTNAME=0.0.0.0 \
             DATABASE_URL="${DATABASE_URL}" \
             RESEND_API_KEY="${RESEND_API_KEY}" \
-            INTERNAL_API_URL="http://localhost:3000" \
+            INTERNAL_API_URL="https://dixis.gr/api/v1" \
+            NEXT_PUBLIC_API_BASE_URL="https://dixis.gr/api/v1" \
             pm2 start /var/www/dixis/current/frontend/server.js \
                 --name "dixis-frontend" \
                 --time \


### PR DESCRIPTION
## Summary
PR #2193 fixed the .env echo but missed line 214 which passes env vars directly to PM2 start.

**Root cause**: Line 214 still had `INTERNAL_API_URL="http://localhost:3000"` overriding the .env fix.

**Fix**: Pass correct URLs inline to PM2:
- `INTERNAL_API_URL="https://dixis.gr/api/v1"`
- `NEXT_PUBLIC_API_BASE_URL="https://dixis.gr/api/v1"`

## Evidence
Before fix (PM2 env empty):
```
pm2 env dixis-frontend | grep INTERNAL_API_URL
Not found
```

After manual fix:
```
NEXT_PUBLIC_API_BASE_URL: https://dixis.gr/api/v1
INTERNAL_API_URL: https://dixis.gr/api/v1
NODE_ENV: production
```

Demo banner: **GONE**
```
curl -s https://dixis.gr/products | grep "demo"
✅ NO DEMO BANNER FOUND!
```

## Test plan
- [ ] Deploy triggers after merge
- [ ] No 404 errors in PM2 logs
- [ ] Site shows real products, no demo banner

Generated-by: claude-opus-4-5-20250514