### PR TITLE
fix: use canonical /var/www/dixis/current paths in deploy workflows

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -38,8 +38,8 @@ jobs:
           script: |
             set -euo pipefail
 
-            # Path verified from vps-migrate.yml, vps-fix-backend.yml
-            BACKEND_PATH="/var/www/dixis/backend"
+            # Path verified from verify-vps-ssh.yml (canonical)
+            BACKEND_PATH="/var/www/dixis/current/backend"
 
             echo "=== PREFLIGHT CHECKS ==="
 
@@ -105,7 +105,7 @@ jobs:
 
             if [ -n "$MISSING_ENVS" ]; then
               echo "❌ FATAL: Missing or placeholder values for:$MISSING_ENVS"
-              echo "Please fill these in /var/www/dixis/backend/.env before deploying"
+              echo "Please fill these in /var/www/dixis/current/backend/.env before deploying"
               exit 1
             fi
             echo "✅ Required env vars are set (APP_KEY, DATABASE_URL)"

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -85,7 +85,7 @@ jobs:
             set -euo pipefail
             echo "=== FRONTEND ENV PRECHECK ==="
 
-            ENV_FILE="/var/www/dixis/frontend/.env"
+            ENV_FILE="/var/www/dixis/current/frontend/.env"
 
             if [ ! -f "$ENV_FILE" ]; then
               echo "❌ FATAL: .env file not found at $ENV_FILE"
@@ -104,7 +104,7 @@ jobs:
 
             if [ -n "$MISSING_ENVS" ]; then
               echo "❌ FATAL: Missing or placeholder values for:$MISSING_ENVS"
-              echo "Please fill these in /var/www/dixis/frontend/.env before deploying"
+              echo "Please fill these in /var/www/dixis/current/frontend/.env before deploying"
               exit 1
             fi
             echo "✅ Required env vars are set"


### PR DESCRIPTION
## Summary

Both deploy workflows were using wrong paths causing deploy failures:
- `deploy-frontend.yml`: `/var/www/dixis/frontend` → `/var/www/dixis/current/frontend`
- `deploy-backend.yml`: `/var/www/dixis/backend` → `/var/www/dixis/current/backend`

## Root Cause

Deploy workflows used inconsistent paths. The canonical structure (per `verify-vps-ssh.yml`) is:
```
/var/www/dixis/current/
├── frontend/
└── backend/
```

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `deploy-frontend.yml` | 88 | `/var/www/dixis/frontend/.env` | `/var/www/dixis/current/frontend/.env` |
| `deploy-frontend.yml` | 107 | `/var/www/dixis/frontend/.env` | `/var/www/dixis/current/frontend/.env` |
| `deploy-backend.yml` | 42 | `/var/www/dixis/backend` | `/var/www/dixis/current/backend` |
| `deploy-backend.yml` | 108 | `/var/www/dixis/backend/.env` | `/var/www/dixis/current/backend/.env` |

## Test Plan

- [ ] PR merges successfully
- [ ] Trigger `deploy-frontend.yml` workflow → preflight should pass
- [ ] Trigger `deploy-backend.yml` workflow → preflight should pass

---
Generated-by: Claude Code