### PR TITLE
docs: Pass OPS-EMAIL-PROOF-01 email verification runbook + script

### DIFF
--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -44,6 +44,14 @@
   - PRD cross-reference: 5/5 requirements mapped
   - Gap: Users page shows AdminUser only (nice-to-have for post-V1)
 
+### Ops Runbooks
+
+- ✅ **OPS-EMAIL-PROOF-01**: Email delivery verification runbook + proof script
+  - Created `docs/OPS/RUNBOOKS/EMAIL-PROOF-01.md` (ops checklist)
+  - Created `scripts/email-proof.sh` (deterministic proof script)
+  - Documents required env vars: `RESEND_KEY`, `MAIL_MAILER`, `EMAIL_NOTIFICATIONS_ENABLED`
+  - Unblocks EMAIL-PROOF-01 verification once SSH access available
+
 ## Upcoming Work
 
 ### MVP Gaps (0 remaining)
@@ -104,8 +112,10 @@ Pre-launch verification before announcing V1:
 
 - [~] **EMAIL-PROOF-01**: Verify Resend delivery end-to-end
   - ✅ Resend configured in production (`/api/health` shows `configured: true`)
-  - ⚠️ E2E delivery test blocked: RESEND_API_KEY not available locally
-  - Action: Provide API key or SSH access for full verification
+  - ✅ Runbook created: `docs/OPS/RUNBOOKS/EMAIL-PROOF-01.md`
+  - ✅ Proof script created: `scripts/email-proof.sh`
+  - ⚠️ Final verification blocked: SSH access required
+  - Action: Run `./scripts/email-proof.sh --send --to=your@email.com` once SSH configured
 
 - [x] **SECURITY-AUTH-RL-01**: Auth rate limiting proof
   - ✅ **FIXED** by Pass SEC-AUTH-RL-02
@@ -131,4 +141,4 @@ Pre-launch verification before announcing V1:
 
 ---
 
-_Last updated by Pass ADMIN-IA-01 (2026-01-19)_
+_Last updated by Pass OPS-EMAIL-PROOF-01 (2026-01-19)_

--- a/docs/OPS/RUNBOOKS/EMAIL-PROOF-01.md
+++ b/docs/OPS/RUNBOOKS/EMAIL-PROOF-01.md
@@ -1,0 +1,209 @@
+# EMAIL-PROOF-01: Email Delivery Verification Runbook
+
+**Created**: 2026-01-19
+**Pass**: OPS-EMAIL-PROOF-01
+**Purpose**: Unblock EMAIL-PROOF-01 by documenting exact configuration and verification steps
+
+---
+
+## Overview
+
+This runbook enables production email verification by documenting:
+1. Required environment variables
+2. Production setup checklist
+3. Deterministic proof script for verification
+
+---
+
+## Required Environment Variables
+
+### Backend (`backend/.env` on VPS)
+
+| Variable | Description | Required | Example |
+|----------|-------------|----------|---------|
+| `MAIL_MAILER` | Mail driver to use | Yes | `resend` |
+| `RESEND_KEY` | Resend API key | Yes | `re_xxxx...` |
+| `MAIL_FROM_ADDRESS` | Sender email address | Yes | `no-reply@dixis.gr` |
+| `MAIL_FROM_NAME` | Sender display name | Yes | `Dixis` |
+| `EMAIL_NOTIFICATIONS_ENABLED` | Feature flag | Yes | `true` |
+
+### Where Variables Are Used
+
+```
+backend/config/services.php:28      → 'key' => env('RESEND_KEY')
+backend/config/mail.php:17          → 'default' => env('MAIL_MAILER', 'log')
+backend/config/mail.php:64-66       → 'resend' => ['transport' => 'resend']
+backend/config/mail.php:112-113     → 'address' => env('MAIL_FROM_ADDRESS')
+backend/config/notifications.php:28 → 'address' => env('MAIL_FROM_ADDRESS')
+```
+
+### Code That Checks Configuration
+
+```php
+// backend/routes/api.php lines 40-66 (healthz endpoint)
+$resendKeySet = !empty(config('services.resend.key'));
+if ($mailer === 'resend') {
+    $emailConfigured = $resendKeySet;
+}
+
+// backend/app/Console/Commands/TestEmail.php lines 129-130
+if ($mailer === 'resend') {
+    return !empty(config('services.resend.key'));
+}
+```
+
+---
+
+## Production Setup Checklist
+
+### Prerequisites
+
+- [ ] SSH access to production VPS (`ssh dixis-prod`)
+- [ ] Resend account with verified domain (`dixis.gr`)
+- [ ] Resend API key from dashboard
+
+### Step 1: Get Resend API Key
+
+1. Go to https://resend.com/api-keys
+2. Click "Create API Key"
+3. Name: `dixis-production`
+4. Permission: "Sending access"
+5. Copy the key (starts with `re_`)
+
+### Step 2: Set Environment Variable on VPS
+
+```bash
+# SSH into production
+ssh dixis-prod
+
+# Edit backend .env
+nano /var/www/dixis.gr/backend/.env
+
+# Add/update these lines:
+MAIL_MAILER=resend
+RESEND_KEY=re_xxxx_your_key_here
+MAIL_FROM_ADDRESS=no-reply@dixis.gr
+MAIL_FROM_NAME=Dixis
+EMAIL_NOTIFICATIONS_ENABLED=true
+
+# Clear config cache
+cd /var/www/dixis.gr/backend
+php artisan config:clear
+php artisan config:cache
+```
+
+### Step 3: Verify Configuration
+
+```bash
+# Check health endpoint shows email configured
+curl -sf https://dixis.gr/api/healthz | jq '.email'
+# Expected: {"flag":"enabled","mailer":"resend","configured":true,...}
+
+# Dry-run email test (validates config without sending)
+ssh dixis-prod 'cd /var/www/dixis.gr/backend && php artisan dixis:email:test --to=test@example.com --dry-run'
+# Expected: "[DRY RUN] Email configuration is valid."
+```
+
+### Step 4: Send Test Email
+
+```bash
+# Send actual test email
+ssh dixis-prod 'cd /var/www/dixis.gr/backend && php artisan dixis:email:test --to=your@email.com'
+# Expected: "[OK] Test email sent successfully to your@email.com"
+```
+
+### Step 5: Verify Receipt
+
+1. Check inbox for "Test Email from Dixis"
+2. Check spam folder if not in inbox
+3. Verify sender is `no-reply@dixis.gr`
+
+---
+
+## Deterministic Proof Script
+
+After setting up email, run the proof script:
+
+```bash
+./scripts/email-proof.sh
+```
+
+This script:
+1. Verifies health endpoint shows email configured
+2. Runs dry-run to validate configuration
+3. Sends actual test email (if `--send` flag provided)
+4. Outputs machine-readable proof
+
+### Usage
+
+```bash
+# Dry-run only (default)
+./scripts/email-proof.sh
+
+# Actually send test email
+./scripts/email-proof.sh --send --to=your@email.com
+```
+
+---
+
+## Troubleshooting
+
+### "configured": false
+
+The Resend key is missing or invalid.
+
+```bash
+# Check if key is set
+ssh dixis-prod 'grep RESEND_KEY /var/www/dixis.gr/backend/.env'
+
+# Verify key format (should start with re_)
+# If missing, add it and run config:cache
+```
+
+### "flag": "disabled"
+
+EMAIL_NOTIFICATIONS_ENABLED is false.
+
+```bash
+# Check flag
+ssh dixis-prod 'grep EMAIL_NOTIFICATIONS_ENABLED /var/www/dixis.gr/backend/.env'
+
+# Set to true if missing
+echo "EMAIL_NOTIFICATIONS_ENABLED=true" >> /var/www/dixis.gr/backend/.env
+php artisan config:cache
+```
+
+### Test email not received
+
+1. Check Resend dashboard for delivery status
+2. Verify domain is verified in Resend
+3. Check spam/junk folder
+4. Verify MAIL_FROM_ADDRESS matches Resend verified domain
+
+---
+
+## Mailable Classes
+
+These are the production mailables that require email to be configured:
+
+| Mailable | Trigger | Template |
+|----------|---------|----------|
+| `ConsumerOrderPlaced` | Order created | `emails/orders/consumer-order-placed.blade.php` |
+| `ProducerNewOrder` | Order created | `emails/orders/producer-new-order.blade.php` |
+| `OrderShipped` | Status → shipped | `emails/orders/order-shipped.blade.php` |
+| `OrderDelivered` | Status → delivered | `emails/orders/order-delivered.blade.php` |
+| `VerifyEmailMail` | User registration | `emails/auth/verify-email.blade.php` |
+| `ResetPasswordMail` | Password reset | `emails/auth/reset-password.blade.php` |
+| `ProducerWeeklyDigest` | Scheduled job | `emails/producer/weekly-digest.blade.php` |
+
+---
+
+## Related Documentation
+
+- `docs/AGENT/SUMMARY/Pass-V1-VERIFY-TRIO-01.md` - Original EMAIL-PROOF-01 blocker
+- `docs/OPS/STATE.md` - Pass EMAIL-SMOKE-01 prior verification
+- `backend/app/Console/Commands/TestEmail.php` - Test command source
+
+---
+
+_Pass: OPS-EMAIL-PROOF-01 | Generated: 2026-01-19 | Author: Claude_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,49 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-19 (Pass SEC-AUTH-RL-02)
+**Last Updated**: 2026-01-19 (Pass OPS-EMAIL-PROOF-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~350 lines (target ≤250).
+> **Current size**: ~380 lines (target ≤250).
+
+---
+
+## 2026-01-19 — Pass OPS-EMAIL-PROOF-01: Email Delivery Verification Runbook
+
+**Status**: ✅ DONE
+
+Created ops runbook and deterministic proof script to unblock EMAIL-PROOF-01 verification.
+
+### Artifacts Created
+
+| Artifact | Purpose |
+|----------|---------|
+| `docs/OPS/RUNBOOKS/EMAIL-PROOF-01.md` | Step-by-step ops checklist for setting RESEND_KEY |
+| `scripts/email-proof.sh` | Deterministic proof script with dry-run + send modes |
+
+### Required Env Vars Documented
+
+| Variable | Location | Purpose |
+|----------|----------|---------|
+| `RESEND_KEY` | `config/services.php:28` | Resend API key |
+| `MAIL_MAILER` | `config/mail.php:17` | Set to `resend` |
+| `EMAIL_NOTIFICATIONS_ENABLED` | `config/notifications.php` | Feature flag |
+| `MAIL_FROM_ADDRESS` | `config/mail.php:112` | Sender email |
+
+### Script Usage
+
+```bash
+# Validate config only (dry-run)
+./scripts/email-proof.sh
+
+# Send actual test email
+./scripts/email-proof.sh --send --to=your@email.com
+```
+
+### Next Steps
+
+1. Configure SSH access to production VPS
+2. Run `./scripts/email-proof.sh --send --to=<email>` to complete EMAIL-PROOF-01
+3. Document successful delivery in proof file
 
 ---
 

--- a/scripts/email-proof.sh
+++ b/scripts/email-proof.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+# email-proof.sh - Verify production email configuration and delivery
+#
+# Usage:
+#   ./scripts/email-proof.sh                         # Dry-run only (validate config)
+#   ./scripts/email-proof.sh --send --to=you@email   # Send actual test email
+#
+# Pass: OPS-EMAIL-PROOF-01
+# Created: 2026-01-19
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+PROD_URL="${PROD_URL:-https://dixis.gr}"
+SSH_HOST="${SSH_HOST:-dixis-prod}"
+BACKEND_PATH="${BACKEND_PATH:-/var/www/dixis.gr/backend}"
+
+# Parse arguments
+SEND_EMAIL=false
+RECIPIENT=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --send)
+            SEND_EMAIL=true
+            shift
+            ;;
+        --to=*)
+            RECIPIENT="${1#*=}"
+            shift
+            ;;
+        --to)
+            RECIPIENT="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--send] [--to=email@example.com]"
+            exit 1
+            ;;
+    esac
+done
+
+echo "=============================================="
+echo "EMAIL-PROOF-01: Production Email Verification"
+echo "=============================================="
+echo ""
+echo "Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+echo "Target: $PROD_URL"
+echo ""
+
+# Step 1: Check health endpoint for email configuration
+echo -e "${YELLOW}[1/4] Checking health endpoint...${NC}"
+HEALTH_JSON=$(curl -sf "${PROD_URL}/api/healthz" 2>/dev/null || echo '{}')
+
+if [ "$HEALTH_JSON" = "{}" ]; then
+    echo -e "${RED}FAIL: Could not reach ${PROD_URL}/api/healthz${NC}"
+    exit 1
+fi
+
+# Extract email configuration
+EMAIL_FLAG=$(echo "$HEALTH_JSON" | jq -r '.email.flag // "unknown"')
+EMAIL_MAILER=$(echo "$HEALTH_JSON" | jq -r '.email.mailer // "unknown"')
+EMAIL_CONFIGURED=$(echo "$HEALTH_JSON" | jq -r '.email.configured // false')
+RESEND_KEY_SET=$(echo "$HEALTH_JSON" | jq -r '.email.keys_present.resend // false')
+
+echo "  flag:       $EMAIL_FLAG"
+echo "  mailer:     $EMAIL_MAILER"
+echo "  configured: $EMAIL_CONFIGURED"
+echo "  resend_key: $RESEND_KEY_SET"
+echo ""
+
+# Validate configuration
+STEP1_PASS=true
+if [ "$EMAIL_FLAG" != "enabled" ]; then
+    echo -e "${RED}  ERROR: EMAIL_NOTIFICATIONS_ENABLED is not true${NC}"
+    STEP1_PASS=false
+fi
+if [ "$EMAIL_CONFIGURED" != "true" ]; then
+    echo -e "${RED}  ERROR: Email is not configured${NC}"
+    STEP1_PASS=false
+fi
+if [ "$EMAIL_MAILER" = "resend" ] && [ "$RESEND_KEY_SET" != "true" ]; then
+    echo -e "${RED}  ERROR: RESEND_KEY is not set${NC}"
+    STEP1_PASS=false
+fi
+
+if [ "$STEP1_PASS" = true ]; then
+    echo -e "${GREEN}[1/4] PASS: Email configuration valid${NC}"
+else
+    echo -e "${RED}[1/4] FAIL: Email configuration invalid${NC}"
+    echo ""
+    echo "To fix, ensure these are set in production .env:"
+    echo "  MAIL_MAILER=resend"
+    echo "  RESEND_KEY=re_xxxx..."
+    echo "  EMAIL_NOTIFICATIONS_ENABLED=true"
+    exit 1
+fi
+echo ""
+
+# Step 2: Test SSH connectivity
+echo -e "${YELLOW}[2/4] Testing SSH connectivity...${NC}"
+if ssh -o BatchMode=yes -o ConnectTimeout=10 "$SSH_HOST" 'echo ok' >/dev/null 2>&1; then
+    echo -e "${GREEN}[2/4] PASS: SSH connection successful${NC}"
+else
+    echo -e "${YELLOW}[2/4] SKIP: SSH connection not available (key-based auth required)${NC}"
+    echo "  To enable full verification, configure SSH access to $SSH_HOST"
+    echo ""
+
+    # If we can't SSH but health check passed, output partial proof
+    if [ "$STEP1_PASS" = true ]; then
+        echo "=============================================="
+        echo "PARTIAL PROOF (Health Check Only)"
+        echo "=============================================="
+        echo ""
+        echo "EMAIL_FLAG=$EMAIL_FLAG"
+        echo "EMAIL_MAILER=$EMAIL_MAILER"
+        echo "EMAIL_CONFIGURED=$EMAIL_CONFIGURED"
+        echo "RESEND_KEY_SET=$RESEND_KEY_SET"
+        echo ""
+        echo "SSH access required for full verification (dry-run + send tests)"
+        exit 0
+    fi
+    exit 1
+fi
+echo ""
+
+# Step 3: Run dry-run via SSH
+echo -e "${YELLOW}[3/4] Running dry-run validation on VPS...${NC}"
+DRY_RUN_OUTPUT=$(ssh "$SSH_HOST" "cd $BACKEND_PATH && php artisan dixis:email:test --to=test@example.com --dry-run" 2>&1)
+echo "$DRY_RUN_OUTPUT"
+echo ""
+
+if echo "$DRY_RUN_OUTPUT" | grep -q "Email configuration is valid"; then
+    echo -e "${GREEN}[3/4] PASS: Dry-run validation successful${NC}"
+elif echo "$DRY_RUN_OUTPUT" | grep -q "Would send to"; then
+    echo -e "${GREEN}[3/4] PASS: Configuration valid (minor warnings)${NC}"
+else
+    echo -e "${RED}[3/4] FAIL: Dry-run validation failed${NC}"
+    exit 1
+fi
+echo ""
+
+# Step 4: Send test email (if --send flag provided)
+if [ "$SEND_EMAIL" = true ]; then
+    if [ -z "$RECIPIENT" ]; then
+        echo -e "${RED}[4/4] ERROR: --send requires --to=email@example.com${NC}"
+        exit 1
+    fi
+
+    echo -e "${YELLOW}[4/4] Sending test email to $RECIPIENT...${NC}"
+    SEND_OUTPUT=$(ssh "$SSH_HOST" "cd $BACKEND_PATH && php artisan dixis:email:test --to='$RECIPIENT'" 2>&1)
+    echo "$SEND_OUTPUT"
+    echo ""
+
+    if echo "$SEND_OUTPUT" | grep -q "Test email sent successfully"; then
+        echo -e "${GREEN}[4/4] PASS: Test email sent${NC}"
+        SEND_STATUS="SENT"
+    else
+        echo -e "${RED}[4/4] FAIL: Failed to send test email${NC}"
+        SEND_STATUS="FAILED"
+    fi
+else
+    echo -e "${YELLOW}[4/4] SKIP: Add --send --to=email to send test email${NC}"
+    SEND_STATUS="SKIPPED"
+fi
+echo ""
+
+# Output proof
+echo "=============================================="
+echo "PROOF: EMAIL-PROOF-01"
+echo "=============================================="
+echo ""
+echo "DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+echo "PROD_URL=$PROD_URL"
+echo "EMAIL_FLAG=$EMAIL_FLAG"
+echo "EMAIL_MAILER=$EMAIL_MAILER"
+echo "EMAIL_CONFIGURED=$EMAIL_CONFIGURED"
+echo "RESEND_KEY_SET=$RESEND_KEY_SET"
+echo "DRY_RUN=PASS"
+echo "SEND_STATUS=$SEND_STATUS"
+if [ -n "$RECIPIENT" ] && [ "$SEND_STATUS" = "SENT" ]; then
+    echo "RECIPIENT=$RECIPIENT"
+fi
+echo ""
+echo "STATUS=PASS"
+echo ""
+echo -e "${GREEN}Email verification complete.${NC}"


### PR DESCRIPTION
## Summary

- Created ops runbook documenting RESEND_KEY setup steps (`docs/OPS/RUNBOOKS/EMAIL-PROOF-01.md`)
- Created deterministic proof script (`scripts/email-proof.sh`) with dry-run + send modes
- Updated NEXT-7D.md and STATE.md with pass details

## Purpose

Unblocks EMAIL-PROOF-01 from V1-VERIFY-TRIO-01 by providing:

1. **Exact env var names + locations** where they are used
2. **Ops checklist** for setting RESEND_KEY on production
3. **Deterministic proof script** to run immediately after key is set

## Usage

```bash
# Validate config only (dry-run)
./scripts/email-proof.sh

# Send actual test email (requires SSH access)
./scripts/email-proof.sh --send --to=your@email.com
```

## Test Plan

- [ ] Runbook is complete and accurate
- [ ] Script runs without errors in dry-run mode
- [ ] Once SSH access is configured, full email delivery can be verified

---

Pass: OPS-EMAIL-PROOF-01
Generated-by: Claude (Opus 4.5)