### PR TITLE
docs: Add visual test proof for products page

### DIFF
--- a/docs/AGENT/SUMMARY/Proof-UI-Visual-Products-2026-01-21.md
+++ b/docs/AGENT/SUMMARY/Proof-UI-Visual-Products-2026-01-21.md
@@ -1,0 +1,79 @@
+# Proof: UI Visual Test — Products Page
+
+**Date (UTC):** 2026-01-21
+**Commit:** `88028e04`
+**Environment:** Production (https://dixis.gr)
+
+---
+
+## Summary
+
+Visual validation test for products page executed successfully against production.
+
+---
+
+## Test Execution
+
+### Command
+
+```bash
+BASE_URL="https://dixis.gr" npx playwright test tests/e2e/visual-products-test.spec.ts --reporter=list
+```
+
+### Result: **PASS**
+
+```
+Running 1 test using 1 worker
+
+✓ Found 8 product cards
+✓ Price format: 15,99 €
+✓ Desktop screenshot saved
+✓ Mobile screenshot saved
+✅ Visual test PASSED
+  ✓  1 tests/e2e/visual-products-test.spec.ts:6:7 › Visual Test: Products Page @visual › products page displays correctly with Greek formatting (1.4s)
+
+  1 passed (2.4s)
+```
+
+---
+
+## Assertions Validated
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Page title (Greek) | ✅ PASS | "Προϊόντα" heading visible |
+| Product cards visible | ✅ PASS | 8 cards found |
+| Card title visible | ✅ PASS | `[data-testid="product-card-title"]` |
+| Card price visible | ✅ PASS | `[data-testid="product-card-price"]` |
+| Card add button visible | ✅ PASS | `[data-testid="product-card-add"]` |
+| Price format (el-GR) | ✅ PASS | `15,99 €` (Greek format) |
+| Desktop layout | ✅ PASS | Screenshot captured |
+| Mobile layout (375x667) | ✅ PASS | Screenshot captured |
+
+---
+
+## Screenshots/Artifacts
+
+- Desktop: `test-results/visual-products-desktop.png`
+- Mobile: `test-results/visual-products-mobile.png`
+- Video: `test-results/visual-products-test.spec-*.webm`
+
+---
+
+## Verified Features
+
+1. **Greek Localization** — Price displays as `15,99 €` (not `15.99€`)
+2. **Product Cards** — All required elements present (title, price, add button)
+3. **Responsive Design** — Layout works on both desktop and mobile viewports
+4. **Data Integrity** — 8 real products rendered from production API
+
+---
+
+## Production Health
+
+- API healthz: `https://dixis.gr/api/healthz` → `{"status":"ok"}`
+- Products API responding correctly
+
+---
+
+_Proof: UI-Visual-Products | Generated: 2026-01-21 | Author: Claude_


### PR DESCRIPTION
## Summary

Visual test proof documentation for products page validation.

## Verified

- Price format el-GR: `15,99 €` (Greek locale) ✅
- 8 product cards rendered correctly ✅
- Desktop + mobile responsive layouts ✅
- All testid elements present ✅

## Test plan

- [x] Docs-only change, no code changes