### PR TITLE
feat: Pass UI-HEADER-NAV-CLARITY-01 move language switcher to footer

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-UI-HEADER-NAV-CLARITY-01.md
+++ b/docs/AGENT/SUMMARY/Pass-UI-HEADER-NAV-CLARITY-01.md
@@ -1,0 +1,69 @@
+# Summary: Pass UI-HEADER-NAV-CLARITY-01
+
+**Date**: 2026-01-22
+**Status**: PENDING CI
+**Type**: UI Cleanup
+**Base**: `cd42664f`
+
+---
+
+## TL;DR
+
+Moved language switcher (EL/EN) from header to footer for stable, non-shifting mobile UI.
+
+---
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `Header.tsx` | Removed language switcher (desktop + mobile) |
+| `Footer.tsx` | Added language switcher with testids |
+| `header-nav.spec.ts` | Updated test to verify lang NOT in header |
+| `locale.spec.ts` | Updated test to use footer testids |
+
+### Header.tsx (-45 lines)
+
+Removed:
+- `useLocale` hook
+- `locales` import
+- `handleLocaleChange` function
+- Desktop language switcher (`lang-el`, `lang-en` testids)
+- Mobile language switcher (`mobile-lang-el`, `mobile-lang-en` testids)
+
+### Footer.tsx (+27 lines)
+
+Added:
+- `'use client'` directive
+- `useLocale`, `useTranslations` hooks
+- `locales` import
+- `handleLocaleChange` function
+- Language switcher with testids: `footer-lang-el`, `footer-lang-en`
+
+---
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| Build | PASS |
+| TypeScript | PASS (no errors) |
+| Diff | +45/-62 lines |
+
+---
+
+## Rationale
+
+From `docs/NEXT-7D.md` backlog:
+> **Language toggle position**: Remove from header; place in footer or settings page (toggle shifting position is undesirable on mobile)
+
+---
+
+## Risk
+
+- **Risk**: LOW — purely presentational move
+- **Rollback**: Revert commit
+
+---
+
+_Summary: UI-HEADER-NAV-CLARITY-01 | 2026-01-22_

--- a/docs/AGENT/TASKS/Pass-UI-HEADER-NAV-CLARITY-01.md
+++ b/docs/AGENT/TASKS/Pass-UI-HEADER-NAV-CLARITY-01.md
@@ -1,0 +1,34 @@
+# TASK — Pass UI-HEADER-NAV-CLARITY-01
+
+## Goal
+
+Move language switcher from header to footer for stable, non-shifting UI.
+
+## Scope
+
+Frontend ONLY. No business logic changes.
+
+## Steps
+
+1. [x] Sync to main @ `cd42664f`
+2. [x] Remove language switcher from Header.tsx (desktop + mobile)
+3. [x] Add language switcher to Footer.tsx
+4. [x] Update E2E tests to use new footer testids
+5. [x] Build verification: PASS
+6. [x] TypeScript check: PASS
+7. [x] Create TASKS + SUMMARY artifacts
+8. [ ] PR merged with CI green
+
+## DoD
+
+- [x] Header has NO language switcher
+- [x] Footer HAS language switcher with testids `footer-lang-el`, `footer-lang-en`
+- [x] E2E tests updated
+- [x] Build passes
+- [ ] CI green
+- [ ] Pass artifacts created
+- [ ] STATE + NEXT-7D updated
+
+## Result
+
+**PENDING CI** — Awaiting merge.

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,7 +1,16 @@
+'use client';
 import Link from 'next/link';
 import Logo from '@/components/brand/Logo';
+import { useLocale, useTranslations } from '@/contexts/LocaleContext';
+import { locales, type Locale } from '../../../i18n';
 
 export default function Footer() {
+  const { locale, setLocale } = useLocale();
+  const t = useTranslations();
+
+  const handleLocaleChange = (newLocale: Locale) => {
+    setLocale(newLocale);
+  };
   return (
     <footer className="border-t border-neutral-200 bg-white mt-auto">
       {/* Mobile-first padding */}
@@ -67,6 +76,24 @@ export default function Footer() {
             © {new Date().getFullYear()} Dixis. Με αγάπη για τους τοπικούς παραγωγούς.
           </p>
           <div className="flex items-center gap-4">
+            {/* Language Switcher */}
+            <div className="flex items-center gap-1" data-testid="footer-language-switcher">
+              {locales.map((loc) => (
+                <button
+                  key={loc}
+                  onClick={() => handleLocaleChange(loc)}
+                  className={`text-xs font-medium px-2 py-1 rounded transition-colors ${
+                    locale === loc
+                      ? 'bg-primary text-white'
+                      : 'text-neutral-500 hover:text-neutral-700 hover:bg-neutral-100'
+                  }`}
+                  data-testid={`footer-lang-${loc}`}
+                  aria-label={t(`language.${loc}`)}
+                >
+                  {loc.toUpperCase()}
+                </button>
+              ))}
+            </div>
             <span className="text-xs text-neutral-400">Made with Cyprus Green</span>
           </div>
         </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -5,8 +5,7 @@ import Logo from '@/components/brand/Logo';
 import CartIcon from '@/components/cart/CartIcon';
 import NotificationBell from '@/components/notifications/NotificationBell';
 import { useAuth } from '@/hooks/useAuth';
-import { useLocale, useTranslations } from '@/contexts/LocaleContext';
-import { locales, type Locale } from '../../../i18n';
+import { useTranslations } from '@/contexts/LocaleContext';
 
 export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -14,7 +13,6 @@ export default function Header() {
   const userMenuRef = useRef<HTMLDivElement>(null);
   const { user, logout, isAuthenticated, isProducer, isAdmin } = useAuth();
   const t = useTranslations();
-  const { locale, setLocale } = useLocale();
 
   // Close user menu when clicking outside
   useEffect(() => {
@@ -40,10 +38,6 @@ export default function Header() {
     } catch (error) {
       console.error('Logout failed:', error);
     }
-  };
-
-  const handleLocaleChange = (newLocale: Locale) => {
-    setLocale(newLocale);
   };
 
   // Determine if cart should be shown (not for producers)
@@ -76,25 +70,6 @@ export default function Header() {
 
         {/* Desktop Right Side: Utilities + Auth */}
         <div className="hidden md:flex items-center gap-3">
-          {/* Language Switcher */}
-          <div className="flex items-center gap-1">
-            {locales.map((loc) => (
-              <button
-                key={loc}
-                onClick={() => handleLocaleChange(loc)}
-                className={`text-xs font-medium px-2 py-1 rounded transition-colors ${
-                  locale === loc
-                    ? 'bg-primary text-white'
-                    : 'text-neutral-500 hover:text-neutral-700 hover:bg-neutral-100'
-                }`}
-                data-testid={`lang-${loc}`}
-                aria-label={t(`language.${loc}`)}
-              >
-                {loc.toUpperCase()}
-              </button>
-            ))}
-          </div>
-
           {/* Notification Bell - only for authenticated users */}
           {isAuthenticated && <NotificationBell />}
 
@@ -206,24 +181,6 @@ export default function Header() {
 
         {/* Mobile Right Side: Utilities + Hamburger */}
         <div className="flex md:hidden items-center gap-2">
-          {/* Mobile Language Switcher */}
-          <div className="flex items-center gap-1">
-            {locales.map((loc) => (
-              <button
-                key={loc}
-                onClick={() => handleLocaleChange(loc)}
-                className={`text-xs font-medium px-2 py-1 rounded transition-colors ${
-                  locale === loc
-                    ? 'bg-primary text-white'
-                    : 'text-neutral-500 hover:text-neutral-700'
-                }`}
-                data-testid={`mobile-lang-${loc}`}
-              >
-                {loc.toUpperCase()}
-              </button>
-            ))}
-          </div>
-
           {/* Notification Bell - only for authenticated users */}
           {isAuthenticated && <NotificationBell />}
 

--- a/frontend/tests/e2e/header-nav.spec.ts
+++ b/frontend/tests/e2e/header-nav.spec.ts
@@ -51,14 +51,16 @@ test.describe('Header Navigation - Guest @smoke', () => {
     await expect(forbiddenLink).not.toBeVisible();
   });
 
-  test('language toggle is visible', async ({ page }) => {
-    const desktopEl = page.locator('[data-testid="lang-el"]');
-    const mobileEl = page.locator('[data-testid="mobile-lang-el"]');
-    await expect.poll(async () => {
-      const desktopVisible = await desktopEl.isVisible().catch(() => false);
-      const mobileVisible = await mobileEl.isVisible().catch(() => false);
-      return desktopVisible || mobileVisible;
-    }, { timeout: 10000 }).toBe(true);
+  test('language toggle is NOT in header (moved to footer)', async ({ page }) => {
+    // Language switcher has been moved to footer per UI-HEADER-NAV-CLARITY-01
+    const headerLangEl = page.locator('header [data-testid="lang-el"]');
+    const headerLangEn = page.locator('header [data-testid="lang-en"]');
+    await expect(headerLangEl).not.toBeVisible();
+    await expect(headerLangEn).not.toBeVisible();
+
+    // Verify it's in the footer instead
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await expect(page.getByTestId('footer-lang-el')).toBeVisible({ timeout: 5000 });
   });
 
   test('user dropdown NOT visible for guest', async ({ page }) => {

--- a/frontend/tests/e2e/locale.spec.ts
+++ b/frontend/tests/e2e/locale.spec.ts
@@ -12,17 +12,14 @@ test.describe('Locale @smoke', () => {
     // Wait for page to load
     await expect(page.getByTestId('search-input')).toBeVisible({ timeout: 15000 });
 
-    // Check that language switcher buttons exist (either desktop or mobile)
-    const desktopEl = page.getByTestId('lang-el');
-    const desktopEn = page.getByTestId('lang-en');
-    const mobileEl = page.getByTestId('mobile-lang-el');
-    const mobileEn = page.getByTestId('mobile-lang-en');
+    // Check that language switcher buttons exist in footer
+    const footerEl = page.getByTestId('footer-lang-el');
+    const footerEn = page.getByTestId('footer-lang-en');
 
-    // At least one set should be visible
-    const desktopVisible = await desktopEl.isVisible() && await desktopEn.isVisible();
-    const mobileVisible = await mobileEl.isVisible() && await mobileEn.isVisible();
-
-    expect(desktopVisible || mobileVisible).toBe(true);
+    // Footer language switcher should be visible (scroll down if needed)
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await expect(footerEl).toBeVisible({ timeout: 5000 });
+    await expect(footerEn).toBeVisible({ timeout: 5000 });
   });
 
   test('locale cookie sets Greek when explicitly set', async ({ page, context }) => {


### PR DESCRIPTION
## Summary

Move language switcher (EL/EN) from header to footer for stable, non-shifting mobile UI.

## Changes

- **Header.tsx**: Removed language switcher (desktop + mobile)
- **Footer.tsx**: Added language switcher with testids `footer-lang-el`, `footer-lang-en`
- **E2E tests**: Updated to verify lang NOT in header and IS in footer

## Rationale

From `docs/NEXT-7D.md` backlog:
> Language toggle position: Remove from header; place in footer (toggle shifting position is undesirable on mobile)

## Test plan

- [x] Build passes
- [x] TypeScript check passes
- [ ] CI E2E tests pass
- [ ] Footer language switcher visible
- [ ] Header has no language buttons

Generated-by: Claude