### PR TITLE
feat: Pass PAYMENTS-STRIPE-ELEMENTS-01 embed Stripe Elements

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-PAYMENTS-STRIPE-ELEMENTS-01.md
+++ b/docs/AGENT/SUMMARY/Pass-PAYMENTS-STRIPE-ELEMENTS-01.md
@@ -1,0 +1,37 @@
+# Pass PAYMENTS-STRIPE-ELEMENTS-01: Summary
+
+**Completed**: 2026-01-18
+
+## What Was Done
+
+Replaced Stripe Checkout redirect with embedded Stripe Elements card form in checkout.
+
+## Key Changes
+
+1. **Checkout page**: Renders `StripeProvider` + `StripePaymentForm` when card selected
+2. **API client**: Fixed endpoint paths to match backend (`/payments/orders/{id}/init`)
+3. **E2E test**: Updated to fill form, submit, then interact with Stripe iframe
+
+## Flow
+
+```
+Checkout form → Submit → Order created → initPayment → Stripe Elements → Pay → confirmPayment → Success
+```
+
+## Files
+
+- `frontend/src/app/(storefront)/checkout/page.tsx`
+- `frontend/src/lib/api/payment.ts`
+- `frontend/tests/e2e/card-payment-real-auth.spec.ts`
+
+## Verification
+
+- TypeScript: Passes
+- Lint: No errors
+- LOC: ~145 net (within 300 limit)
+
+## Next Steps
+
+1. CI checks on PR
+2. Deploy to verify Stripe Elements renders
+3. E2E test should pass after deploy (Stripe key embedded at build)

--- a/docs/AGENT/TASKS/Pass-PAYMENTS-STRIPE-ELEMENTS-01.md
+++ b/docs/AGENT/TASKS/Pass-PAYMENTS-STRIPE-ELEMENTS-01.md
@@ -1,0 +1,125 @@
+# Pass PAYMENTS-STRIPE-ELEMENTS-01: Stripe Elements Integration
+
+**Created**: 2026-01-18
+
+## Objective
+
+Replace Stripe Checkout (redirect-based) with embedded Stripe Elements card form in the checkout flow.
+
+## Problem
+
+Card payments previously redirected users to Stripe Checkout (external page). This creates a fragmented UX and loses checkout context.
+
+## Solution
+
+Integrate existing `StripeProvider` and `StripePaymentForm` components into checkout page:
+1. After order creation, call `initPayment` API to get `client_secret`
+2. Render Stripe Elements form inline
+3. On successful payment, call `confirmPayment` API
+4. Redirect to thank-you page
+
+## Changes Made
+
+### Frontend
+
+1. **`frontend/src/app/(storefront)/checkout/page.tsx`**
+   - Import `StripeProvider` and `StripePaymentForm`
+   - Add state for `stripeClientSecret`, `pendingOrderId`, `orderTotal`
+   - Add `handleStripePaymentSuccess`, `handleStripePaymentError`, `handleCancelPayment` handlers
+   - Replace `createPaymentCheckout` (redirect) with `paymentApi.initPayment`
+   - Render Stripe Elements form when `clientSecret` is available
+
+2. **`frontend/src/lib/api/payment.ts`**
+   - Fixed API endpoint paths to match backend routes:
+     - `/payments/orders/{orderId}/init` (was `/orders/{orderId}/payment/init`)
+     - `/payments/orders/{orderId}/confirm`
+     - `/payments/orders/{orderId}/cancel`
+     - `/payments/orders/{orderId}/status`
+
+3. **`frontend/tests/e2e/card-payment-real-auth.spec.ts`**
+   - Updated test 4 to work with new Stripe Elements flow
+   - Test now fills checkout form first, submits, then interacts with Stripe iframe
+   - Added proper handling for PaymentElement iframe structure
+
+### Backend (No Changes)
+
+Backend endpoints already implemented correctly:
+- `POST /api/v1/payments/orders/{order}/init` → returns `client_secret`
+- `POST /api/v1/payments/orders/{order}/confirm` → accepts `payment_intent_id`
+
+## Flow Diagram
+
+```
+User fills checkout form
+         ↓
+Selects "Card" payment
+         ↓
+Clicks "Continue to Payment"
+         ↓
+Order created (status: pending)
+         ↓
+initPayment API called
+         ↓
+client_secret returned
+         ↓
+Stripe Elements form rendered
+         ↓
+User enters card details (4242...)
+         ↓
+Stripe confirmPayment called
+         ↓
+confirmPayment API called
+         ↓
+Order updated (status: paid)
+         ↓
+Redirect to /thank-you
+```
+
+## Definition of Done
+
+- [x] Card payment shows embedded Stripe Elements form
+- [x] API paths corrected to match backend routes
+- [x] E2E test updated for new flow
+- [x] TypeScript compiles without errors
+- [x] Lint passes (no new errors)
+- [ ] E2E test passes in CI
+- [ ] Test card 4242 4242 4242 4242 completes payment (requires deployed build)
+
+## Verification
+
+### TypeScript
+```
+npx tsc --noEmit  # No errors
+```
+
+### Lint
+```
+npm run lint  # No errors (warnings only, pre-existing)
+```
+
+### LOC Count
+```
+219 insertions, 74 deletions = ~145 LOC net change (within ≤300 limit)
+```
+
+## Files Changed
+
+- `frontend/src/app/(storefront)/checkout/page.tsx` (+105 lines)
+- `frontend/src/lib/api/payment.ts` (+5/-5 lines)
+- `frontend/tests/e2e/card-payment-real-auth.spec.ts` (+109/-64 lines)
+- `docs/AGENT/TASKS/Pass-PAYMENTS-STRIPE-ELEMENTS-01.md` (new)
+- `docs/AGENT/SUMMARY/Pass-PAYMENTS-STRIPE-ELEMENTS-01.md` (new)
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Stripe key not embedded at build time | Key added in PR #2290 workflow |
+| Order orphaned if payment fails | User can retry on same order |
+| CSP blocks Stripe iframe | Verify CSP allows *.stripe.com |
+
+## References
+
+- Pass PAYMENTS-CARD-REAL-01 (prerequisite)
+- Backend PaymentController: `backend/app/Http/Controllers/Api/PaymentController.php`
+- Stripe docs: https://stripe.com/docs/payments/payment-element

--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -1,11 +1,11 @@
 # NEXT 7 DAYS
 
-**Last Updated**: 2026-01-18 (Pass-PAYMENTS-CARD-REAL-01)
+**Last Updated**: 2026-01-18 (Pass-PAYMENTS-STRIPE-ELEMENTS-01)
 
 > **Entry point**: `docs/ACTIVE.md` | **Archive**: `docs/OPS/STATE-ARCHIVE/`
 
 ## WIP (1 item only)
-_(empty — pick next unblocked item from NEXT)_
+- **Pass PAYMENTS-STRIPE-ELEMENTS-01** — Stripe Elements integration (PR pending)
 
 ## NEXT (ordered, max 3)
 

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,8 +1,38 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-18 (Pass-PAYMENTS-CARD-REAL-01)
+**Last Updated**: 2026-01-18 (Pass-PAYMENTS-STRIPE-ELEMENTS-01)
 
 > **Note**: This file kept ≤250 lines. Older passes in [STATE-ARCHIVE/](STATE-ARCHIVE/).
+
+## 2026-01-18 — Pass PAYMENTS-STRIPE-ELEMENTS-01: Stripe Elements Integration
+
+**Status**: 🔄 IN PROGRESS
+
+Replaced Stripe Checkout redirect with embedded Stripe Elements card form.
+
+### Changes
+
+1. **Checkout page**: Integrated `StripeProvider` + `StripePaymentForm` for inline card payment
+2. **API client**: Fixed paths to match backend (`/payments/orders/{id}/init`)
+3. **E2E test**: Updated to work with new Stripe Elements flow
+
+### Flow
+
+```
+Checkout form → Submit → initPayment → Stripe Elements → Pay → confirmPayment → Success
+```
+
+### PRs
+
+- #TBD (feat: Pass PAYMENTS-STRIPE-ELEMENTS-01) — pending
+
+### Files Changed
+
+- `frontend/src/app/(storefront)/checkout/page.tsx`
+- `frontend/src/lib/api/payment.ts`
+- `frontend/tests/e2e/card-payment-real-auth.spec.ts`
+
+---
 
 ## 2026-01-18 — Pass PAYMENTS-CARD-REAL-01: Card Payment E2E with Real Auth
 

--- a/frontend/src/lib/api/payment.ts
+++ b/frontend/src/lib/api/payment.ts
@@ -102,7 +102,7 @@ class PaymentApiClient {
       return_url?: string;
     } = {}
   ): Promise<PaymentIntentResponse> {
-    return this.request<PaymentIntentResponse>(`/orders/${orderId}/payment/init`, {
+    return this.request<PaymentIntentResponse>(`/payments/orders/${orderId}/init`, {
       method: 'POST',
       body: JSON.stringify(options),
     });
@@ -112,20 +112,20 @@ class PaymentApiClient {
     orderId: number,
     paymentIntentId: string
   ): Promise<PaymentConfirmationResponse> {
-    return this.request<PaymentConfirmationResponse>(`/orders/${orderId}/payment/confirm`, {
+    return this.request<PaymentConfirmationResponse>(`/payments/orders/${orderId}/confirm`, {
       method: 'POST',
       body: JSON.stringify({ payment_intent_id: paymentIntentId }),
     });
   }
 
   async cancelPayment(orderId: number): Promise<{ message: string }> {
-    return this.request<{ message: string }>(`/orders/${orderId}/payment/cancel`, {
+    return this.request<{ message: string }>(`/payments/orders/${orderId}/cancel`, {
       method: 'POST',
     });
   }
 
-async getPaymentStatus(orderId: number): Promise<PaymentStatusResponse> {
-    return this.request<PaymentStatusResponse>(`/orders/${orderId}/payment/status`);
+  async getPaymentStatus(orderId: number): Promise<PaymentStatusResponse> {
+    return this.request<PaymentStatusResponse>(`/payments/orders/${orderId}/status`);
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace Stripe Checkout redirect with embedded Stripe Elements card form
- Fix API endpoint paths to match backend routes (`/payments/orders/{id}/init`)
- Update E2E test for new Stripe Elements flow

## Changes

| File | Change |
|------|--------|
| `checkout/page.tsx` | Integrate StripeProvider + StripePaymentForm |
| `payment.ts` | Fix API paths to `/payments/orders/...` |
| `card-payment-real-auth.spec.ts` | Update test for Elements flow |

## Flow

```
Checkout form → Submit → initPayment → Stripe Elements → Pay → confirmPayment → Success
```

## Test plan

- [ ] CI checks pass (lint, typecheck)
- [ ] Card payment shows Stripe Elements form after checkout submit
- [ ] Test card 4242... works in TEST mode
- [ ] Order status updates to "paid" after successful payment

## References

- Pass PAYMENTS-CARD-REAL-01 (prerequisite)
- docs/AGENT/TASKS/Pass-PAYMENTS-STRIPE-ELEMENTS-01.md

---
Generated-by: Claude Code