### PR TITLE
Pass USER-FEEDBACK-LOOP-01: add feedback link to footer

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-USER-FEEDBACK-LOOP-01.md
+++ b/docs/AGENT/SUMMARY/Pass-USER-FEEDBACK-LOOP-01.md
@@ -1,0 +1,101 @@
+# Pass USER-FEEDBACK-LOOP-01 — Simple Feedback Loop
+
+**Status**: PASS
+**Date/Time (UTC)**: 2026-01-20T21:00Z
+**Commit SHA**: (pending PR merge)
+
+---
+
+## Summary
+
+Added feedback link to footer, exposing the existing `/contact` page to users.
+
+---
+
+## What
+
+Added a "Επικοινωνία / Σχόλια" (Contact / Feedback) link to the site footer that points to the existing `/contact` page.
+
+## Why
+
+- Post-V1 iteration goal: collect user feedback early
+- `/contact` page existed but was not linked anywhere visible
+- Users had no obvious way to send feedback
+
+## How
+
+Modified `frontend/src/components/layout/Footer.tsx`:
+- Renamed "Νομικά" (Legal) section to "Υποστήριξη" (Support)
+- Added link to `/contact` as first item in the section
+
+**File**: `frontend/src/components/layout/Footer.tsx`
+**Lines Changed**: 47-52
+
+```tsx
+{/* Legal & Support - touch-friendly spacing */}
+<div>
+  <h4 className="font-semibold text-neutral-900 mb-3 sm:mb-4">Υποστήριξη</h4>
+  <nav className="flex flex-col gap-1">
+    <Link href="/contact" className="...">
+      Επικοινωνία / Σχόλια
+    </Link>
+    ...
+  </nav>
+</div>
+```
+
+---
+
+## Existing Infrastructure (Leveraged)
+
+The pass discovered a robust existing contact system:
+
+| Component | Path | Features |
+|-----------|------|----------|
+| Contact Page | `frontend/src/app/contact/page.tsx` | Greek form, state management, honeypot |
+| Contact API | `frontend/src/app/api/contact/route.ts` | Zod validation, rate limiting (10/10min), email to info@dixis.gr |
+
+**No new backend or DB changes required.**
+
+---
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| Build passes | PASS |
+| Link renders in footer | PASS |
+| Link points to /contact | PASS |
+| Greek copy correct | PASS |
+
+---
+
+## Risks
+
+- **Risk**: LOW (UI-only change, no backend)
+- **Rollback**: Revert single line in Footer.tsx
+
+---
+
+## Environment Variables
+
+The contact form uses these existing env vars (no changes needed):
+
+| Variable | Purpose |
+|----------|---------|
+| `ADMIN_EMAIL` | Override recipient (default: info@dixis.gr) |
+| `SMTP_*` / `RESEND_*` | Email delivery config |
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/layout/Footer.tsx` | +5 lines (link + section rename) |
+
+**Total LOC**: ~5
+
+---
+
+_Generated: 2026-01-20T21:00Z | Author: Claude_

--- a/docs/AGENT/TASKS/Pass-USER-FEEDBACK-LOOP-01.md
+++ b/docs/AGENT/TASKS/Pass-USER-FEEDBACK-LOOP-01.md
@@ -1,0 +1,87 @@
+# Pass USER-FEEDBACK-LOOP-01 — Simple Feedback Loop
+
+**Status**: IN_PROGRESS
+**Priority**: P2 (Post-V1 Iteration)
+**Estimated LOC**: ~10
+
+---
+
+## Objective
+
+Enable early users to easily send feedback to the Dixis team, without introducing backend complexity.
+
+---
+
+## Requirements
+
+1. **Minimal scope**: Use existing infrastructure, no new DB tables
+2. **Globally visible**: Feedback link accessible from every page (footer)
+3. **EL-first**: Greek copy as primary language
+4. **Privacy-friendly**: No tracking, just simple form submission
+
+---
+
+## Implementation
+
+### Discovery
+
+Found existing contact system already in place:
+- **Page**: `/contact` (`frontend/src/app/contact/page.tsx`)
+- **API**: `/api/contact` (`frontend/src/app/api/contact/route.ts`)
+
+Features already implemented:
+- Greek UI with form (name, email, message)
+- Zod validation
+- Rate limiting (10 req/10 min per IP)
+- Honeypot spam protection
+- Email to `ADMIN_EMAIL` or `info@dixis.gr`
+- Auto-reply to sender
+
+### Gap Identified
+
+The `/contact` page exists but was **not linked in the footer**, making it hard for users to discover.
+
+### Fix Applied
+
+Added "Επικοινωνία / Σχόλια" link to footer, pointing to existing `/contact` page.
+
+**File**: `frontend/src/components/layout/Footer.tsx`
+**Line**: 51
+
+```tsx
+<Link href="/contact" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
+  Επικοινωνία / Σχόλια
+</Link>
+```
+
+---
+
+## Acceptance Criteria
+
+- [x] Feedback link visible in footer on all pages
+- [x] Link points to existing `/contact` page
+- [x] Greek copy ("Επικοινωνία / Σχόλια")
+- [x] No new backend complexity
+- [x] Build passes
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/layout/Footer.tsx` | MODIFIED (+5 lines) |
+
+---
+
+## Existing Infrastructure (No Changes Needed)
+
+| Component | Path | Description |
+|-----------|------|-------------|
+| Contact Page | `frontend/src/app/contact/page.tsx` | Form with states |
+| Contact API | `frontend/src/app/api/contact/route.ts` | Rate-limited, validated |
+| Email Service | `frontend/src/lib/mail.ts` | Resend integration |
+
+---
+
+_Created: 2026-01-20 | Author: Claude_

--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -7,8 +7,8 @@
 
 ## Next Pass Recommendation
 
-- **USER-FEEDBACK-LOOP-01**: Set up simple feedback mechanism (form/email) to collect early user input
-  - Analytics infrastructure ready (ANALYTICS-BASIC-01); next step is user feedback collection.
+- **PERF-PRODUCTS-REDIS-01**: Redis cache layer for product list (defer unless scale requires)
+  - Analytics and feedback loop ready; focus shifts to scaling infrastructure if needed.
 
 ---
 
@@ -58,9 +58,14 @@
   - All services healthy, 0 errors on 2026-01-20
 
 - ✅ **ANALYTICS-BASIC-01**: Privacy-friendly analytics infrastructure
-  - PR #TBD pending
+  - PR #2350 merged, commit `8cc2b56b`
   - Plausible/Umami support with feature flags
   - Cookie-less, GDPR-compliant
+
+- ✅ **USER-FEEDBACK-LOOP-01**: Simple feedback loop for early users
+  - PR #TBD pending
+  - Added "Επικοινωνία / Σχόλια" link to footer
+  - Links to existing /contact page (no new backend)
 
 ### Admin Dashboard Audit
 

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,41 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-20 (Pass ANALYTICS-BASIC-01)
+**Last Updated**: 2026-01-20 (Pass USER-FEEDBACK-LOOP-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~470 lines (target ≤250).
+> **Current size**: ~490 lines (target ≤250).
+
+---
+
+## 2026-01-20 — Pass USER-FEEDBACK-LOOP-01: Simple Feedback Loop
+
+**Status**: ✅ PASS
+
+Added feedback link to footer, exposing the existing `/contact` page to users.
+
+### Discovery
+
+Found existing robust contact system:
+- **Page**: `/contact` with Greek form, honeypot protection
+- **API**: `/api/contact` with rate limiting, Zod validation, email to info@dixis.gr
+
+### Fix Applied
+
+Added "Επικοινωνία / Σχόλια" link to footer pointing to existing `/contact` page.
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/layout/Footer.tsx` | +5 lines (link + section rename) |
+
+### Evidence
+
+- Build: PASS
+- Link renders in footer: PASS
+- Points to /contact: PASS
+
+### PRs
+
+- #TBD (feat: Pass USER-FEEDBACK-LOOP-01) — pending
 
 ---
 

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -44,10 +44,13 @@ export default function Footer() {
             </nav>
           </div>
 
-          {/* Legal - touch-friendly spacing */}
+          {/* Legal & Support - touch-friendly spacing */}
           <div>
-            <h4 className="font-semibold text-neutral-900 mb-3 sm:mb-4">Νομικά</h4>
+            <h4 className="font-semibold text-neutral-900 mb-3 sm:mb-4">Υποστήριξη</h4>
             <nav className="flex flex-col gap-1">
+              <Link href="/contact" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
+                Επικοινωνία / Σχόλια
+              </Link>
               <Link href="/legal/terms" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
                 Όροι Χρήσης
               </Link>


### PR DESCRIPTION
## Summary

Expose existing `/contact` page by adding "Επικοινωνία / Σχόλια" (Contact / Feedback) link to footer.

## Changes

| File | Change |
|------|--------|
| `frontend/src/components/layout/Footer.tsx` | +5 lines (link + section rename) |
| `docs/AGENT/TASKS/Pass-USER-FEEDBACK-LOOP-01.md` | NEW |
| `docs/AGENT/SUMMARY/Pass-USER-FEEDBACK-LOOP-01.md` | NEW |
| `docs/OPS/STATE.md` | Updated |
| `docs/NEXT-7D.md` | Updated |

## What This Does

- Renamed footer section from "Νομικά" to "Υποστήριξη"
- Added link to existing `/contact` page as first item

## Existing Infrastructure (No Changes)

The `/contact` page already has:
- Greek UI with form (name, email, message)
- Honeypot spam protection
- Rate limiting (10 req/10 min per IP)
- Email to `ADMIN_EMAIL` or `info@dixis.gr`
- Auto-reply to sender

**No backend changes required.**

## Test Plan

- [x] Build passes
- [x] Link renders in footer (line 51-52)
- [x] Link points to `/contact`

---

Generated-by: Claude (Pass USER-FEEDBACK-LOOP-01)