### PR TITLE
docs: Pass SEARCH-FTS-01 state update

### DIFF
--- a/docs/ACTIVE.md
+++ b/docs/ACTIVE.md
@@ -1,6 +1,6 @@
 # ACTIVE — Dixis Agent State
 
-**Updated**: 2026-01-16 (ADMIN-USERS-01)
+**Updated**: 2026-01-16 (SEARCH-FTS-01)
 
 > **This is THE entry point.** Read this first on every session.
 
@@ -16,9 +16,9 @@ _(empty — pick next unblocked item from NEXT)_
 
 | # | Pass | Description | Effort |
 |---|------|-------------|--------|
-| 1 | SEARCH-FTS-01 | Full-text product search | Medium |
-| 2 | EN-LANGUAGE-01 | English language support | Small |
-| 3 | PRODUCER-DASHBOARD-01 | Producer dashboard enhancements | Medium |
+| 1 | EN-LANGUAGE-01 | English language support | Small |
+| 2 | PRODUCER-DASHBOARD-01 | Producer dashboard enhancements | Medium |
+| 3 | NOTIFICATIONS-01 | In-app notifications system | Medium |
 
 ---
 

--- a/docs/AGENT/SUMMARY/Pass-SEARCH-FTS-01.md
+++ b/docs/AGENT/SUMMARY/Pass-SEARCH-FTS-01.md
@@ -1,0 +1,47 @@
+# Pass SEARCH-FTS-01 Summary
+
+**Date**: 2026-01-16
+**Status**: ✅ CLOSED
+
+## What Changed
+
+Implemented ranked full-text product search using PostgreSQL tsvector with frontend search input.
+
+## Files Created/Modified
+
+| File | Change |
+|------|--------|
+| `backend/database/migrations/2026_01_16_163733_add_search_vector_to_products_table.php` | NEW - tsvector + GIN index |
+| `backend/app/Http/Controllers/Public/ProductController.php` | MODIFIED - FTS ranking |
+| `backend/tests/Feature/PublicProductsTest.php` | MODIFIED - 2 new search tests |
+| `frontend/src/components/ProductSearchInput.tsx` | NEW - Debounced search input |
+| `frontend/src/app/(storefront)/products/page.tsx` | MODIFIED - Added search UI |
+| `frontend/tests/e2e/filters-search.spec.ts` | MODIFIED - Updated for /products |
+
+## Key Decisions
+
+1. **websearch_to_tsquery**: Safely parses user input (handles phrases, operators)
+2. **'simple' config**: No stemming, works with Greek and English
+3. **ILIKE fallback**: Non-PostgreSQL (CI SQLite) uses existing LIKE search
+4. **300ms debounce**: Reduces API calls while typing
+
+## How Ranking Works
+
+On PostgreSQL:
+1. User query is passed to `websearch_to_tsquery('simple', ?)`
+2. Products matching `search_vector @@ query` are selected
+3. Results ranked by `ts_rank_cd(search_vector, query)`
+4. Ordered by rank DESC (best match first)
+
+On SQLite (CI):
+- Falls back to `WHERE name LIKE '%term%' OR description LIKE '%term%'`
+- No ranking, just matching
+
+## Evidence
+
+- PR #2242: https://github.com/lomendor/Project-Dixis/pull/2242 (MERGED)
+- All checks passed: E2E PostgreSQL, PHPUnit, quality-gates, heavy-checks
+
+## Next
+
+Pick EN-LANGUAGE-01 (English Language Support) or PRODUCER-DASHBOARD-01 from NEXT-7D.

--- a/docs/AGENT/TASKS/Pass-SEARCH-FTS-01.md
+++ b/docs/AGENT/TASKS/Pass-SEARCH-FTS-01.md
@@ -1,0 +1,64 @@
+# Pass SEARCH-FTS-01 — Full-Text Product Search
+
+**When**: 2026-01-16
+
+## Goal
+
+Implement ranked full-text product search with PostgreSQL FTS and frontend search input.
+
+## Why
+
+- PRD requirement: "Product search functionality"
+- Identified in PRD-AUDIT-01 as unblocked gap
+- Improves product discoverability for consumers
+
+## How
+
+### Backend
+
+1. **Migration** (`2026_01_16_163733_add_search_vector_to_products_table.php`):
+   - Adds `search_vector` tsvector column (PostgreSQL-only)
+   - Combines `name` and `description` fields
+   - Creates GIN index for fast FTS queries
+
+2. **ProductController::index()** updated:
+   - Uses `websearch_to_tsquery('simple', ?)` for safe query construction
+   - Ranks results with `ts_rank_cd()`
+   - Orders by relevance (best match first)
+   - ILIKE fallback for non-PostgreSQL (SQLite in CI)
+
+### Frontend
+
+1. **ProductSearchInput** component:
+   - 300ms debounce to reduce API calls
+   - Syncs with `?search=` URL param for shareable links
+   - Shows loading spinner during search
+
+2. **Products page** (`/products`):
+   - Search input with `data-testid="search-input"`
+   - "No results" message with `data-testid="no-results"`
+   - Result count shows search term
+
+## Definition of Done
+
+- [x] Backend migration adds tsvector + GIN index (pgsql-only)
+- [x] Backend uses websearch_to_tsquery for safe FTS
+- [x] Backend ranks by ts_rank_cd (best match first)
+- [x] Frontend search input on /products page
+- [x] Frontend URL sync (?search=...) for shareable links
+- [x] Frontend "no results" message
+- [x] PHPUnit tests pass (nonsense query, Greek chars)
+- [x] E2E tests pass (filters-search.spec.ts updated)
+- [x] TASKS + SUMMARY + STATE + NEXT-7D updated
+
+## PRs
+
+| PR | Title | Status |
+|----|-------|--------|
+| #2242 | feat: Pass SEARCH-FTS-01 full-text product search | MERGED |
+
+## Technical Notes
+
+- **Greek handling**: Uses `'simple'` text search config (no stemming). Accent handling is client-side only.
+- **CI compatibility**: Migration conditional on `DB::getDriverName() === 'pgsql'`
+- **No silent fallback**: FTS errors on PostgreSQL will propagate (no try/catch hiding)

--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -1,6 +1,6 @@
 # NEXT 7 DAYS
 
-**Last Updated**: 2026-01-16 (ADMIN-USERS-01)
+**Last Updated**: 2026-01-16 (SEARCH-FTS-01)
 
 > **Entry point**: `docs/ACTIVE.md` | **Archive**: `docs/OPS/STATE-ARCHIVE/`
 
@@ -16,9 +16,9 @@ _(empty — pick next unblocked item from NEXT)_
 
 ### Unblocked (ready to start)
 
-3. **Pass SEARCH-FTS-01** — Full-Text Product Search
-4. **Pass EN-LANGUAGE-01** — English Language Support
-5. **Pass PRODUCER-DASHBOARD-01** — Producer Dashboard Enhancements
+3. **Pass EN-LANGUAGE-01** — English Language Support
+4. **Pass PRODUCER-DASHBOARD-01** — Producer Dashboard Enhancements
+5. **Pass NOTIFICATIONS-01** — In-app Notifications System
 
 See `docs/OPS/STATE.md` for full DoD checklists.
 See `docs/AGENT/SOPs/CREDENTIALS.md` for VPS enablement steps.
@@ -33,6 +33,7 @@ See `docs/PRODUCT/PRD-AUDIT.md` for full gap analysis.
 
 ## Recently Completed (2026-01-14 to 2026-01-16)
 
+- **SEARCH-FTS-01** — Full-text product search with PostgreSQL FTS + ranking ✅
 - **ADMIN-USERS-01** — Admin user management UI at /admin/users ✅
 - **GUEST-CHECKOUT-01** — Guest checkout enabled (no auth required to purchase) ✅
 - **OPS-STATE-THIN-01** — Thin STATE + archive (1009→385 lines, history preserved) ✅

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,8 +1,39 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-16 (ADMIN-USERS-01)
+**Last Updated**: 2026-01-16 (SEARCH-FTS-01)
 
 > **Note**: This file kept ≤250 lines. Older passes in [STATE-ARCHIVE/](STATE-ARCHIVE/).
+
+## 2026-01-16 — Pass SEARCH-FTS-01: Full-Text Product Search
+
+**Status**: ✅ CLOSED
+
+Implemented ranked full-text product search with PostgreSQL FTS and frontend search input.
+
+### Changes
+
+- **Backend migration**: tsvector column + GIN index (PostgreSQL-only)
+- **Backend controller**: websearch_to_tsquery + ts_rank_cd ranking
+- **Frontend**: Search input on /products with debounce + URL sync
+- **Tests**: PHPUnit + E2E filters-search.spec.ts updated
+
+### Features
+
+| Feature | Status |
+|---------|--------|
+| tsvector + GIN index (pgsql) | ✅ |
+| websearch_to_tsquery (safe) | ✅ |
+| ts_rank_cd ranking | ✅ |
+| ILIKE fallback (SQLite CI) | ✅ |
+| Search input with debounce | ✅ |
+| URL sync (?search=...) | ✅ |
+| "No results" message | ✅ |
+
+### PRs
+
+- #2242 (feat: Pass SEARCH-FTS-01 full-text product search) — merged
+
+---
 
 ## 2026-01-16 — Pass ADMIN-USERS-01: Admin User Management UI
 


### PR DESCRIPTION
## Summary

Documentation updates for Pass SEARCH-FTS-01 (Full-Text Product Search).

- Add `docs/AGENT/TASKS/Pass-SEARCH-FTS-01.md` — Task definition
- Add `docs/AGENT/SUMMARY/Pass-SEARCH-FTS-01.md` — Pass summary
- Update `docs/OPS/STATE.md` — Add pass entry at top
- Update `docs/NEXT-7D.md` — Move SEARCH-FTS-01 to recently completed
- Update `docs/ACTIVE.md` — Update next passes queue

## Related PR

- #2242 (feat: Pass SEARCH-FTS-01 full-text product search) — MERGED

## Test Plan

- [x] Docs-only change, no code affected
- [x] Main PR #2242 merged successfully

---
Generated-by: claude-opus-4-5-20251101