### PR TITLE
fix(e2e): use flexible product URL pattern for CI

### DIFF
--- a/frontend/tests/e2e/guest-checkout.spec.ts
+++ b/frontend/tests/e2e/guest-checkout.spec.ts
@@ -25,7 +25,8 @@ test.describe('Guest Checkout @smoke', () => {
 
     const firstProduct = page.locator('[data-testid="product-card"]').first();
     await firstProduct.locator('a').first().click();
-    await page.waitForURL(/\/products\/\d+/);
+    // Wait for any product detail page (numeric ID or slug like demo-1)
+    await page.waitForURL(/\/products\/[^/]+$/, { timeout: 10000 });
 
     const addToCartBtn = page.getByTestId('add-to-cart');
     await addToCartBtn.click();
@@ -47,7 +48,8 @@ test.describe('Guest Checkout @smoke', () => {
 
     const firstProduct = page.locator('[data-testid="product-card"]').first();
     await firstProduct.locator('a').first().click();
-    await page.waitForURL(/\/products\/\d+/);
+    // Wait for any product detail page (numeric ID or slug like demo-1)
+    await page.waitForURL(/\/products\/[^/]+$/, { timeout: 10000 });
 
     const addToCartBtn = page.getByTestId('add-to-cart');
     await addToCartBtn.click();
@@ -88,7 +90,8 @@ test.describe('Guest Checkout @smoke', () => {
 
     const firstProduct = page.locator('[data-testid="product-card"]').first();
     await firstProduct.locator('a').first().click();
-    await page.waitForURL(/\/products\/\d+/);
+    // Wait for any product detail page (numeric ID or slug like demo-1)
+    await page.waitForURL(/\/products\/[^/]+$/, { timeout: 10000 });
 
     const addToCartBtn = page.getByTestId('add-to-cart');
     await addToCartBtn.click();
@@ -130,7 +133,8 @@ test.describe('Guest Checkout @smoke', () => {
 
     const firstProduct = page.locator('[data-testid="product-card"]').first();
     await firstProduct.locator('a').first().click();
-    await page.waitForURL(/\/products\/\d+/);
+    // Wait for any product detail page (numeric ID or slug like demo-1)
+    await page.waitForURL(/\/products\/[^/]+$/, { timeout: 10000 });
 
     const addToCartBtn = page.getByTestId('add-to-cart');
     await addToCartBtn.click();


### PR DESCRIPTION
## Summary

Fixes the guest checkout E2E test to work with CI mock products that use slugs (like `demo-1`) instead of numeric IDs.

## Change

- `/products/\d+/` → `/products/[^/]+$/`
- Adds 10s explicit timeout

## Root Cause

CI seeded products have slugs like `demo-1`, not numeric IDs. The original regex only matched numeric IDs.

---
Follow-up to PR #2232 which merged before E2E completed.