### PR TITLE
fix(deploy): remove sudo from port check to prevent false-fail

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -250,7 +250,8 @@ jobs:
 
             # === OPS-PM2-01 STRICT PROOF: 20x localhost curl must all return 200/204 ===
             echo "--- OPS-PM2-01: Strict 20x Curl Proof ---"
-            sudo ss -lntp | grep -E ":3000" || { echo "FAIL: NO_LISTENER_3000"; exit 1; }
+            # Check port 3000 is listening (no sudo needed - curl will fail if not)
+            curl -s --max-time 3 http://127.0.0.1:3000/ > /dev/null || { echo "FAIL: NO_LISTENER_3000"; exit 1; }
             FAIL_COUNT=0
             for i in $(seq 1 20); do
               CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://127.0.0.1:3000/manifest.webmanifest || echo "000")


### PR DESCRIPTION
## Summary
Replace `sudo ss -lntp` with curl-based connectivity check.

**Problem**: Deploy user doesn't have passwordless sudo → verification step fails even when PM2 starts successfully.

**Fix**: Use `curl -s --max-time 3 http://127.0.0.1:3000/` instead of `sudo ss`.

## Diff
```diff
- sudo ss -lntp | grep -E ":3000" || { echo "FAIL: NO_LISTENER_3000"; exit 1; }
+ curl -s --max-time 3 http://127.0.0.1:3000/ > /dev/null || { echo "FAIL: NO_LISTENER_3000"; exit 1; }
```

## Test plan
- [ ] Deploy workflow passes without sudo error
- [ ] Verification still catches if port 3000 isn't listening

Generated-by: claude-opus-4-5-20250514