### PR TITLE
docs: Pass CI-FLAKE-NOTIFICATIONS-01 evidence

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-CI-FLAKE-NOTIFICATIONS-01.md
+++ b/docs/AGENT/SUMMARY/Pass-CI-FLAKE-NOTIFICATIONS-01.md
@@ -1,0 +1,39 @@
+# Summary: Pass CI-FLAKE-NOTIFICATIONS-01
+
+**Date**: 2026-01-21
+**Status**: DONE
+**Type**: CI Flake Fix
+
+---
+
+## Overview
+
+Fixed E2E smoke test failure caused by duplicate `notification-bell` testid in Header.
+
+## Key Findings
+
+- `NotificationBell` component renders twice (desktop + mobile header)
+- Both have same testid, triggering Playwright strict mode violation
+- Fix: Use `.first()` selector to target desktop bell
+
+## Evidence
+
+| Metric | Before | After |
+|--------|--------|-------|
+| E2E (PostgreSQL) | FAIL | PASS |
+| notifications.spec.ts | 0/3 | 3/3 |
+
+## What Changed
+
+```diff
+- const bell = page.getByTestId('notification-bell');
++ const bell = page.getByTestId('notification-bell').first();
+```
+
+## PR
+
+#2379 merged | Commit: `7a1d1408`
+
+---
+
+_Summary: CI-FLAKE-NOTIFICATIONS-01 | 2026-01-21_

--- a/docs/AGENT/TASKS/Pass-CI-FLAKE-NOTIFICATIONS-01.md
+++ b/docs/AGENT/TASKS/Pass-CI-FLAKE-NOTIFICATIONS-01.md
@@ -1,0 +1,63 @@
+# Pass CI-FLAKE-NOTIFICATIONS-01
+
+**Date**: 2026-01-21
+**Status**: DONE
+**Type**: CI Flake Fix
+
+---
+
+## What
+
+Fix flaky E2E smoke test: Playwright strict mode violation for duplicate `notification-bell` testid.
+
+## Why
+
+- E2E (PostgreSQL) CI check was failing on unrelated PRs
+- Root cause: `NotificationBell` renders twice in Header.tsx (desktop + mobile)
+- Both instances have same `data-testid="notification-bell"`
+- Playwright strict mode requires unique selectors
+
+## Root Cause Analysis
+
+```
+Error: strict mode violation: getByTestId('notification-bell') resolved to 2 elements:
+    1) <button ...> aka getByRole('button', { name: 'Notifications' })
+    2) <button ...> aka locator('div').filter({ hasText: /^ELEN🛒 Cart$/ }).getByTestId('notification-bell')
+```
+
+**Location of duplicate testids:**
+- `Header.tsx:99` - Desktop header (inside `hidden md:flex`)
+- `Header.tsx:228` - Mobile header (inside `flex md:hidden`)
+
+## Fix
+
+Test-only fix: Use `.first()` to disambiguate the selector.
+
+```typescript
+// Before (flaky)
+const bell = page.getByTestId('notification-bell');
+
+// After (stable)
+const bell = page.getByTestId('notification-bell').first();
+```
+
+This targets the desktop bell which is visible on default Playwright viewport.
+
+## Evidence
+
+| Check | Before | After |
+|-------|--------|-------|
+| E2E (PostgreSQL) | FAIL | PASS |
+| Notifications smoke tests | 0/3 | 3/3 |
+
+## Files Changed
+
+- `frontend/tests/e2e/notifications.spec.ts` (+5/-3 lines)
+
+## PR
+
+- #2379 merged, commit `7a1d1408`
+
+---
+
+_Pass: CI-FLAKE-NOTIFICATIONS-01 | 2026-01-21_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,42 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-21 (Pass V1-QA-EXECUTE-01-4)
+**Last Updated**: 2026-01-21 (Pass CI-FLAKE-NOTIFICATIONS-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~510 lines (target ≤250).
+
+---
+
+## 2026-01-21 — Pass CI-FLAKE-NOTIFICATIONS-01: Fix Notification Bell Flaky Test
+
+**Status**: ✅ PASS — CLOSED
+
+Fixed E2E smoke test failure caused by duplicate `notification-bell` testid.
+
+### Root Cause
+
+`NotificationBell` renders twice in Header.tsx (desktop + mobile), both with same testid.
+Playwright strict mode requires unique selectors.
+
+### Fix
+
+Test-only: Use `.first()` to target desktop bell.
+
+### Evidence
+
+| Check | Before | After |
+|-------|--------|-------|
+| E2E (PostgreSQL) | FAIL | PASS |
+| notifications.spec.ts | 0/3 | 3/3 |
+
+### PR
+
+- #2379 merged, commit `7a1d1408`
+
+### Artifacts
+
+- `docs/AGENT/TASKS/Pass-CI-FLAKE-NOTIFICATIONS-01.md`
+- `docs/AGENT/SUMMARY/Pass-CI-FLAKE-NOTIFICATIONS-01.md`
 
 ---
 


### PR DESCRIPTION
Docs-only. Adds TASKS/SUMMARY for CI flake fix, updates STATE.md.