### PR TITLE
fix: stabilize card-payment-real-auth E2E tests

### DIFF
--- a/docs/AGENT/TASKS/Pass-PAYMENTS-CARD-REAL-01.md
+++ b/docs/AGENT/TASKS/Pass-PAYMENTS-CARD-REAL-01.md
@@ -51,12 +51,33 @@ Updated `.github/workflows/deploy-frontend.yml`:
 
 ## Verification Evidence
 
-### E2E Test Results (2026-01-18)
+### E2E Test Results (2026-01-18 - Final Run)
 
 ```
-Payment options: { cod: true, card: true }
-Card payment option is visible and selectable for authenticated user
+Running 4 tests using 1 worker
+
+  ✓ UI login with real credentials (21.8s)
+    UI login successful
+
+  ✓ add product to cart and reach checkout
+    Reached checkout page as authenticated user
+
+  ✓ card payment option visible for authenticated user
+    Payment options: { cod: true, card: true }
+    Card payment option is visible and selectable for authenticated user
+
+  ○ Stripe test card payment flow [skipped]
+    Stripe Elements not loaded (expected - needs rebuild with STRIPE_PUBLIC_KEY)
+
+  1 skipped
+  3 passed (2.2m)
 ```
+
+### Test Fixes Applied
+
+1. **Auth state clearing**: Tests now clear localStorage/sessionStorage before login to avoid CI mock state interference
+2. **Hydration wait**: Added 500ms wait before clicking login button to handle React re-renders
+3. **Auth indicator selector**: Fixed to include "Logout" button text (English)
 
 ### Health Endpoint
 

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -12,21 +12,34 @@ Enabled repeatable card payment E2E verification and fixed deploy workflow env p
 
 ### Changes
 
-1. **E2E Test with Real Auth**: UI login with secure credentials
-2. **Deploy Workflow**: Stripe publishable key at build time
-3. **GitHub Secret**: `STRIPE_PUBLIC_KEY` for CI/CD
+1. **E2E Test with Real Auth**: UI login with secure credentials (e2e-card-test@dixis.gr)
+2. **Deploy Workflow**: Stripe publishable key at build time (line 55)
+3. **GitHub Secret**: `STRIPE_PUBLIC_KEY` for CI/CD build embedding
+4. **Test Stabilization**: Fixed selector issues for CI mock auth state
 
-### Evidence
+### Evidence (Final Run)
 
 ```
-Payment options: { cod: true, card: true }
+Running 4 tests using 1 worker
+
+  ✓ UI login with real credentials (21.8s)
+  ✓ add product to cart and reach checkout
+  ✓ card payment option visible for authenticated user
+    Payment options: { cod: true, card: true }
+  ○ Stripe test card payment flow [skipped - needs rebuild with key]
+
+  1 skipped, 3 passed (2.2m)
 ```
 
-Card payment option visible for authenticated users.
+### Test Fixes Applied
+
+- Auth state clearing before login to avoid CI mock interference
+- Hydration wait (500ms) before clicking login button
+- Auth indicator selector fixed for "Logout" button text
 
 ### PRs
 
-- #2290 (feat: Pass PAYMENTS-CARD-REAL-01)
+- #2290 (feat: Pass PAYMENTS-CARD-REAL-01) — merged
 
 ---
 


### PR DESCRIPTION
## Summary

- Clear auth state before login to avoid CI mock interference
- Add 500ms hydration wait before clicking login button
- Fix auth indicator selector to include "Logout" button text
- Update docs with final test results

## Test Results

```
Running 4 tests using 1 worker

  ✓ UI login with real credentials (21.8s)
  ✓ add product to cart and reach checkout
  ✓ card payment option visible for authenticated user
    Payment options: { cod: true, card: true }
  ○ Stripe test card payment flow [skipped - needs rebuild with key]

  1 skipped, 3 passed (2.2m)
```

## Test plan

- [x] Run E2E tests against production: `BASE_URL=https://dixis.gr npx playwright test card-payment-real-auth.spec.ts`
- [x] Verify 3 tests pass, 1 skipped (expected - Stripe Elements needs build with key)