### PR TITLE
test: add 4 @smoke page load tests (TEST-COVERAGE-01)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-TEST-COVERAGE-01.md
+++ b/docs/AGENT/SUMMARY/Pass-TEST-COVERAGE-01.md
@@ -1,0 +1,30 @@
+# Pass TEST-COVERAGE-01 Summary
+
+**Date**: 2026-01-15
+**Status**: COMPLETE
+
+## Changes
+
+Added 4 new `@smoke` tests for public page loads:
+- `/producers` - Producer listing
+- `/contact` - Contact page
+- `/legal/terms` - Terms of service
+- `/legal/privacy` - Privacy policy
+
+## Files Modified
+
+- `frontend/tests/e2e/smoke.spec.ts` (+48 lines)
+
+## Impact
+
+- Smoke test count in smoke.spec.ts: 11 → 15
+- Total @smoke coverage: ~37 → ~41 tests
+- CI runtime impact: Minimal (4 fast page loads)
+
+## Verification
+
+All tests follow CI-safe patterns:
+- No auth required
+- No SSR data dependency
+- Accept multiple valid status codes
+- Use web-first assertions

--- a/docs/AGENT/TASKS/Pass-TEST-COVERAGE-01.md
+++ b/docs/AGENT/TASKS/Pass-TEST-COVERAGE-01.md
@@ -1,0 +1,47 @@
+# Pass TEST-COVERAGE-01
+
+**When**: 2026-01-15
+
+## What
+
+Expand `@smoke` test coverage by adding 4 new CI-safe page load tests.
+
+## Why
+
+More smoke tests = faster detection of broken pages in CI. All new tests target public, read-only pages that require no auth or data setup.
+
+## How
+
+Added 4 tests to `frontend/tests/e2e/smoke.spec.ts`:
+1. `@smoke producers page loads` - Producer listing page
+2. `@smoke contact page loads` - Contact page
+3. `@smoke terms page loads` - Legal terms page
+4. `@smoke privacy page loads` - Legal privacy page
+
+All tests are CI-safe:
+- No auth required
+- No SSR data dependency
+- Accept 200/304 status codes
+- Verify body is visible
+
+## Verification
+
+| Test | Expected |
+|------|----------|
+| `@smoke producers page loads` | 200/304, body visible |
+| `@smoke contact page loads` | 200/304, body visible |
+| `@smoke terms page loads` | 200/304, body visible |
+| `@smoke privacy page loads` | 200/304, body visible |
+
+## Definition of Done
+
+- [x] 4 new `@smoke` tests added to smoke.spec.ts
+- [ ] CI E2E PostgreSQL job discovers and runs all @smoke tests
+- [ ] All @smoke tests PASS
+- [ ] quality-gates PASS
+
+## PRs
+
+| PR | Title | Status |
+|----|-------|--------|
+| TBD | test: add 4 @smoke page load tests (TEST-COVERAGE-01) | PENDING |

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -158,3 +158,51 @@ test('@smoke home page loads', async ({ page }) => {
   // Page rendered meaningful structure
   expect(hasNav || hasMain).toBe(true);
 });
+
+// === TEST-COVERAGE-01: 4 new @smoke tests for public pages ===
+
+// @smoke — Producers listing page loads without crash
+// CI-safe: Public page that lists producers
+test('@smoke producers page loads', async ({ page }) => {
+  const response = await page.goto('/producers', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+  // Page should load (200) or show content
+  const status = response?.status() || 0;
+  expect([200, 304].includes(status)).toBe(true);
+
+  // Body should be visible
+  await expect(page.locator('body')).toBeVisible({ timeout: 10000 });
+});
+
+// @smoke — Contact page loads without crash
+// CI-safe: Static contact page
+test('@smoke contact page loads', async ({ page }) => {
+  const response = await page.goto('/contact', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+  const status = response?.status() || 0;
+  expect([200, 304].includes(status)).toBe(true);
+
+  await expect(page.locator('body')).toBeVisible({ timeout: 10000 });
+});
+
+// @smoke — Terms page loads without crash
+// CI-safe: Static legal page
+test('@smoke terms page loads', async ({ page }) => {
+  const response = await page.goto('/legal/terms', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+  const status = response?.status() || 0;
+  expect([200, 304].includes(status)).toBe(true);
+
+  await expect(page.locator('body')).toBeVisible({ timeout: 10000 });
+});
+
+// @smoke — Privacy page loads without crash
+// CI-safe: Static legal page
+test('@smoke privacy page loads', async ({ page }) => {
+  const response = await page.goto('/legal/privacy', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+  const status = response?.status() || 0;
+  expect([200, 304].includes(status)).toBe(true);
+
+  await expect(page.locator('body')).toBeVisible({ timeout: 10000 });
+});


### PR DESCRIPTION
## Summary

Added 4 new CI-safe `@smoke` page load tests for public pages:
- `/producers` - Producer listing page
- `/contact` - Contact page
- `/legal/terms` - Terms of service
- `/legal/privacy` - Privacy policy

## Why

More smoke coverage = faster detection of broken pages in CI.

## Tests Added

| Test | Page | Validation |
|------|------|------------|
| `@smoke producers page loads` | /producers | 200/304, body visible |
| `@smoke contact page loads` | /contact | 200/304, body visible |
| `@smoke terms page loads` | /legal/terms | 200/304, body visible |
| `@smoke privacy page loads` | /legal/privacy | 200/304, body visible |

## CI Safety

All tests follow established patterns:
- No auth required
- No SSR data dependency
- Accept multiple valid status codes
- Use web-first assertions (`expect(locator).toBeVisible()`)

## Test plan

- [ ] E2E (PostgreSQL) discovers and runs new tests
- [ ] All @smoke tests PASS
- [ ] quality-gates PASS