### PR TITLE
feat: Pass 60.1 - enhanced email runbook + test command

### DIFF
--- a/backend/app/Console/Commands/TestEmail.php
+++ b/backend/app/Console/Commands/TestEmail.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Pass 60.1: Test email command.
+ *
+ * Usage:
+ *   php artisan dixis:email:test --to=your@email.com                    # Send test email
+ *   php artisan dixis:email:test --to=your@email.com --dry-run          # Validate config only
+ *   php artisan dixis:email:test --to=your@email.com --subject="Custom" # Custom subject
+ */
+class TestEmail extends Command
+{
+    protected $signature = 'dixis:email:test
+        {--to= : Recipient email address (required)}
+        {--subject= : Custom subject line}
+        {--dry-run : Validate configuration without sending}';
+
+    protected $description = 'Send a test email to verify email configuration';
+
+    public function handle(): int
+    {
+        $to = $this->option('to');
+        $subject = $this->option('subject') ?? 'Test Email from Dixis';
+        $dryRun = $this->option('dry-run');
+
+        // Validate --to option
+        if (empty($to)) {
+            $this->error('The --to option is required. Usage: php artisan dixis:email:test --to=your@email.com');
+            return Command::FAILURE;
+        }
+
+        // Basic email validation
+        if (!filter_var($to, FILTER_VALIDATE_EMAIL)) {
+            $this->error("Invalid email address: {$to}");
+            return Command::FAILURE;
+        }
+
+        // Get configuration
+        $emailEnabled = config('notifications.email_enabled', false);
+        $mailer = config('mail.default', 'log');
+        $fromAddress = config('mail.from.address', 'info@dixis.gr');
+        $fromName = config('mail.from.name', 'Dixis');
+
+        // Mask FROM address for display (privacy)
+        $maskedFrom = $this->maskEmail($fromAddress);
+
+        if ($dryRun) {
+            $this->info('[DRY RUN] Email configuration validation:');
+            $this->newLine();
+
+            // Check feature flag
+            $flagStatus = $emailEnabled ? 'enabled' : 'disabled';
+            $flagStyle = $emailEnabled ? 'info' : 'comment';
+            $this->line("  EMAIL_NOTIFICATIONS_ENABLED: <{$flagStyle}>{$flagStatus}</{$flagStyle}>");
+
+            // Check mailer
+            $this->line("  Mailer: <info>{$mailer}</info>");
+
+            // Check configuration based on mailer
+            $configured = $this->isMailerConfigured($mailer);
+            $configStatus = $configured ? '<info>valid</info>' : '<error>missing keys</error>';
+            $this->line("  Configuration: {$configStatus}");
+
+            // FROM address
+            $fromOk = !empty($fromAddress) && $fromAddress !== 'hello@example.com';
+            $fromStatus = $fromOk ? '<info>configured</info>' : '<comment>using default</comment>';
+            $this->line("  FROM address: {$fromStatus}");
+
+            $this->newLine();
+
+            if (!$emailEnabled) {
+                $this->warn('[DRY RUN] EMAIL_NOTIFICATIONS_ENABLED is false. Set to true before sending.');
+                $this->line("[DRY RUN] Would send to: {$to}");
+            } elseif (!$configured) {
+                $this->warn("[DRY RUN] Mailer '{$mailer}' is not fully configured.");
+                $this->line("[DRY RUN] Would send to: {$to}");
+            } else {
+                $this->info('[DRY RUN] Email configuration is valid.');
+                $this->line("[DRY RUN] Would send to: {$to}");
+                $this->line("[DRY RUN] From: {$fromName} <{$maskedFrom}>");
+                $this->line("[DRY RUN] Subject: {$subject}");
+            }
+
+            return Command::SUCCESS;
+        }
+
+        // Not dry-run: check if email is enabled
+        if (!$emailEnabled) {
+            $this->error('Email notifications are disabled (EMAIL_NOTIFICATIONS_ENABLED=false).');
+            $this->line('Use --dry-run to validate configuration without sending.');
+            return Command::FAILURE;
+        }
+
+        // Check if mailer is configured
+        if (!$this->isMailerConfigured($mailer)) {
+            $this->error("Mailer '{$mailer}' is not fully configured.");
+            $this->line('Use --dry-run to see configuration details.');
+            return Command::FAILURE;
+        }
+
+        // Send actual email
+        $this->info("Sending test email to: {$to}");
+
+        try {
+            Mail::raw("This is a test email from Dixis.\n\nIf you received this, your email configuration is working correctly.\n\nMailer: {$mailer}\nSent at: " . now()->toISOString(), function ($message) use ($to, $subject) {
+                $message->to($to)
+                    ->subject($subject);
+            });
+
+            $this->newLine();
+            $this->info("[OK] Test email sent successfully to {$to}");
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $this->error('Failed to send test email: ' . $e->getMessage());
+            return Command::FAILURE;
+        }
+    }
+
+    /**
+     * Check if the given mailer is properly configured.
+     */
+    protected function isMailerConfigured(string $mailer): bool
+    {
+        if ($mailer === 'resend') {
+            return !empty(config('services.resend.key'));
+        }
+
+        if ($mailer === 'smtp') {
+            $host = config('mail.mailers.smtp.host');
+            $user = config('mail.mailers.smtp.username');
+            return !empty($host) && $host !== '127.0.0.1' && !empty($user);
+        }
+
+        // Log, array, and other dev mailers are always "configured"
+        if (in_array($mailer, ['log', 'array', 'failover', 'roundrobin'])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Mask email for display (privacy).
+     */
+    protected function maskEmail(string $email): string
+    {
+        $parts = explode('@', $email);
+        if (count($parts) !== 2) {
+            return '***';
+        }
+        $local = $parts[0];
+        $domain = $parts[1];
+        $masked = substr($local, 0, 1) . '***';
+        return "{$masked}@{$domain}";
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -34,11 +34,16 @@ Route::get('/health', function () {
     ];
 
     // Pass 60: Email configuration status (no secrets exposed)
+    // Pass 60.1: Added from_configured field
     $emailEnabled = config('notifications.email_enabled', false);
     $mailer = config('mail.default', 'log');
     $resendKeySet = !empty(config('services.resend.key'));
     $smtpHostSet = !empty(config('mail.mailers.smtp.host')) && config('mail.mailers.smtp.host') !== '127.0.0.1';
     $smtpUserSet = !empty(config('mail.mailers.smtp.username'));
+
+    // Check FROM address configuration (fallback to info@dixis.gr is applied in mail.php)
+    $fromAddress = config('mail.from.address', 'info@dixis.gr');
+    $fromConfigured = !empty($fromAddress) && $fromAddress !== 'hello@example.com';
 
     // Determine if email is properly configured based on mailer type
     $emailConfigured = false;
@@ -56,6 +61,7 @@ Route::get('/health', function () {
         'flag' => $emailEnabled ? 'enabled' : 'disabled',
         'mailer' => $mailer,
         'configured' => $emailConfigured,
+        'from_configured' => $fromConfigured,
         'keys_present' => [
             'resend' => $resendKeySet,
             'smtp_host' => $smtpHostSet,
@@ -102,11 +108,16 @@ Route::get('/healthz', function () {
     ];
 
     // Pass 60: Email configuration status (no secrets exposed)
+    // Pass 60.1: Added from_configured field
     $emailEnabled = config('notifications.email_enabled', false);
     $mailer = config('mail.default', 'log');
     $resendKeySet = !empty(config('services.resend.key'));
     $smtpHostSet = !empty(config('mail.mailers.smtp.host')) && config('mail.mailers.smtp.host') !== '127.0.0.1';
     $smtpUserSet = !empty(config('mail.mailers.smtp.username'));
+
+    // Check FROM address configuration (fallback to info@dixis.gr is applied in mail.php)
+    $fromAddress = config('mail.from.address', 'info@dixis.gr');
+    $fromConfigured = !empty($fromAddress) && $fromAddress !== 'hello@example.com';
 
     // Determine if email is properly configured based on mailer type
     $emailConfigured = false;
@@ -124,6 +135,7 @@ Route::get('/healthz', function () {
         'flag' => $emailEnabled ? 'enabled' : 'disabled',
         'mailer' => $mailer,
         'configured' => $emailConfigured,
+        'from_configured' => $fromConfigured,
         'keys_present' => [
             'resend' => $resendKeySet,
             'smtp_host' => $smtpHostSet,

--- a/backend/tests/Feature/Api/V1/HealthTest.php
+++ b/backend/tests/Feature/Api/V1/HealthTest.php
@@ -60,6 +60,7 @@ class HealthTest extends TestCase
 
     /**
      * Pass 60: Verify health endpoint includes email configuration status
+     * Pass 60.1: Added from_configured field
      */
     public function test_health_endpoint_includes_email_status(): void
     {
@@ -73,6 +74,7 @@ class HealthTest extends TestCase
                     'flag',
                     'mailer',
                     'configured',
+                    'from_configured',
                     'keys_present' => ['resend', 'smtp_host', 'smtp_user'],
                 ],
                 'timestamp',
@@ -86,10 +88,15 @@ class HealthTest extends TestCase
         // Mailer should be a valid string
         $mailer = $res->json('email.mailer');
         $this->assertIsString($mailer);
+
+        // from_configured should be a boolean
+        $fromConfigured = $res->json('email.from_configured');
+        $this->assertIsBool($fromConfigured);
     }
 
     /**
      * Pass 60: Verify healthz endpoint also includes email configuration status
+     * Pass 60.1: Added from_configured field
      */
     public function test_healthz_endpoint_includes_email_status(): void
     {
@@ -101,7 +108,12 @@ class HealthTest extends TestCase
                     'flag',
                     'mailer',
                     'configured',
+                    'from_configured',
                 ],
             ]);
+
+        // from_configured should be a boolean
+        $fromConfigured = $res->json('email.from_configured');
+        $this->assertIsBool($fromConfigured);
     }
 }

--- a/backend/tests/Feature/Console/TestEmailCommandTest.php
+++ b/backend/tests/Feature/Console/TestEmailCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * Pass 60.1: Tests for dixis:email:test Artisan command.
+ *
+ * These tests use Mail::fake() to avoid actually sending emails in CI.
+ */
+#[\PHPUnit\Framework\Attributes\CoversClass(\App\Console\Commands\TestEmail::class)]
+class TestEmailCommandTest extends TestCase
+{
+    /**
+     * Test that command fails without --to option.
+     */
+    public function test_command_requires_to_option(): void
+    {
+        $this->artisan('dixis:email:test')
+            ->assertFailed();
+    }
+
+    /**
+     * Test that command validates email format.
+     */
+    public function test_command_validates_email_format(): void
+    {
+        $this->artisan('dixis:email:test', ['--to' => 'invalid-email'])
+            ->assertFailed();
+    }
+
+    /**
+     * Test that dry-run mode works and shows configuration status.
+     */
+    public function test_dry_run_mode_shows_configuration(): void
+    {
+        $this->artisan('dixis:email:test', [
+            '--to' => 'test@example.com',
+            '--dry-run' => true,
+        ])
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that command refuses to send when EMAIL_NOTIFICATIONS_ENABLED=false.
+     */
+    public function test_command_refuses_when_email_disabled(): void
+    {
+        // Ensure email is disabled
+        config(['notifications.email_enabled' => false]);
+
+        $this->artisan('dixis:email:test', ['--to' => 'test@example.com'])
+            ->assertFailed();
+    }
+
+    /**
+     * Test that dry-run works even when email is disabled.
+     */
+    public function test_dry_run_works_when_email_disabled(): void
+    {
+        config(['notifications.email_enabled' => false]);
+
+        $this->artisan('dixis:email:test', [
+            '--to' => 'test@example.com',
+            '--dry-run' => true,
+        ])
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test that command sends email when enabled (using Mail::fake).
+     */
+    public function test_command_sends_email_when_enabled(): void
+    {
+        Mail::fake();
+
+        // Enable email with log mailer (always configured)
+        config(['notifications.email_enabled' => true]);
+        config(['mail.default' => 'log']);
+
+        $this->artisan('dixis:email:test', ['--to' => 'test@example.com'])
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test custom subject option with dry-run.
+     */
+    public function test_custom_subject_option(): void
+    {
+        $this->artisan('dixis:email:test', [
+            '--to' => 'test@example.com',
+            '--subject' => 'Custom Subject',
+            '--dry-run' => true,
+        ])
+            ->assertSuccessful();
+    }
+}


### PR DESCRIPTION
## Summary

- Enhanced operator runbook with Resend setup checklist, DNS verification steps, and rollback procedures
- Added `from_configured` boolean to `/api/health` and `/api/healthz` endpoints
- Created `php artisan dixis:email:test` command with `--to`, `--subject`, and `--dry-run` options
- Added PHPUnit tests for health endpoint changes and Artisan command

## Files Changed

| File | Change |
|------|--------|
| `docs/AGENT/TASKS/Pass-60-EMAIL-ENABLE.md` | Enhanced runbook with verification steps |
| `backend/routes/api.php` | Added `from_configured` to health endpoints |
| `backend/app/Console/Commands/TestEmail.php` | New Artisan command |
| `backend/tests/Feature/Api/V1/HealthTest.php` | Updated tests for `from_configured` |
| `backend/tests/Feature/Console/TestEmailCommandTest.php` | New command tests |

## Test plan

- [x] PHPUnit tests pass locally (12 tests, 58 assertions)
- [ ] CI checks pass
- [ ] Verify healthz includes `from_configured` after merge

## Usage

```bash
# Dry run (validate config without sending)
php artisan dixis:email:test --to=your@email.com --dry-run

# Send actual test email (requires EMAIL_NOTIFICATIONS_ENABLED=true)
php artisan dixis:email:test --to=your@email.com

# Custom subject
php artisan dixis:email:test --to=your@email.com --subject="Custom Subject"
```

---
Generated by: Claude Code (Pass 60.1)