### PR TITLE
docs(ops): record deploy-verify proof pass

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-OPS-VERIFY-01.md
+++ b/docs/AGENT/SUMMARY/Pass-OPS-VERIFY-01.md
@@ -1,0 +1,43 @@
+# Pass OPS-VERIFY-01 Summary
+
+**Date**: 2026-01-14
+**Duration**: ~30 minutes
+**Result**: SUCCESS
+
+## TL;DR
+
+Deploy workflow was failing because `sudo ss -lntp` requires passwordless sudo, which the `deploy` user doesn't have. Fixed by replacing with curl-based checks. Documented the 3-point verification proof standard.
+
+## Problem
+
+```
+sudo: a password is required
+```
+
+The `deploy` user is intentionally configured without passwordless sudo for security. The deploy workflow used `sudo ss -lntp` to check if port 3000 was listening.
+
+## Solution
+
+1. **PR #2195**: Replace `sudo ss -lntp` with `curl -s http://127.0.0.1:3000/`
+2. **PR #2197**: Document verification standard in `docs/OPS/DEPLOY-VERIFY-PROOF.md`
+
+## Verification Standard (3-Point Proof)
+
+| Check | Command | Success |
+|-------|---------|---------|
+| Port listener | `curl -s http://127.0.0.1:3000/` | 0 exit code |
+| Health endpoint | `curl /api/healthz` | `"status":"ok"` |
+| Deep health | `curl /api/healthz?deep=1` | `"db":"connected"` |
+
+Plus OPS-PM2-01: 20x consecutive curl requests must all return 200/204.
+
+## Decision
+
+**No sudo in deploy verify** — All post-deploy checks use curl-based proofs that run as the unprivileged `deploy` user.
+
+## Links
+
+- PR #2195: https://github.com/lomendor/Project-Dixis/pull/2195
+- PR #2197: https://github.com/lomendor/Project-Dixis/pull/2197
+- Docs: `docs/OPS/DEPLOY-VERIFY-PROOF.md`
+- STATE: `docs/OPS/STATE.md` (updated)

--- a/docs/AGENT/TASKS/Pass-OPS-VERIFY-01.md
+++ b/docs/AGENT/TASKS/Pass-OPS-VERIFY-01.md
@@ -1,0 +1,53 @@
+# Pass OPS-VERIFY-01: Deploy Verification Proof Standard
+
+**Date**: 2026-01-14
+**Status**: COMPLETE
+
+## What
+
+Establish a curl-based deploy verification standard for the frontend deployment workflow. Remove all `sudo` commands since the `deploy` user lacks passwordless sudo access.
+
+## Why
+
+1. **Deploy failures**: The deploy workflow was failing with "sudo: password required" because `sudo ss -lntp` requires passwordless sudo
+2. **No sudo access**: The `deploy` user is intentionally configured without passwordless sudo for security
+3. **Need for proof standard**: Post-deploy verification must prove the app is healthy without elevated privileges
+
+## How
+
+### 1. Remove sudo from workflow (PR #2195)
+
+Replaced `sudo ss -lntp` with curl-based port listener check:
+
+```bash
+# Before (broken)
+sudo ss -lntp | grep :3000
+
+# After (works)
+curl -s --max-time 3 http://127.0.0.1:3000/ > /dev/null || { echo "FAIL: NO_LISTENER_3000"; exit 1; }
+```
+
+### 2. Document verification standard (PR #2197)
+
+Created `docs/OPS/DEPLOY-VERIFY-PROOF.md` with:
+- 3-point verification proof (port, health, deep health)
+- OPS-PM2-01 20x curl stability proof
+- Troubleshooting with non-sudo options
+
+## Verification
+
+- PR #2195 merged: Deploy workflow no longer uses sudo
+- PR #2197 merged: Documentation complete
+- Deploy workflow succeeds without permission errors
+
+## PRs
+
+| PR | Title | Status |
+|----|-------|--------|
+| #2195 | fix: remove sudo from deploy verify | MERGED |
+| #2197 | docs: deploy verification proof standard | MERGED |
+
+## Files Changed
+
+- `.github/workflows/deploy-frontend.yml` — Line 253 updated
+- `docs/OPS/DEPLOY-VERIFY-PROOF.md` — New file (104 lines)

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,6 +1,28 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-12 (Pass-58)
+**Last Updated**: 2026-01-14 (Pass-OPS-VERIFY-01)
+
+## 2026-01-14 — Pass OPS-VERIFY-01: Deploy Verification Proof Standard
+
+**Status**: ✅ MERGED
+
+Established curl-based deploy verification standard. Removed sudo commands from deploy workflow since `deploy` user lacks passwordless sudo.
+
+### Decision
+
+**No sudo in deploy verify** — All post-deploy checks use curl-based proofs:
+1. Port listener check: `curl -s http://127.0.0.1:3000/`
+2. Health endpoint: `/api/healthz`
+3. OPS-PM2-01 20x curl stability proof
+
+### PRs
+- #2195 (fix: remove sudo from deploy verify) — merged
+- #2197 (docs: deploy verification proof standard) — merged
+
+### Documentation
+- `docs/OPS/DEPLOY-VERIFY-PROOF.md` — Canonical verification standard
+
+---
 
 ## 2026-01-12 — Pass 58: E2E Flaky Test Fix (Card Option Guardrail)
 


### PR DESCRIPTION
## Summary
Record merged ops/docs proof standard and update STATE/TASKS/SUMMARY.

## Changes
- `docs/OPS/STATE.md`: Added Pass-OPS-VERIFY-01 entry
- `docs/AGENT/TASKS/Pass-OPS-VERIFY-01.md`: What/why/how documentation
- `docs/AGENT/SUMMARY/Pass-OPS-VERIFY-01.md`: TL;DR + links

## Context
Follows merge of:
- PR #2195 (remove sudo from deploy verify)
- PR #2197 (deploy verification proof standard)