### PR TITLE
docs: SEC-UDEV-01 incident + security audit report

### DIFF
--- a/docs/SECURITY/AUDIT-2026-01-15.md
+++ b/docs/SECURITY/AUDIT-2026-01-15.md
@@ -1,0 +1,242 @@
+# Security Audit Report — 2026-01-15
+
+**Audit Time**: 2026-01-15 10:53 UTC
+**Auditor**: Claude (AI-assisted)
+**VPS**: srv709397 (147.93.126.235)
+**Method**: READ-ONLY — No changes made to VPS
+
+---
+
+## Executive Summary
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| **System Load** | CLEAN | Load 0.00, no suspicious CPU usage |
+| **Processes** | CLEAN | All processes legitimate (Next.js, PM2, PHP-FPM, nginx) |
+| **Network** | CLEAN | No mining pool connections, only SSH active |
+| **Persistence (UDEV)** | CLEAN | `/etc/udev/rules.d/` is empty |
+| **Persistence (Cron)** | CLEAN | No suspicious cron jobs |
+| **Persistence (Systemd)** | CLEAN | All 24 running services legitimate |
+| **SSH/Access** | CLEAN | Proper key-only auth, brute force attempts blocked |
+| **IOC Sweep** | CLEAN | No suspicious files in /tmp, /var/tmp, /dev/shm |
+| **Firewall** | ACTIVE | UFW with INPUT policy DROP |
+
+**Overall Assessment**: System appears clean after SEC-UDEV-01 remediation.
+
+---
+
+## 1. Current Load & Processes
+
+### System Load
+```
+Uptime: 1 day, 13:28
+Load average: 0.00, 0.00, 0.13
+```
+
+### Top CPU Processes
+| User | PID | %CPU | Command |
+|------|-----|------|---------|
+| deploy | 20734 | 1.0% | next-server (v15.5.9) |
+| deploy | 20711 | 0.3% | pm2-logrotate |
+| root | 752 | 0.1% | fail2ban-server |
+| deploy | 20700 | 0.1% | PM2 God Daemon |
+
+**Assessment**: All processes are legitimate application services. No suspicious high-CPU processes.
+
+### Top Memory Processes
+| User | PID | %MEM | Command |
+|------|-----|------|---------|
+| deploy | 20734 | 3.5% | next-server (v15.5.9) |
+| deploy | 20711 | 0.8% | pm2-logrotate |
+| deploy | 20700 | 0.7% | PM2 God Daemon |
+| root | 1142 | 0.7% | PM2 (root - suspected unused) |
+
+**Note**: There's a PM2 daemon running as root (PID 1142). This may be leftover from previous setup — worth investigating if intentional.
+
+---
+
+## 2. Persistence Check
+
+### UDEV Rules
+```
+/etc/udev/rules.d/: EMPTY (2 entries: . and ..)
+```
+**Assessment**: CLEAN — The malicious `99-auto-upgrade.rules` was successfully removed in SEC-UDEV-01.
+
+### Cron Jobs (/etc/cron.d/)
+| File | Size | Purpose |
+|------|------|---------|
+| .placeholder | 102 | System placeholder |
+| certbot | 802 | Let's Encrypt renewal |
+| e2scrub_all | 201 | Filesystem check |
+| php | 712 | PHP session cleanup |
+| sysstat | 396 | System statistics |
+
+**Pattern Search**: No matches for `wget`, `curl`, `/dev/tcp`, `base64`, or known C2 domains.
+
+**Assessment**: CLEAN — All cron jobs are legitimate system/application jobs.
+
+### Systemd Timers
+All 19 timers are standard Ubuntu system timers:
+- sysstat-collect.timer
+- phpsessionclean.timer
+- certbot.timer
+- apt-daily.timer
+- logrotate.timer
+- etc.
+
+**Assessment**: CLEAN — No suspicious custom timers.
+
+### Running Services (24 total)
+All services are legitimate:
+- nginx, php8.2-fpm (web stack)
+- fail2ban (security)
+- ssh (remote access)
+- systemd-* (system services)
+
+**Assessment**: CLEAN — No suspicious services.
+
+---
+
+## 3. Network & Egress
+
+### Active Connections
+```
+State  Local Address:Port    Peer Address:Port    Process
+ESTAB  147.93.126.235:22     94.66.136.90:21963   sshd (audit session)
+```
+
+### Mining Pool Connection Check
+```
+grep -E 'stratum|3333|4444|5555|14444|xmr|monero|pool': No matches
+```
+
+**Assessment**: CLEAN — Only legitimate SSH connection active. No mining pool or C2 connections.
+
+### Firewall (iptables/UFW)
+```
+Chain INPUT (policy DROP)
+Chain FORWARD (policy DROP)
+Chain OUTPUT (policy ACCEPT)
+```
+
+**Note**: OUTPUT policy is ACCEPT, meaning unrestricted egress. Consider adding egress filtering.
+
+---
+
+## 4. Access & SSH
+
+### SSH Configuration
+| Setting | Value | Assessment |
+|---------|-------|------------|
+| PermitRootLogin | prohibit-password | KEY-ONLY (correct) |
+| PasswordAuthentication | no | CORRECT |
+| AllowUsers | deploy opsadmin root | OK |
+
+### SSH Key Metadata (no content exposed)
+| User | File | Permissions | Last Modified |
+|------|------|-------------|---------------|
+| root | authorized_keys | 0600 | 2026-01-15 10:33 |
+| deploy | authorized_keys | 0600 | 2026-01-13 23:12 |
+| opsadmin | authorized_keys | 0600 | 2026-01-06 23:29 |
+| ubuntu | authorized_keys | 0600 | 2026-01-06 23:20 |
+
+**Assessment**: Proper permissions on all authorized_keys files.
+
+### Auth Log Analysis (last 80 filtered entries)
+
+**Legitimate Logins**:
+- `94.66.136.90` (admin IP) — Multiple successful key-based logins
+- `172.184.211.242` (GitHub Actions) — Deploy user login
+- `64.236.177.9` (GitHub Actions) — Deploy user login
+
+**Blocked Attempts**:
+- `196.189.51.3` — Brute force (root, ubuntu, admin) — BLOCKED
+- `174.138.9.72` — Brute force (root) — BLOCKED
+- `164.92.146.52` — Brute force (root) — BLOCKED
+
+**Assessment**: fail2ban is working correctly, blocking brute force attempts.
+
+### Users with Shell Access
+| User | UID | Shell | Home |
+|------|-----|-------|------|
+| root | 0 | /bin/bash | /root |
+| ubuntu | 1000 | /bin/bash | /home/ubuntu |
+| deploy | 1001 | /bin/bash | /home/deploy |
+| opsadmin | 1002 | /bin/bash | /home/opsadmin |
+
+**Assessment**: Expected users only. No unauthorized UID 0 accounts.
+
+---
+
+## 5. File IOC Sweep
+
+### Temp Directories (modified in last 12h)
+```
+find /tmp /var/tmp /dev/shm -maxdepth 2 -type f -mmin -720: NO FILES FOUND
+```
+
+**Assessment**: CLEAN — No suspicious files in temporary directories.
+
+### Hosts File Blocks
+The following domains are blocked in `/etc/hosts`:
+- 30+ mining pools (minexmr, supportxmr, nanopool, etc.)
+- C2 domain: `abcdefghijklmnopqrst.net`
+
+**Note**: /etc/hosts blocking is a weak measure. Consider firewall-based blocking.
+
+---
+
+## 6. Conclusions
+
+### Findings Summary
+
+| ID | Severity | Finding | Status |
+|----|----------|---------|--------|
+| F1 | INFO | PM2 running as root (PID 1142) | INVESTIGATE |
+| F2 | LOW | OUTPUT chain policy ACCEPT (no egress filtering) | CONSIDER |
+| F3 | LOW | /etc/hosts-based blocking (weak) | IMPROVE |
+| F4 | INFO | ubuntu user has shell but may be unused | VERIFY |
+
+### System Status
+The VPS appears **clean** after the SEC-UDEV-01 remediation:
+- Malicious UDEV rule removed
+- Malicious cron job removed
+- Miner process killed
+- C2 domain blocked
+- No active malicious connections
+
+---
+
+## 7. Next Actions (Priority Order)
+
+| Priority | Action | Rationale |
+|----------|--------|-----------|
+| 1 | **Monitor for 48-72h** | Verify miner doesn't return |
+| 2 | **Investigate PM2 as root** | Check if `/root/.pm2` is needed or leftover |
+| 3 | **Add egress filtering** | Block outbound to known mining ports (3333, 4444, 5555, 14444) |
+| 4 | **Review ubuntu user** | Disable or remove if unused |
+| 5 | **Fail2ban tuning** | Increase ban time for repeat offenders |
+| 6 | **Consider key rotation** | Rotate SSH keys as precaution |
+| 7 | **Automate security checks** | Add cron job for periodic IOC sweep |
+| 8 | **Document incident** | Complete SEC-UDEV-01 post-mortem |
+
+---
+
+## Appendix: Raw Data References
+
+All data collected via READ-ONLY commands:
+- `ps aux --sort=-%cpu`
+- `ss -tpn`
+- `ls -la /etc/udev/rules.d/`
+- `ls -la /etc/cron.d/`
+- `systemctl list-timers --all`
+- `systemctl list-units --type=service --state=running`
+- `tail -n 400 /var/log/auth.log | grep -iE 'Accepted|Failed|Invalid|sudo'`
+- `getent passwd`
+- `ls -la ~/.ssh/` (metadata only, no key content)
+- `find /tmp /var/tmp /dev/shm -maxdepth 2 -type f -mmin -720`
+- `iptables -L -n`
+- `cat /etc/hosts`
+
+**NO CHANGES WERE MADE TO THE VPS DURING THIS AUDIT.**


### PR DESCRIPTION
## Summary

- Document SEC-UDEV-01 incident: UDEV persistence mechanism discovered and removed
- Add comprehensive read-only security audit (2026-01-15)
- SSH hardening verified (key-only root login restored)
- All persistence mechanisms confirmed clean after remediation

## Incident Summary

**Root Cause Found**: `/etc/udev/rules.d/99-auto-upgrade.rules` was recreating the malicious cron job on every network event.

**Why it kept returning**: We deleted the cron job but not the UDEV rule that recreated it.

## Audit Findings

| Category | Status |
|----------|--------|
| System Load | CLEAN |
| Processes | CLEAN |
| Network | CLEAN |
| Persistence | CLEAN |
| SSH/Access | CLEAN |
| IOC Sweep | CLEAN |

## Files Changed

- `docs/OPS/STATE.md` — SEC-UDEV-01 incident documentation
- `docs/SECURITY/AUDIT-2026-01-15.md` — Full audit report (read-only VPS scan)

## Test plan

- [x] VPS audit completed (read-only)
- [x] No changes made to VPS during audit
- [x] SSH hardening verified
- [ ] Monitor VPS for 48-72h to confirm no recurrence