### PR TITLE
docs: Pass EMAIL-SMOKE-01 VPS → Resend e2e smoke test

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-EMAIL-SMOKE-01.md
+++ b/docs/AGENT/SUMMARY/Pass-EMAIL-SMOKE-01.md
@@ -1,0 +1,46 @@
+# Pass EMAIL-SMOKE-01: Summary
+
+**Completed**: 2026-01-17
+
+## What Was Done
+
+Verified end-to-end email sending from VPS production backend via Resend.
+
+## Evidence
+
+### Mail Configuration (No Secrets)
+
+| Config | Value |
+|--------|-------|
+| MAIL_MAILER | resend |
+| MAIL_FROM_ADDRESS | info@dixis.gr |
+| MAIL_FROM_NAME | Dixis |
+
+### Test 1: Artisan Command
+
+```bash
+$ ssh dixis-prod 'cd /var/www/dixis/current/backend && php artisan dixis:email:test --to=kourkoutisp@gmail.com'
+Sending test email to: kourkoutisp@gmail.com
+
+[OK] Test email sent successfully to kourkoutisp@gmail.com
+```
+
+### Test 2: Password Reset Endpoint
+
+```bash
+$ curl -s -X POST "https://dixis.gr/api/v1/auth/password/forgot" \
+    -H "Content-Type: application/json" \
+    -d '{"email":"kourkoutisp@gmail.com"}'
+{"message":"If an account exists with this email, you will receive a password reset link."}
+```
+
+## Files Changed
+
+- docs/AGENT/TASKS/Pass-EMAIL-SMOKE-01.md (new)
+- docs/AGENT/SUMMARY/Pass-EMAIL-SMOKE-01.md (new)
+- docs/OPS/STATE.md (updated)
+- docs/NEXT-7D.md (updated)
+
+## Result
+
+Email sending from production VPS via Resend is **fully operational**.

--- a/docs/AGENT/TASKS/Pass-EMAIL-SMOKE-01.md
+++ b/docs/AGENT/TASKS/Pass-EMAIL-SMOKE-01.md
@@ -1,0 +1,46 @@
+# Pass EMAIL-SMOKE-01: VPS → Resend End-to-End Smoke Test
+
+**Created**: 2026-01-17
+
+## Objective
+
+Prove end-to-end email sending from VPS backend via Resend is working.
+
+## Scope
+
+- Smoke test only, no feature work
+- Use existing `dixis:email:test` artisan command
+- Verify password reset endpoint also triggers email
+
+## Prerequisites
+
+- SSH access via `dixis-prod` alias (Pass OPS-SSH-HYGIENE-01)
+- Resend configured (Pass OPS-EMAIL-UNBLOCK-01)
+
+## Definition of Done
+
+- [ ] `php artisan dixis:email:test --to=<email>` returns OK
+- [ ] Password reset endpoint returns 200
+- [ ] Evidence documented in STATE.md
+
+## Verification Commands
+
+```bash
+# SSH test email
+ssh dixis-prod 'cd /var/www/dixis/current/backend && php artisan dixis:email:test --to=kourkoutisp@gmail.com'
+
+# Password reset API
+curl -s -X POST "https://dixis.gr/api/v1/auth/password/forgot" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"kourkoutisp@gmail.com"}'
+```
+
+## Expected Results
+
+```
+[OK] Test email sent successfully to kourkoutisp@gmail.com
+```
+
+```json
+{"message":"If an account exists with this email, you will receive a password reset link."}
+```

--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -1,6 +1,6 @@
 # NEXT 7 DAYS
 
-**Last Updated**: 2026-01-17 (Pass-OPS-SSH-HYGIENE-01)
+**Last Updated**: 2026-01-17 (Pass-EMAIL-SMOKE-01)
 
 > **Entry point**: `docs/ACTIVE.md` | **Archive**: `docs/OPS/STATE-ARCHIVE/`
 
@@ -43,10 +43,10 @@ Email is live on production via Resend. Verified 2026-01-17 via `/api/health`:
 
 ## Recently Completed (2026-01-14 to 2026-01-17)
 
+- **Pass EMAIL-SMOKE-01** — VPS → Resend e2e smoke (artisan test + reset endpoint) ✅
 - **Pass OPS-SSH-HYGIENE-01** — Canonical SSH access (alias + key cleanup + docs) ✅
 - **Pass OPS-EMAIL-UNBLOCK-01** — Email now live on production (Resend verified) ✅
 - **Pass OPS-EMAIL-ENABLE-01** — VPS env configured (RESEND_KEY present) ✅
-- **Pass OPS-EMAIL-SMOKE-01** — Password reset endpoint returns HTTP 200 ✅
 - **Pass EMAIL-AUTH-01** — Password Reset via Resend (backend + frontend + tests) ✅
 - **Pass 60.1** — Email Verify Tooling (from_configured + Artisan test command) ✅
 - **Pass 60** — Email Enable (health diagnostic, now enabled) ✅

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,8 +1,42 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-17 (Pass-OPS-SSH-HYGIENE-01)
+**Last Updated**: 2026-01-17 (Pass-EMAIL-SMOKE-01)
 
 > **Note**: This file kept ≤250 lines. Older passes in [STATE-ARCHIVE/](STATE-ARCHIVE/).
+
+## 2026-01-17 — Pass EMAIL-SMOKE-01: VPS → Resend End-to-End Smoke Test
+
+**Status**: ✅ CLOSED
+
+Verified end-to-end email sending from VPS production backend via Resend.
+
+### Mail Configuration (No Secrets)
+
+| Config | Value |
+|--------|-------|
+| MAIL_MAILER | resend |
+| MAIL_FROM_ADDRESS | info@dixis.gr |
+| MAIL_FROM_NAME | Dixis |
+
+### Evidence
+
+**Test 1: Artisan Command**
+```
+$ ssh dixis-prod 'php artisan dixis:email:test --to=kourkoutisp@gmail.com'
+[OK] Test email sent successfully to kourkoutisp@gmail.com
+```
+
+**Test 2: Password Reset Endpoint**
+```
+$ curl -s -X POST "https://dixis.gr/api/v1/auth/password/forgot" ...
+{"message":"If an account exists with this email, you will receive a password reset link."}
+```
+
+### PRs
+
+- #TBD (docs: Pass EMAIL-SMOKE-01 VPS email smoke test) — pending
+
+---
 
 ## 2026-01-17 — Pass OPS-SSH-HYGIENE-01: Canonical SSH Access
 


### PR DESCRIPTION
## Summary

Verified end-to-end email sending from VPS production backend via Resend.

## Evidence (No Secrets)

| Config | Value |
|--------|-------|
| MAIL_MAILER | resend |
| MAIL_FROM_ADDRESS | info@dixis.gr |
| MAIL_FROM_NAME | Dixis |

### Test 1: Artisan Command

```
$ ssh dixis-prod 'php artisan dixis:email:test --to=kourkoutisp@gmail.com'
[OK] Test email sent successfully to kourkoutisp@gmail.com
```

### Test 2: Password Reset Endpoint

```
$ curl -s -X POST "https://dixis.gr/api/v1/auth/password/forgot" ...
{"message":"If an account exists with this email, you will receive a password reset link."}
```

## Test Plan

- [x] Artisan email test command passes
- [x] Password reset endpoint returns 200
- [x] No code changes, docs only

Generated-by: Claude Code