### PR TITLE
docs: close Pass 60.1 in STATE/NEXT/ACTIVE

### DIFF
--- a/docs/ACTIVE.md
+++ b/docs/ACTIVE.md
@@ -1,6 +1,6 @@
 # ACTIVE — Dixis Agent State
 
-**Updated**: 2026-01-17 (CREDENTIALS-01)
+**Updated**: 2026-01-17 (Pass-60.1-EMAIL-VERIFY)
 
 > **This is THE entry point.** Read this first on every session.
 
@@ -20,6 +20,7 @@ _(All unblocked passes complete — see docs/PRODUCT/PRD-MUST-V1.md for V1 statu
 
 ## Recently Completed
 
+- **Pass 60.1** — Email Verify Tooling (from_configured + test command) ✅
 - **Pass 60** — Email Enable (health diagnostic, awaiting credentials) ✅
 - **Pass 52** — Stripe Enable (health diagnostic, Stripe live on prod) ✅
 - **CREDENTIALS-01** — Credential wiring map for Pass 52/60 ✅
@@ -36,7 +37,7 @@ _(All unblocked passes complete — see docs/PRODUCT/PRD-MUST-V1.md for V1 statu
 
 | Pass | Blocker | See |
 |------|---------|-----|
-| Pass 60 — Email Infra | Resend API key needed | `docs/AGENT/TASKS/Pass-60-EMAIL-ENABLE.md` |
+| OPS-EMAIL-ENABLE-01 | Resend key OR SMTP creds + `EMAIL_NOTIFICATIONS_ENABLED=true` | `docs/AGENT/TASKS/Pass-60-EMAIL-ENABLE.md` |
 
 ---
 

--- a/docs/AGENT/SUMMARY/Pass-60_1-EMAIL-VERIFY.md
+++ b/docs/AGENT/SUMMARY/Pass-60_1-EMAIL-VERIFY.md
@@ -1,0 +1,89 @@
+# Pass 60.1: Email Verification Tooling
+
+**Status**: CLOSED
+**Date**: 2026-01-17
+**PR**: #2271
+
+## What Changed
+
+### Health Endpoints
+
+Added `from_configured` boolean to `/api/health` and `/api/healthz`:
+
+```json
+{
+  "email": {
+    "flag": "disabled",
+    "mailer": "resend",
+    "configured": false,
+    "from_configured": true,
+    "keys_present": {"resend": false, "smtp_host": false, "smtp_user": false}
+  }
+}
+```
+
+### Artisan Command
+
+New command for operators to verify email configuration:
+
+```bash
+# Dry run (validate config without sending)
+php artisan dixis:email:test --to=your@email.com --dry-run
+
+# Send actual test email
+php artisan dixis:email:test --to=your@email.com
+
+# Custom subject
+php artisan dixis:email:test --to=your@email.com --subject="Custom"
+```
+
+Command behavior:
+- Validates email format
+- Checks `EMAIL_NOTIFICATIONS_ENABLED` flag
+- Refuses to send when flag is false (unless `--dry-run`)
+- Shows mailer configuration status in dry-run mode
+
+### Enhanced Runbook
+
+Updated `docs/AGENT/TASKS/Pass-60-EMAIL-ENABLE.md` with:
+- Resend account setup checklist (domain verification, DNS records)
+- VPS enablement steps with explicit verification commands
+- Rollback procedures
+- Troubleshooting section
+
+### Tests
+
+| Test File | Tests |
+|-----------|-------|
+| `HealthTest.php` | Updated 2 tests for `from_configured` |
+| `TestEmailCommandTest.php` | 7 new tests for Artisan command |
+
+## Evidence
+
+- PR #2271 merged: https://github.com/lomendor/Project-Dixis/pull/2271
+- Production healthz shows `from_configured: true`
+- All CI checks passed (phpunit, E2E, quality-gates)
+
+## What Blocks Next
+
+Email sending remains blocked until operator provides:
+
+**Option A (Resend)**:
+- `RESEND_KEY=re_...`
+- `EMAIL_NOTIFICATIONS_ENABLED=true`
+
+**Option B (SMTP)**:
+- `MAIL_HOST`, `MAIL_USERNAME`, `MAIL_PASSWORD`
+- `EMAIL_NOTIFICATIONS_ENABLED=true`
+
+See `docs/AGENT/TASKS/Pass-60-EMAIL-ENABLE.md` for complete runbook.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/routes/api.php` | Added `from_configured` to health endpoints |
+| `backend/app/Console/Commands/TestEmail.php` | New Artisan command |
+| `backend/tests/Feature/Api/V1/HealthTest.php` | Updated tests |
+| `backend/tests/Feature/Console/TestEmailCommandTest.php` | New tests |
+| `docs/AGENT/TASKS/Pass-60-EMAIL-ENABLE.md` | Enhanced runbook |

--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -1,6 +1,6 @@
 # NEXT 7 DAYS
 
-**Last Updated**: 2026-01-17 (Pass-60-EMAIL-ENABLE)
+**Last Updated**: 2026-01-17 (Pass-60.1-EMAIL-VERIFY)
 
 > **Entry point**: `docs/ACTIVE.md` | **Archive**: `docs/OPS/STATE-ARCHIVE/`
 
@@ -11,7 +11,10 @@ _(empty — pick next unblocked item from NEXT)_
 
 ### Blocked (awaiting credentials)
 
-1. **Pass 60 — Email Infrastructure Enable** (BLOCKED — needs SMTP/Resend keys, see CREDENTIALS.md)
+1. **OPS-EMAIL-ENABLE-01** — VPS env + test send (BLOCKED — needs Resend key OR SMTP creds)
+   - Required: `RESEND_KEY` OR (`MAIL_HOST` + `MAIL_USERNAME` + `MAIL_PASSWORD`)
+   - Required: `EMAIL_NOTIFICATIONS_ENABLED=true`
+   - Runbook: `docs/AGENT/TASKS/Pass-60-EMAIL-ENABLE.md`
 
 ### Unblocked (ready to start)
 
@@ -71,6 +74,7 @@ Full enablement steps: `docs/AGENT/SOPs/CREDENTIALS.md`
 
 ## Recently Completed (2026-01-14 to 2026-01-17)
 
+- **Pass 60.1** — Email Verify Tooling (from_configured + Artisan test command) ✅
 - **Pass 60** — Email Enable (health diagnostic, awaiting credentials) ✅
 - **Pass 52** — Stripe Enable (health diagnostic, Stripe live on prod) ✅
 - **CREDENTIALS-01** — Credential wiring map for Pass 52/60 ✅

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,8 +1,54 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-17 (Pass-60-EMAIL-ENABLE)
+**Last Updated**: 2026-01-17 (Pass-60.1-EMAIL-VERIFY)
 
 > **Note**: This file kept ≤250 lines. Older passes in [STATE-ARCHIVE/](STATE-ARCHIVE/).
+
+## 2026-01-17 — Pass 60.1: Email Verification Tooling
+
+**Status**: ✅ CLOSED
+
+Enhanced operator tooling for email enablement. Email still BLOCKED pending credentials.
+
+### Changes
+
+- **Health endpoints**: Added `from_configured` field to `/api/health` and `/api/healthz`
+- **Artisan command**: `php artisan dixis:email:test --to=<email> [--dry-run]`
+- **Runbook**: Enhanced with Resend setup checklist, DNS verification, rollback steps
+
+### Tests Added
+
+- Updated `test_health_endpoint_includes_email_status()` (from_configured assertion)
+- Updated `test_healthz_endpoint_includes_email_status()` (from_configured assertion)
+- New `TestEmailCommandTest` (7 tests for Artisan command)
+
+### Production Verification
+
+```json
+{
+  "email": {
+    "flag": "disabled",
+    "mailer": "resend",
+    "configured": false,
+    "from_configured": true,
+    "keys_present": {"resend": false, "smtp_host": false, "smtp_user": false}
+  }
+}
+```
+
+### Blocked Until
+
+Operator provides credentials:
+- **Option A (Resend)**: `RESEND_KEY=re_...` + `EMAIL_NOTIFICATIONS_ENABLED=true`
+- **Option B (SMTP)**: `MAIL_HOST`, `MAIL_USERNAME`, `MAIL_PASSWORD` + `EMAIL_NOTIFICATIONS_ENABLED=true`
+
+See `docs/AGENT/TASKS/Pass-60-EMAIL-ENABLE.md` for VPS enablement runbook.
+
+### PRs
+
+- #2271 (feat: Pass 60.1 - enhanced email runbook + test command) — merged
+
+---
 
 ## 2026-01-17 — Pass 60: Email Infrastructure Enable
 


### PR DESCRIPTION
## Summary

Docs-only PR to close Pass 60.1 in repository documentation.

- **STATE.md**: Pass 60.1 marked CLOSED with PR #2271 and production proof
- **NEXT-7D.md**: Added OPS-EMAIL-ENABLE-01 as next blocked item
- **ACTIVE.md**: Updated recently completed list and blocked section
- **SUMMARY**: Created Pass-60_1-EMAIL-VERIFY.md

## Production Proof (no secrets)

```json
{
  "email": {
    "flag": "disabled",
    "mailer": "resend",
    "configured": false,
    "from_configured": true,
    "keys_present": {"resend": false, "smtp_host": false, "smtp_user": false}
  }
}
```

## Next Step

**OPS-EMAIL-ENABLE-01** remains BLOCKED until operator provides:
- `RESEND_KEY` OR (`MAIL_HOST` + `MAIL_USERNAME` + `MAIL_PASSWORD`)
- `EMAIL_NOTIFICATIONS_ENABLED=true`

Runbook: `docs/AGENT/TASKS/Pass-60-EMAIL-ENABLE.md`

---
Generated by: Claude Code (Pass 60.1 docs)