### PR TITLE
docs: clarify Stripe Elements test skip reason

### DIFF
--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -41,6 +41,13 @@ Running 4 tests using 1 worker
 
 - #2290 (feat: Pass PAYMENTS-CARD-REAL-01) — merged
 - #2292 (fix: stabilize E2E tests) — merged
+- #2295 (docs: final state update) — merged
+
+### Note on Stripe Elements Test
+
+The "Stripe test card payment flow" test **correctly skips** because Stripe Elements (actual card input form) is **not yet implemented**. The current scope covers:
+- ✅ Card payment option visible for authenticated users
+- ⏭️ Stripe Elements card form - future pass
 
 ---
 


### PR DESCRIPTION
The E2E test correctly skips because Stripe Elements card form is not yet implemented - only the card payment option is visible.