### PR TITLE
docs: Pass EMAIL-VERIFY-01 production deploy evidence

### DIFF
--- a/docs/AGENT/PASSES/SUMMARY-Pass-EMAIL-VERIFY-01.md
+++ b/docs/AGENT/PASSES/SUMMARY-Pass-EMAIL-VERIFY-01.md
@@ -1,10 +1,15 @@
 # SUMMARY: Pass EMAIL-VERIFY-01 — Email Verification Flow
 
 **Date**: 2026-01-18
-**Status**: ✅ DONE
-**PR**: #TBD
+**Status**: ✅ CLOSED (Production Deployed)
+**PR**: #2312 (merged)
+**Commit**: `04aefc91`
 
 ---
+
+## TL;DR
+
+Email verification flow fully implemented and deployed to production. Users can now verify their email after registration. Endpoints working, migration applied, health OK.
 
 ## What Was Done
 
@@ -38,16 +43,28 @@ Implemented complete email verification flow:
 | `EmailVerificationTest.php` | NEW (11 tests) |
 | `email-verification.spec.ts` | NEW (2 tests) |
 
+## Production Deploy
+
+| Step | Status |
+|------|--------|
+| Backend deploy (Run 21118201989) | ✅ Success |
+| Frontend deploy (Run 21118202544) | ✅ Success |
+| Migration (`php artisan migrate --force`) | ✅ Success |
+
 ## Evidence
 
 ```bash
-# Backend tests
-php artisan test --filter=EmailVerificationTest
-# 11 passed, 0 failed
+# Health check (2026-01-18 22:32 UTC)
+curl -sf https://dixis.gr/api/healthz
+# {"status":"ok","database":"connected",...}
 
-# Frontend build
-npm run build
-# ✓ Compiled successfully
+# Resend endpoint
+curl -X POST https://dixis.gr/api/v1/auth/email/resend -d '{"email":"test@example.com"}'
+# {"message":"If an account exists with this email and is not yet verified, you will receive a verification link."}
+
+# Verify endpoint (invalid token returns proper error, not Server Error)
+curl -X POST https://dixis.gr/api/v1/auth/email/verify -d '{"email":"test@example.com","token":"invalid"}'
+# {"message":"Invalid or expired verification token."}
 ```
 
 ## Enable on Production

--- a/docs/AGENT/PASSES/TASK-Pass-EMAIL-VERIFY-01.md
+++ b/docs/AGENT/PASSES/TASK-Pass-EMAIL-VERIFY-01.md
@@ -90,6 +90,38 @@ Implement end-to-end email verification flow allowing users to verify their emai
 - Existing users unaffected (`email_verified_at` nullable)
 - Registration continues to work without verification enabled
 
+## Production Deploy
+
+**Date**: 2026-01-18
+**Commit**: `04aefc91`
+
+### Commands Executed
+
+```bash
+# 1. Trigger deploys via GitHub Actions
+gh workflow run "Deploy Backend (VPS)" --ref main -f run_migrations=true
+gh workflow run "Deploy Frontend (VPS)" --ref main
+
+# 2. SSH to VPS and run migration (manual step)
+cd /var/www/dixis/current/backend
+php artisan migrate --force
+# Output: 2026_01_18_000001_create_email_verification_tokens_table .... DONE
+
+# 3. Verify endpoints work
+curl -X POST https://dixis.gr/api/v1/auth/email/resend -d '{"email":"test@example.com"}'
+# {"message":"If an account exists with this email and is not yet verified..."}
+
+curl -X POST https://dixis.gr/api/v1/auth/email/verify -d '{"email":"test@example.com","token":"invalid"}'
+# {"message":"Invalid or expired verification token."}
+```
+
+### Deploy Runs
+
+| Workflow | Run ID | Status |
+|----------|--------|--------|
+| Deploy Backend (VPS) | 21118201989 | ✅ Success |
+| Deploy Frontend (VPS) | 21118202544 | ✅ Success |
+
 ---
 
 _Pass: EMAIL-VERIFY-01 | Author: Claude_

--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -1,0 +1,14 @@
+# Next 7 Days
+
+**Period**: 2026-01-19 to 2026-01-26
+**Updated**: 2026-01-18
+
+---
+
+## Upcoming Work
+
+- **Perf pass: /products slow load** — Investigate caching/query/SSR optimization for storefront product listing page
+
+---
+
+_Last updated by Pass EMAIL-VERIFY-01 docs wrap-up_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -7,7 +7,7 @@
 
 ## 2026-01-18 — Pass EMAIL-VERIFY-01: Email Verification Flow
 
-**Status**: ✅ DONE
+**Status**: ✅ CLOSED (Production Deployed)
 
 Implemented complete email verification flow for user registration.
 
@@ -29,9 +29,33 @@ EMAIL_NOTIFICATIONS_ENABLED=true   # Enable email sending (already set)
 
 Default: `EMAIL_VERIFICATION_REQUIRED=false` (backwards compatible, auto-verify)
 
+### Production Deploy
+
+- **Date**: 2026-01-18 22:35 UTC
+- **Commit**: `04aefc91`
+- **Backend Deploy**: Run ID 21118201989 (success)
+- **Frontend Deploy**: Run ID 21118202544 (success)
+- **Migration**: `php artisan migrate --force` (manual SSH)
+
+### Evidence
+
+```bash
+# Health check
+curl -sf https://dixis.gr/api/healthz
+# {"status":"ok","database":"connected",...}
+
+# Resend endpoint
+curl -X POST https://dixis.gr/api/v1/auth/email/resend -d '{"email":"test@example.com"}'
+# {"message":"If an account exists with this email and is not yet verified, you will receive a verification link."}
+
+# Verify endpoint
+curl -X POST https://dixis.gr/api/v1/auth/email/verify -d '{"email":"test@example.com","token":"invalid"}'
+# {"message":"Invalid or expired verification token."}
+```
+
 ### PRs
 
-- #TBD (feat: Pass EMAIL-VERIFY-01 email verification flow) — pending
+- #2312 (feat: Pass EMAIL-VERIFY-01 email verification flow) — merged
 
 ---
 


### PR DESCRIPTION
## Summary

- Update STATE.md: mark EMAIL-VERIFY-01 as CLOSED with production deploy evidence
- Update TASK + SUMMARY docs with deploy commands, run IDs, and proof
- Add NEXT-7D.md with perf pass note for /products slow load

## Evidence

- Commit: `04aefc91`
- Backend Deploy: Run ID 21118201989 (success)
- Frontend Deploy: Run ID 21118202544 (success)
- Migration: `php artisan migrate --force` (manual SSH)
- Health: `{"status":"ok","database":"connected",...}`
- Resend endpoint: Returns proper message (not Server Error)
- Verify endpoint: Returns proper message (not Server Error)

## Docs Updated

- `docs/OPS/STATE.md`
- `docs/AGENT/PASSES/TASK-Pass-EMAIL-VERIFY-01.md`
- `docs/AGENT/PASSES/SUMMARY-Pass-EMAIL-VERIFY-01.md`
- `docs/NEXT-7D.md` (new)

---
Generated-by: Claude