### PR TITLE
docs: Pass 52 closed - Stripe live on production

### DIFF
--- a/docs/ACTIVE.md
+++ b/docs/ACTIVE.md
@@ -8,7 +8,7 @@
 
 ## WIP (max 1)
 
-**Pass 52 — Stripe Enable** (code complete, PR pending)
+_(empty — pick next unblocked item from NEXT)_
 
 ---
 
@@ -20,6 +20,7 @@ _(All unblocked passes complete — see docs/PRODUCT/PRD-MUST-V1.md for V1 statu
 
 ## Recently Completed
 
+- **Pass 52** — Stripe Enable (health diagnostic, Stripe live on prod) ✅
 - **CREDENTIALS-01** — Credential wiring map for Pass 52/60 ✅
 - **PRD-AUDIT-REFRESH-01** — Refresh audit after 8 passes (91% health) ✅
 - **PRD-AUDIT-STRUCTURE-01** — Page inventory + flows + V1 must-haves ✅
@@ -34,7 +35,6 @@ _(All unblocked passes complete — see docs/PRODUCT/PRD-MUST-V1.md for V1 statu
 
 | Pass | Blocker | See |
 |------|---------|-----|
-| Pass 52 — Card Payments | Stripe keys needed | `docs/AGENT/SOPs/CREDENTIALS.md` |
 | Pass 60 — Email Infra | SMTP/Resend keys needed | `docs/AGENT/SOPs/CREDENTIALS.md` |
 
 ---

--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -5,14 +5,13 @@
 > **Entry point**: `docs/ACTIVE.md` | **Archive**: `docs/OPS/STATE-ARCHIVE/`
 
 ## WIP (1 item only)
-**Pass 52 — Stripe Enable** (code complete, PR pending)
+_(empty — pick next unblocked item from NEXT)_
 
 ## NEXT (ordered, max 3)
 
 ### Blocked (awaiting credentials)
 
-1. **Pass 52 — Card Payments Enable** (BLOCKED — needs Stripe keys, see CREDENTIALS.md)
-2. **Pass 60 — Email Infrastructure Enable** (BLOCKED — needs SMTP/Resend keys, see CREDENTIALS.md)
+1. **Pass 60 — Email Infrastructure Enable** (BLOCKED — needs SMTP/Resend keys, see CREDENTIALS.md)
 
 ### Unblocked (ready to start)
 
@@ -72,6 +71,7 @@ Full enablement steps: `docs/AGENT/SOPs/CREDENTIALS.md`
 
 ## Recently Completed (2026-01-14 to 2026-01-17)
 
+- **Pass 52** — Stripe Enable (health diagnostic, Stripe live on prod) ✅
 - **CREDENTIALS-01** — Credential wiring map for Pass 52/60 ✅
 - **PRD-AUDIT-REFRESH-01** — Refresh audit after 8 passes (91% health) ✅
 - **PRD-AUDIT-STRUCTURE-01** — Page inventory + flows + V1 must-haves ✅

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -6,9 +6,9 @@
 
 ## 2026-01-17 — Pass 52: Stripe Enable
 
-**Status**: READY FOR CREDENTIALS (code complete)
+**Status**: ✅ CLOSED
 
-Added payment configuration status to health endpoints. All Stripe wiring from Pass 51 confirmed complete.
+Added payment configuration status to health endpoints. Stripe fully operational on production.
 
 ### Changes
 
@@ -21,13 +21,20 @@ Added payment configuration status to health endpoints. All Stripe wiring from P
 - `test_health_endpoint_includes_payments_status()`
 - `test_healthz_endpoint_includes_payments_status()`
 
-### Operator Steps
+### Production Verification
 
-See `docs/AGENT/TASKS/Pass-52-STRIPE-ENABLE.md` for VPS enablement.
-
-### Next
-
-User to provide Stripe credentials, run operator steps on VPS.
+```json
+{
+  "payments": {
+    "cod": "enabled",
+    "card": {
+      "flag": "enabled",
+      "stripe_configured": true,
+      "keys_present": {"secret": true, "public": true, "webhook": true}
+    }
+  }
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary

State doc updates after Pass 52 merge and production verification.

## Changes

- Mark Pass 52 as CLOSED in STATE.md
- Add production verification JSON showing Stripe configured
- Remove Pass 52 from blocked list (now active)
- Update Recently Completed sections

## Evidence

```bash
curl -s https://dixis.gr/api/healthz | jq '.payments.card'
{
  "flag": "enabled",
  "stripe_configured": true,
  "keys_present": {"secret": true, "public": true, "webhook": true}
}
```

---
Generated-by: Claude Code