### PR TITLE
docs: close out CI-FLAKE-FILTERS-SEARCH-01

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-CI-FLAKE-FILTERS-SEARCH-01.md
+++ b/docs/AGENT/SUMMARY/Pass-CI-FLAKE-FILTERS-SEARCH-01.md
@@ -1,0 +1,91 @@
+# Pass CI-FLAKE-FILTERS-SEARCH-01: E2E Filters-Search Test Stabilization
+
+**Date**: 2026-01-20
+**PR**: #2344
+**Commit**: d91bd969
+**Status**: PASS
+
+---
+
+## TL;DR
+
+Fixed flaky `filters-search.spec.ts` E2E test that was timing out in CI. The test used `page.waitForURL()` which expects navigation events, but Next.js `router.push()` with `startTransition` performs soft navigation that doesn't fire Playwright's navigation detection.
+
+---
+
+## Root Cause
+
+The `ProductSearchInput` component uses:
+```typescript
+startTransition(() => {
+  router.push(`/products?search=${value}`, { scroll: false });
+});
+```
+
+This is **soft navigation** in Next.js — it updates the URL without triggering a full page load event. Playwright's `waitForURL()` listens for navigation events that never fire.
+
+---
+
+## Fix Applied
+
+**Before** (flaky):
+```typescript
+await searchInput.fill('Πορτοκάλια');
+await page.waitForTimeout(500);
+await page.waitForLoadState('networkidle');
+await page.waitForURL(/\/products.*search=/i, { timeout: 15000 }); // FAILS - no nav event
+```
+
+**After** (stable):
+```typescript
+await searchInput.fill('Πορτοκάλια');
+await page.waitForTimeout(600); // Debounce (300ms) + buffer
+
+// Wait for API response as deterministic signal
+await page.waitForResponse(
+  (response) =>
+    response.url().includes('/api/') &&
+    response.url().includes('products') &&
+    response.status() === 200,
+  { timeout: 30000 }
+).catch(() => { /* API may have already completed */ });
+
+// Use expect.poll for URL check (works without nav events)
+await expect.poll(
+  async () => page.url(),
+  { timeout: 30000, intervals: [250, 500, 1000, 2000] }
+).toMatch(/\/products.*search=/i);
+```
+
+---
+
+## Evidence
+
+| Check | Result |
+|-------|--------|
+| E2E (PostgreSQL) | PASS (4m13s) |
+| build-and-test | PASS |
+| quality-gates | PASS |
+| All required checks | PASS |
+
+PR #2344 merged at 2026-01-20T09:59:29Z.
+
+---
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `frontend/tests/e2e/filters-search.spec.ts` | +31/-11 lines |
+
+---
+
+## Risk Assessment
+
+- **Risk**: LOW
+- **Scope**: Test-only change, no business logic affected
+- **Rollback**: Revert commit d91bd969 if issues arise
+
+---
+
+_Pass: CI-FLAKE-FILTERS-SEARCH-01 | Generated: 2026-01-20 | Author: Claude_

--- a/docs/AGENT/TASKS/Pass-CI-FLAKE-FILTERS-SEARCH-01.md
+++ b/docs/AGENT/TASKS/Pass-CI-FLAKE-FILTERS-SEARCH-01.md
@@ -1,0 +1,91 @@
+# Pass CI-FLAKE-FILTERS-SEARCH-01: E2E Filters-Search Test Stabilization
+
+**Date**: 2026-01-20
+**PR**: #2344
+**Commit**: d91bd969
+**Status**: DONE
+
+---
+
+## Objective
+
+Fix the flaky `filters-search.spec.ts` E2E test that was causing E2E (PostgreSQL) CI failures.
+
+---
+
+## Problem
+
+The Greek text search test was failing intermittently in CI with:
+
+```
+TimeoutError: page.waitForURL: Timeout 15000ms exceeded.
+waiting for navigation until "load"
+
+> 36 |     await page.waitForURL(/\/products.*search=/i, { timeout: 15000 });
+```
+
+---
+
+## Analysis
+
+1. **ProductSearchInput component** (frontend/src/components/ProductSearchInput.tsx):
+   - Uses 300ms debounce on input
+   - Calls `router.push()` with `startTransition` and `{ scroll: false }`
+   - This is Next.js **soft navigation** — URL changes without page load event
+
+2. **Playwright behavior**:
+   - `waitForURL()` listens for navigation events
+   - Soft navigation doesn't fire these events
+   - Test times out waiting for an event that never comes
+
+---
+
+## Solution
+
+Replace navigation-dependent waits with deterministic signals:
+
+1. **Remove `waitForURL()`** — expects events that don't fire
+2. **Add `waitForResponse()`** — wait for products API as deterministic signal
+3. **Use `expect.poll()`** — poll URL directly without needing navigation events
+4. **Increase timeouts** — from 15s to 30s for CI buffer
+5. **Increase debounce wait** — from 500ms to 600ms
+
+---
+
+## Changes
+
+### frontend/tests/e2e/filters-search.spec.ts
+
+**Greek search test** (lines 28-50):
+- Added `waitForResponse()` for products API
+- Replaced `waitForURL()` with `expect.poll()` for URL assertion
+- Increased timeouts from 15s to 30s
+
+**Nonsense search test** (lines 98-113):
+- Applied same pattern for consistency
+
+---
+
+## Verification
+
+```bash
+# PR checks
+gh pr checks 2344 --watch
+
+# Results
+E2E (PostgreSQL)    PASS    4m13s
+build-and-test      PASS    2m12s
+quality-gates       PASS    3m09s
+```
+
+---
+
+## Lessons Learned
+
+1. **Soft navigation** in Next.js (via `router.push` + `startTransition`) doesn't trigger Playwright's navigation detection
+2. **Prefer API waits** over navigation waits for client-side routing
+3. **Use `expect.poll()`** for URL assertions in SPA contexts
+
+---
+
+_Pass: CI-FLAKE-FILTERS-SEARCH-01 | Generated: 2026-01-20 | Author: Claude_

--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -36,6 +36,11 @@
   - PR #2319 merged
   - maxAttempts: 6 → 8, timeoutMs: 15s → 20s
 
+- ✅ **CI-FLAKE-FILTERS-SEARCH-01**: Stabilized filters-search E2E test
+  - PR #2344 merged, commit `d91bd969`
+  - Fixed: `waitForURL()` timeout due to Next.js soft navigation
+  - Fix: Use `waitForResponse()` + `expect.poll()` instead
+
 ### Admin Dashboard Audit
 
 - ✅ **ADMIN-IA-01** (docs-only): Admin Dashboard V1 Information Architecture
@@ -149,4 +154,4 @@ Pre-launch verification before announcing V1:
 
 ---
 
-_Last updated by Pass V1-QA-EXECUTE-01 (2026-01-20)_
+_Last updated by Pass CI-FLAKE-FILTERS-SEARCH-01 (2026-01-20)_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,6 +1,6 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-20 (Pass V1-LAUNCH-OPS-01)
+**Last Updated**: 2026-01-20 (Pass CI-FLAKE-FILTERS-SEARCH-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~460 lines (target ≤250).
@@ -14,6 +14,53 @@
 - **Rollback SHA**: 52c53a96
 - **Release Notes**: `docs/RELEASES/v1.0.0.md`
 - **24h Runbook**: `docs/OPS/RUNBOOK-V1-LAUNCH-24H.md`
+
+---
+
+## 2026-01-20 — Pass CI-FLAKE-FILTERS-SEARCH-01: E2E Test Stabilization
+
+**Status**: ✅ PASS
+
+Fixed flaky `filters-search.spec.ts` E2E test that was causing E2E (PostgreSQL) CI failures.
+
+### Root Cause
+
+`page.waitForURL()` expects navigation events, but Next.js `router.push()` with `startTransition` performs soft navigation that doesn't fire Playwright's navigation detection.
+
+### Fix Applied
+
+- Removed `waitForURL()` (expects events that never fire)
+- Added `waitForResponse()` for products API as deterministic signal
+- Used `expect.poll()` for URL assertion (works without nav events)
+- Increased timeouts from 15s → 30s for CI buffer
+
+### Evidence
+
+| Check | Result |
+|-------|--------|
+| E2E (PostgreSQL) | PASS (4m13s) |
+| build-and-test | PASS |
+| quality-gates | PASS |
+
+### Files Changed
+
+| File | Changes |
+|------|---------|
+| `frontend/tests/e2e/filters-search.spec.ts` | +31/-11 lines |
+
+### Risk
+
+- **Risk**: LOW (test-only change)
+- **Rollback**: Revert d91bd969
+
+### PRs
+
+- #2344 (test(e2e): stabilize filters-search flake) — **merged**
+
+### Artifacts
+
+- `docs/AGENT/SUMMARY/Pass-CI-FLAKE-FILTERS-SEARCH-01.md`
+- `docs/AGENT/TASKS/Pass-CI-FLAKE-FILTERS-SEARCH-01.md`
 
 ---
 


### PR DESCRIPTION
## Summary

Closes out Pass CI-FLAKE-FILTERS-SEARCH-01 with proper documentation.

## Changes

- Update `docs/OPS/STATE.md` with pass entry (date, PR, commit, evidence)
- Update `docs/NEXT-7D.md` with completed item
- Add `docs/AGENT/TASKS/Pass-CI-FLAKE-FILTERS-SEARCH-01.md` (what/why/how)
- Add `docs/AGENT/SUMMARY/Pass-CI-FLAKE-FILTERS-SEARCH-01.md` (TL;DR + evidence)

## Test Plan

- Docs-only change, no code affected