### PR TITLE
fix: add Stripe domains to CSP for Elements support

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -74,11 +74,15 @@ const nextConfig: NextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              // Stripe Elements requires js.stripe.com scripts
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https:",
               "font-src 'self' data:",
-              `connect-src 'self' ${apiOrigin} ${sentryDsn}`,
+              // Stripe API calls require api.stripe.com and r.stripe.com (analytics)
+              `connect-src 'self' ${apiOrigin} ${sentryDsn} https://api.stripe.com https://r.stripe.com`,
+              // Stripe Elements uses iframes from js.stripe.com and hooks.stripe.com
+              "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
               "frame-ancestors 'none'",
             ].join('; '),
           },


### PR DESCRIPTION
## Summary
- Add Stripe domains to Content-Security-Policy header to allow Stripe Elements iframe to load
- Fixes E2E test failure: Stripe Elements iframe not rendering on checkout page

## Changes
- `script-src`: Added `https://js.stripe.com` (Stripe JS SDK)
- `connect-src`: Added `https://api.stripe.com`, `https://r.stripe.com` (API calls)
- `frame-src`: Added `https://js.stripe.com`, `https://hooks.stripe.com` (iframes)

## Root Cause
The existing CSP had no `frame-src` directive, causing iframes to fall back to `default-src 'self'`, which blocked Stripe's iframe domains.

## Test Plan
- [ ] Deploy to production
- [ ] Verify CSP header includes new Stripe domains: `curl -sI "https://dixis.gr/checkout" | grep -i content-security-policy`
- [ ] Run Stripe Elements E2E spec: passes with iframe visible

## Pass
CSP-STRIPE-01

---
Generated by Claude Code