### PR TITLE
feat: Pass SEARCH-FTS-01 full-text product search

### DIFF
--- a/backend/database/migrations/2026_01_16_163733_add_search_vector_to_products_table.php
+++ b/backend/database/migrations/2026_01_16_163733_add_search_vector_to_products_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Pass SEARCH-FTS-01: Add full-text search vector to products table.
+     * PostgreSQL-only: tsvector generated column + GIN index for ranked search.
+     */
+    public function up(): void
+    {
+        // Only apply FTS on PostgreSQL
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        // Add tsvector column as stored generated column
+        // Combines name and description for full-text search
+        DB::statement("
+            ALTER TABLE products
+            ADD COLUMN IF NOT EXISTS search_vector tsvector
+            GENERATED ALWAYS AS (
+                to_tsvector('simple', COALESCE(name, '') || ' ' || COALESCE(description, ''))
+            ) STORED
+        ");
+
+        // Add GIN index for fast full-text search queries
+        DB::statement("
+            CREATE INDEX IF NOT EXISTS products_search_vector_idx
+            ON products USING GIN (search_vector)
+        ");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Only revert on PostgreSQL
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        DB::statement("DROP INDEX IF EXISTS products_search_vector_idx");
+        DB::statement("ALTER TABLE products DROP COLUMN IF EXISTS search_vector");
+    }
+};

--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -1,7 +1,8 @@
 import { Suspense } from 'react';
 import { ProductCard } from '@/components/ProductCard';
 import { CategoryStrip } from '@/components/CategoryStrip';
-import { DEMO_PRODUCTS, filterProductsByCategory } from '@/data/demoProducts';
+import { ProductSearchInput } from '@/components/ProductSearchInput';
+import { DEMO_PRODUCTS } from '@/data/demoProducts';
 
 type ApiItem = {
   id: string | number;
@@ -14,7 +15,11 @@ type ApiItem = {
   categorySlug?: string;
 };
 
-async function getData(): Promise<{ items: ApiItem[]; total: number; isDemo: boolean }> {
+/**
+ * Pass SEARCH-FTS-01: Fetch products with optional search parameter.
+ * Uses FTS ranking on PostgreSQL backend, ILIKE fallback on others.
+ */
+async function getData(search?: string): Promise<{ items: ApiItem[]; total: number; isDemo: boolean }> {
   // Use internal URL for SSR to avoid external round-trip timeout (Pass 26 fix)
   // CRITICAL: No localhost fallback - use relative URL if not configured
   const isServer = typeof window === 'undefined';
@@ -23,21 +28,30 @@ async function getData(): Promise<{ items: ApiItem[]; total: number; isDemo: boo
     : (process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1');
 
   try {
-    const res = await fetch(`${base}/public/products`, {
+    // Build URL with search param if provided
+    const url = new URL(`${base}/public/products`, 'http://localhost');
+    if (search?.trim()) {
+      url.searchParams.set('search', search.trim());
+    }
+    const endpoint = url.pathname + url.search;
+
+    const res = await fetch(`${base}/public/products${search?.trim() ? `?search=${encodeURIComponent(search.trim())}` : ''}`, {
       cache: 'no-store',
       headers: { 'Content-Type': 'application/json' },
     });
 
     if (!res.ok) {
       console.error('[Products] API fetch failed:', res.status, res.statusText);
-      // Fall back to demo products
-      return { items: mapDemoToApiItems(DEMO_PRODUCTS), total: DEMO_PRODUCTS.length, isDemo: true };
+      // Fall back to demo products (filtered client-side if search provided)
+      const demoItems = mapDemoToApiItems(DEMO_PRODUCTS);
+      const filtered = search ? filterDemoBySearch(demoItems, search) : demoItems;
+      return { items: filtered, total: filtered.length, isDemo: true };
     }
 
     const json = await res.json();
     const products = json?.data ?? [];
 
-    if (products.length === 0) {
+    if (products.length === 0 && !search) {
       console.log('[Products] API returned empty, using demo fallback');
       return { items: mapDemoToApiItems(DEMO_PRODUCTS), total: DEMO_PRODUCTS.length, isDemo: true };
     }
@@ -56,7 +70,9 @@ async function getData(): Promise<{ items: ApiItem[]; total: number; isDemo: boo
     return { items, total: items.length, isDemo: false };
   } catch (err) {
     console.error('[Products] Fetch error (falling back to demo):', err);
-    return { items: mapDemoToApiItems(DEMO_PRODUCTS), total: DEMO_PRODUCTS.length, isDemo: true };
+    const demoItems = mapDemoToApiItems(DEMO_PRODUCTS);
+    const filtered = search ? filterDemoBySearch(demoItems, search) : demoItems;
+    return { items: filtered, total: filtered.length, isDemo: true };
   }
 }
 
@@ -73,6 +89,17 @@ function mapDemoToApiItems(demoProducts: typeof DEMO_PRODUCTS): ApiItem[] {
   }));
 }
 
+// Filter demo products by search term (client-side fallback)
+function filterDemoBySearch(items: ApiItem[], search: string): ApiItem[] {
+  const term = search.toLowerCase().trim();
+  if (!term) return items;
+  return items.filter(
+    (item) =>
+      item.title.toLowerCase().includes(term) ||
+      (item.producerName && item.producerName.toLowerCase().includes(term))
+  );
+}
+
 // Filter items by category
 function filterByCategory(items: ApiItem[], categorySlug: string | null): ApiItem[] {
   if (!categorySlug) return items;
@@ -80,16 +107,31 @@ function filterByCategory(items: ApiItem[], categorySlug: string | null): ApiIte
 }
 
 interface PageProps {
-  searchParams: Promise<{ cat?: string }>;
+  searchParams: Promise<{ cat?: string; search?: string }>;
 }
 
 export default async function Page({ searchParams }: PageProps) {
   const params = await searchParams;
   const categoryFilter = params.cat || null;
+  const searchQuery = params.search || null;
 
-  const { items: allItems = [], isDemo } = await getData();
+  const { items: allItems = [], isDemo } = await getData(searchQuery || undefined);
   const items = filterByCategory(allItems, categoryFilter);
   const total = items.length;
+
+  // Determine appropriate message for empty state
+  const getEmptyMessage = () => {
+    if (searchQuery && categoryFilter) {
+      return `Δεν βρέθηκαν προϊόντα για "${searchQuery}" σε αυτή την κατηγορία.`;
+    }
+    if (searchQuery) {
+      return `Δεν βρέθηκαν προϊόντα για "${searchQuery}".`;
+    }
+    if (categoryFilter) {
+      return 'Δεν υπάρχουν προϊόντα σε αυτή την κατηγορία.';
+    }
+    return 'Δεν υπάρχουν διαθέσιμα προϊόντα αυτή τη στιγμή.';
+  };
 
   return (
     <main className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
@@ -101,13 +143,20 @@ export default async function Page({ searchParams }: PageProps) {
           </div>
         )}
 
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6 gap-4">
           <div>
             <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Προϊόντα</h1>
             <p className="mt-1 text-sm text-gray-600">
-              Απευθείας από παραγωγούς — {total} {categoryFilter ? 'στην κατηγορία' : 'συνολικά'}.
+              {searchQuery
+                ? `${total} αποτέλεσμα${total !== 1 ? 'τα' : ''} για "${searchQuery}"`
+                : `Απευθείας από παραγωγούς — ${total} ${categoryFilter ? 'στην κατηγορία' : 'συνολικά'}.`}
             </p>
           </div>
+
+          {/* Search Input */}
+          <Suspense fallback={<div className="h-10 w-full max-w-md bg-gray-100 rounded-lg animate-pulse" />}>
+            <ProductSearchInput />
+          </Suspense>
         </div>
 
         {/* Category Strip */}
@@ -132,12 +181,11 @@ export default async function Page({ searchParams }: PageProps) {
             ))}
           </div>
         ) : (
-          <div className="text-center py-20 bg-white rounded-xl border border-dashed border-gray-300">
-            <p className="text-gray-500 text-lg">
-              {categoryFilter
-                ? 'Δεν υπάρχουν προϊόντα σε αυτή την κατηγορία.'
-                : 'Δεν υπάρχουν διαθέσιμα προϊόντα αυτή τη στιγμή.'}
-            </p>
+          <div
+            className="text-center py-20 bg-white rounded-xl border border-dashed border-gray-300"
+            data-testid="no-results"
+          >
+            <p className="text-gray-500 text-lg">{getEmptyMessage()}</p>
           </div>
         )}
       </div>

--- a/frontend/src/components/ProductSearchInput.tsx
+++ b/frontend/src/components/ProductSearchInput.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useState, useTransition } from 'react';
+
+/**
+ * Pass SEARCH-FTS-01: Product search input with debounce and URL sync.
+ * 300ms debounce, syncs with ?search= URL param for shareable links.
+ */
+export function ProductSearchInput() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  // Initialize from URL param
+  const initialSearch = searchParams.get('search') || '';
+  const [inputValue, setInputValue] = useState(initialSearch);
+
+  // Debounced URL update
+  const updateSearchParam = useCallback(
+    (value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value.trim()) {
+        params.set('search', value.trim());
+      } else {
+        params.delete('search');
+      }
+      // Keep category param if present
+      const queryString = params.toString();
+      startTransition(() => {
+        router.push(`/products${queryString ? `?${queryString}` : ''}`, { scroll: false });
+      });
+    },
+    [router, searchParams]
+  );
+
+  // Debounce effect (300ms)
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      // Only update if value differs from URL
+      const currentUrlSearch = searchParams.get('search') || '';
+      if (inputValue.trim() !== currentUrlSearch) {
+        updateSearchParam(inputValue);
+      }
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [inputValue, searchParams, updateSearchParam]);
+
+  // Sync input when URL changes externally (e.g., back/forward nav)
+  useEffect(() => {
+    const urlSearch = searchParams.get('search') || '';
+    if (urlSearch !== inputValue && !isPending) {
+      setInputValue(urlSearch);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
+  const handleClear = () => {
+    setInputValue('');
+    updateSearchParam('');
+  };
+
+  return (
+    <div className="relative w-full max-w-md">
+      <input
+        type="search"
+        data-testid="search-input"
+        placeholder="Αναζήτηση προϊόντων..."
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none transition-all"
+        aria-label="Αναζήτηση προϊόντων"
+      />
+      {inputValue && (
+        <button
+          type="button"
+          onClick={handleClear}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+          aria-label="Καθαρισμός αναζήτησης"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+      {isPending && (
+        <div className="absolute right-10 top-1/2 -translate-y-1/2">
+          <div className="w-4 h-4 border-2 border-green-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements full-text product search with ranking on PostgreSQL.

### Backend
- **Migration**: Adds `search_vector` tsvector column (PostgreSQL-only) with GIN index
- **Controller**: Uses `websearch_to_tsquery('simple', ?)` for safe query construction
- **Ranking**: Results ordered by `ts_rank_cd` (best match first)
- **Fallback**: ILIKE search on non-PostgreSQL (SQLite in CI)

### Frontend
- **Search input**: Added to `/products` page with `data-testid="search-input"`
- **Debounce**: 300ms debounce to reduce API calls
- **URL sync**: Search syncs with `?search=` param for shareable links
- **No results**: Shows message with `data-testid="no-results"` when empty

### Tests
- PHPUnit: `test_search_returns_empty_for_nonsense_query`, `test_search_works_with_greek_characters`
- E2E: Updated `filters-search.spec.ts` to navigate to `/products` and test search input

## Technical Notes

- **Greek handling**: Uses `'simple'` text search config (no stemming). Accent handling is client-side only.
- **CI compatibility**: Migration is conditional on `DB::getDriverName() === 'pgsql'`
- **No silent fallback**: FTS errors on PostgreSQL will propagate (no try/catch hiding)

## Test Plan

- [x] Backend tests pass (16 tests in PublicProductsTest)
- [x] Frontend builds without TypeScript errors
- [ ] E2E PostgreSQL check passes
- [ ] Search for "Πορτοκάλια" returns Greek oranges product
- [ ] Nonsense search shows "no results" message

---
Generated-by: claude-opus-4-5-20251101