### PR TITLE
docs: Update bookkeeping for V1 QA re-verification

### DIFF
--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -7,11 +7,14 @@
 
 ## Next Pass Recommendation
 
-- **V1 QA Consolidation: COMPLETE** — Runbook created at `docs/PRODUCT/QA-V1-RUNBOOK.md`
-- **Monitoring 2026-01-22 10:30 UTC: ALL PASS** — Production healthy
-- **VPS Maintenance: PASS** — All metrics healthy, no reboot required
-- **V1 QA: ALL 4 FLOWS PASS** — Re-verification 6 complete
+- **V1 QA Re-verification: 4/4 PASS** — PR #2395 merged (`ad16783a`)
+- **Evidence**: `docs/AGENT/SUMMARY/Proof-2026-01-22-v1-qa-execution.md`
+- **Monitoring 2026-01-22 12:48 UTC**: Backend + API healthy, Products list display issue (outside QA scope)
 - Production stable. Continue monitoring per POST-LAUNCH-CHECKS.md schedule.
+
+### Known Issue (Non-Blocking)
+
+- `/products` page shows "0 συνολικά" — Products API returns data; display-only issue (UI scope, not QA)
 
 ---
 
@@ -26,6 +29,14 @@
 (none)
 
 ### Recently Completed
+
+- ✅ **V1-QA-EXECUTE-01 Re-verification**: All 4 flows PASS (2026-01-22)
+  - Flow A: Order #99, COD, €19.99
+  - Flow B: Order #102, PI `pi_3SsMh9Q9Xukpkfmb2vwY2ktn`
+  - Flow C: Product #11, Green Farm Co.
+  - Flow D: Order #99, pending → processing
+  - PR #2395 merged (`ad16783a`)
+  - Evidence: `docs/AGENT/SUMMARY/Proof-2026-01-22-v1-qa-execution.md`
 
 - ✅ **V1-QA-EXECUTE-01 Consolidation**: QA runbook created
   - Created `docs/PRODUCT/QA-V1-RUNBOOK.md` (reusable QA runbook)

--- a/docs/OPS/PROD-FACTS-LAST.md
+++ b/docs/OPS/PROD-FACTS-LAST.md
@@ -1,7 +1,17 @@
 # PROD FACTS - Last Check
 
-**Last Updated**: 2026-01-22 11:44:13 UTC
-**Status**: ✅ ALL SYSTEMS OPERATIONAL
+**Last Updated**: 2026-01-22 12:48:38 UTC
+**Main HEAD**: `ad16783a`
+**Status**: ⚠️ PARTIAL (1 display issue, APIs OK)
+
+---
+
+## V1 QA Status
+
+| Item | Status | Evidence |
+|------|--------|----------|
+| V1 QA Execution | ✅ 4/4 PASS | PR #2395 |
+| Proof Document | ✅ Complete | `docs/AGENT/SUMMARY/Proof-2026-01-22-v1-qa-execution.md` |
 
 ---
 
@@ -11,7 +21,7 @@
 |----------|--------|---------|
 | Backend Health | ✅ 200 | `/api/healthz` returns OK |
 | Products API | ✅ 200 | `/api/v1/public/products` returns data |
-| Products List | ✅ 200 | `/products` displays products (not empty) |
+| Products List | ⚠️ 200 | `/products` shows "0 συνολικά" (display issue, API has data) |
 | Product Detail | ✅ 200 | `/products/1` shows product content |
 | Login Page | ✅ 200 | `/login` accessible (redirects to `https://dixis.gr/auth/login`) |
 
@@ -21,7 +31,7 @@
 
 - ✅ Backend health endpoint returns `"ok"`
 - ✅ Products API contains `"data"` field
-- ✅ Products list page shows products (no empty state)
+- ⚠️ Products list page shows "0 συνολικά" (UI display issue, backend data OK)
 - ✅ Product detail page contains expected content
 - ✅ Login page accessible (with or without redirect)
 

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -7,6 +7,36 @@
 
 ---
 
+## 2026-01-22 — Pass V1-QA-EXECUTE-01 Re-verification (4 flows PASS)
+
+**Status**: ✅ PASS — CLOSED
+
+Re-executed all 4 V1 QA flows with reproducible API scripts and evidence capture.
+
+### Flow Results
+
+| Flow | Status | Evidence |
+|------|--------|----------|
+| A. Guest COD | ✅ PASS | Order #99, ORD-000099, €19.99 |
+| B. Auth Card | ✅ PASS | Order #102, PI `pi_3SsMh9Q9Xukpkfmb2vwY2ktn` |
+| C. Producer | ✅ PASS | Product #11, Green Farm Co., publicly visible |
+| D. Admin | ✅ PASS | Order #99, pending → processing |
+
+### Evidence
+
+- **Proof Document**: `docs/AGENT/SUMMARY/Proof-2026-01-22-v1-qa-execution.md`
+- **PR**: #2395 (merged `ad16783a`)
+
+### Risks/Next
+
+- Email delivery is **code-verified** (OrderEmailService::sendOrderStatusNotification called)
+- Inbox verification is external/manual (does not block merge)
+- Products list page shows "0 συνολικά" — display issue, API data OK (outside QA scope)
+
+**V1 QA Re-verification: ALL 4 FLOWS PASS**
+
+---
+
 ## 2026-01-22 — Pass V1-QA-EXECUTE-01 Consolidation: QA Runbook Creation
 
 **Status**: ✅ PASS — CLOSED


### PR DESCRIPTION
## Summary
- Updated PROD-FACTS-LAST.md with V1 QA status (4/4 PASS) and main HEAD
- Added V1-QA-EXECUTE-01 re-verification entry to STATE.md
- Updated NEXT-7D.md with PR #2395 link and next steps

## Evidence
- PR #2395 (merged `ad16783a`)
- `docs/AGENT/SUMMARY/Proof-2026-01-22-v1-qa-execution.md`

## Test Plan
- [x] Docs-only change
- [x] No code modifications