### PR TITLE
test(e2e): CI-FLAKE-NOTIFICATIONS-01

### DIFF
--- a/frontend/tests/e2e/notifications.spec.ts
+++ b/frontend/tests/e2e/notifications.spec.ts
@@ -10,8 +10,9 @@ test.describe('Notifications @smoke', () => {
     await page.goto('/products');
     await expect(page.getByTestId('search-input')).toBeVisible({ timeout: 15000 });
 
-    // Bell should be visible (auth state from storageState)
-    const bell = page.getByTestId('notification-bell');
+    // Bell is rendered twice (desktop + mobile header). Use .first() to target desktop bell.
+    // Both have same testid but only one is visible at a time based on viewport.
+    const bell = page.getByTestId('notification-bell').first();
 
     // Check if bell is visible - depends on auth state
     // If not authenticated, bell won't be visible (which is correct behavior)
@@ -34,7 +35,8 @@ test.describe('Notifications @smoke', () => {
     await page.goto('/products');
     await expect(page.getByTestId('search-input')).toBeVisible({ timeout: 15000 });
 
-    const bell = page.getByTestId('notification-bell');
+    // Bell is rendered twice (desktop + mobile header). Use .first() to target desktop bell.
+    const bell = page.getByTestId('notification-bell').first();
     const isVisible = await bell.isVisible();
 
     if (isVisible) {


### PR DESCRIPTION
## Summary

Fix flaky smoke test: duplicate `notification-bell` testid causes Playwright strict mode violation.

## Root Cause

`NotificationBell` component renders twice in Header.tsx:
- Line 99: Desktop (inside `hidden md:flex`)
- Line 228: Mobile (inside `flex md:hidden`)

Both have the same `data-testid="notification-bell"`, causing Playwright to fail with:
```
Error: strict mode violation: getByTestId('notification-bell') resolved to 2 elements
```

## Fix

Use `.first()` to disambiguate the selector in tests. This targets the desktop bell which is visible on desktop viewport (default Playwright viewport).

## Evidence

Local test run: 3/3 notifications tests PASS