### PR TITLE
docs: Finalize Pass UI-A11Y-EL-01

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-UI-A11Y-EL-01.md
+++ b/docs/AGENT/SUMMARY/Pass-UI-A11Y-EL-01.md
@@ -1,7 +1,7 @@
 # Pass: UI-A11Y-EL-01
 
 **Date (UTC):** 2026-01-21
-**Commit:** TBD (pending PR merge)
+**Commit:** `3ed150cf` (PR #2367)
 **Environment:** Frontend UI
 
 ---
@@ -62,7 +62,7 @@ Added to `messages/el.json`:
 - `frontend/src/components/layout/Header.tsx`
 - `frontend/src/app/order/confirmation/[orderId]/page.tsx`
 - `frontend/messages/el.json`
-- PR: TBD
+- PR: #2367 (merged)
 
 ---
 

--- a/docs/AGENT/TASKS/Pass-UI-A11Y-EL-01.md
+++ b/docs/AGENT/TASKS/Pass-UI-A11Y-EL-01.md
@@ -40,9 +40,9 @@ UI/a11y only. No business logic changes.
 - [x] All aria-labels are in Greek
 - [x] Missing translation keys added
 - [x] `pnpm lint` passes
-- [ ] PR created + CI green
-- [ ] Merged
+- [x] PR created + CI green
+- [x] Merged
 
 ## Result
 
-**PENDING** — Awaiting CI verification.
+**PASS** — PR #2367 merged, commit `3ed150cf`.

--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -16,6 +16,15 @@
 
 (none)
 
+### Recently Completed
+
+- ✅ **UI-A11Y-EL-01**: Greek localization and accessibility fixes
+  - PR #2367 merged, commit `3ed150cf`
+  - EUR price formatting to el-GR locale (12,50 € instead of 12.50€)
+  - Greek aria-labels for CartIcon and Header mobile menu
+  - Added missing checkout Stripe translation keys
+  - Evidence: `docs/AGENT/SUMMARY/Pass-UI-A11Y-EL-01.md`
+
 ---
 
 ## Completed


### PR DESCRIPTION
## Summary

- Update summary with commit hash `3ed150cf`
- Mark task DoD complete with PASS result
- Add to Recently Completed in NEXT-7D.md

## Test plan

- [x] Docs-only change, no code changes