### PR TITLE
fix(ci): relax OPS-PM2-01 readiness proof to avoid false deploy fails

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -156,24 +156,38 @@ jobs:
             pm2 logs dixis-frontend --err --nostream --lines 10 2>/dev/null || true
             lsof -i:3000 2>/dev/null || echo "Nothing on port 3000"
 
-            # Remove ALL old .env files using sudo (they have wrong permissions from old deploys)
-            sudo rm -f .env .env.local .env.production .env.production.local 2>/dev/null || true
-
-            # Also remove from the actual symlink target directory
+            # === PRESERVE .env: upsert only workflow-managed keys ===
+            # Remove old .env variants but NOT the main .env
+            sudo rm -f .env.local .env.production .env.production.local 2>/dev/null || true
             ACTUAL_DIR=$(readlink -f /var/www/dixis/current/frontend)
             sudo rm -f "$ACTUAL_DIR/.env.production" 2>/dev/null || true
 
-            # Create fresh .env file with production secrets
-            echo "NODE_ENV=production" > .env
-            echo "PORT=3000" >> .env
-            echo "HOSTNAME=0.0.0.0" >> .env
-            echo "DATABASE_URL=${DATABASE_URL}" >> .env
-            echo "RESEND_API_KEY=${RESEND_API_KEY}" >> .env
-            # Memory limit for Node.js (VPS has limited RAM - stability-focused)
-            echo "NODE_OPTIONS=--max-old-space-size=320" >> .env
-            # Internal URL for SSR - external round-trip (nginx port 80 redirects to HTTPS)
-            echo "INTERNAL_API_URL=https://dixis.gr/api/v1" >> .env
-            cat .env | head -5
+            # Create .env if missing
+            if [ ! -f .env ]; then
+              echo "Creating new .env file..."
+              touch .env
+            fi
+
+            # Upsert workflow-managed keys (preserve existing keys like NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY)
+            upsert_env() {
+              local KEY="$1"
+              local VALUE="$2"
+              # Remove existing line if present, then append new value
+              grep -v "^${KEY}=" .env > .env.tmp 2>/dev/null || true
+              mv .env.tmp .env 2>/dev/null || true
+              echo "${KEY}=${VALUE}" >> .env
+            }
+
+            upsert_env "NODE_ENV" "production"
+            upsert_env "PORT" "3000"
+            upsert_env "HOSTNAME" "0.0.0.0"
+            upsert_env "DATABASE_URL" "${DATABASE_URL}"
+            upsert_env "RESEND_API_KEY" "${RESEND_API_KEY}"
+            upsert_env "NODE_OPTIONS" "--max-old-space-size=320"
+            upsert_env "INTERNAL_API_URL" "https://dixis.gr/api/v1"
+
+            echo "=== .env keys (workflow-managed updated, others preserved) ==="
+            grep -E "^[A-Z_]+=" .env | cut -d= -f1 | head -15
 
             # AGGRESSIVE CLEANUP: Delete all PM2 processes and their configs
             pm2 delete all 2>/dev/null || true
@@ -248,10 +262,26 @@ jobs:
               curl -s http://127.0.0.1:3000/api/healthz?deep=1 || true
             fi
 
+            # === WAIT_FOR_3000: Readiness gate before stability proof (90s max) ===
+            echo "--- WAIT_FOR_3000: Readiness Gate ---"
+            READY=0
+            for attempt in $(seq 1 18); do
+              if curl -fsS --max-time 3 http://127.0.0.1:3000/ > /dev/null 2>&1; then
+                echo "✅ Port 3000 ready after $((attempt*5))s"
+                READY=1
+                break
+              fi
+              echo "Attempt $attempt/18: Not ready yet, waiting 5s..."
+              sleep 5
+            done
+            if [ "$READY" -eq 0 ]; then
+              echo "FAIL: NO_LISTENER_3000 after 90s"
+              pm2 status || true
+              exit 1
+            fi
+
             # === OPS-PM2-01 STRICT PROOF: 20x localhost curl must all return 200/204 ===
             echo "--- OPS-PM2-01: Strict 20x Curl Proof ---"
-            # Check port 3000 is listening (no sudo needed - curl will fail if not)
-            curl -s --max-time 3 http://127.0.0.1:3000/ > /dev/null || { echo "FAIL: NO_LISTENER_3000"; exit 1; }
             FAIL_COUNT=0
             for i in $(seq 1 20); do
               CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://127.0.0.1:3000/manifest.webmanifest || echo "000")


### PR DESCRIPTION
## Why

Deploy workflow fails transiently (slow start / db degraded) even though PROD becomes healthy seconds later.

## What

1. **Add WAIT_FOR_3000 readiness gate** (90s max, 18 attempts × 5s) before 20x curl proof
2. **Deep Health check already warning-only** (verified - no change needed)
3. **Preserve existing .env**: upsert only workflow-managed keys (NODE_ENV, PORT, DATABASE_URL, etc.), preserve other keys like `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`

## Changes

| Item | Before | After |
|------|--------|-------|
| Pre-proof wait | None | 90s readiness gate |
| .env handling | Wipe & recreate | Upsert only managed keys |
| db:error | Warning (non-blocking) | No change needed |

## Test Plan

- [ ] CI checks pass
- [ ] Trigger deploy-frontend workflow manually
- [ ] Deploy should PASS (no false NO_LISTENER_3000)

---
Generated-by: Claude Code