### PR TITLE
fix: Pass MONITORING-REGEX-01 false positive in prod-facts.sh

### DIFF
--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -8,13 +8,9 @@
 ## Next Pass Recommendation
 
 - **V1 QA Re-verification: 4/4 PASS** — PR #2395 merged (`ad16783a`)
-- **Evidence**: `docs/AGENT/SUMMARY/Proof-2026-01-22-v1-qa-execution.md`
-- **Monitoring 2026-01-22 12:48 UTC**: Backend + API healthy, Products list display issue (outside QA scope)
+- **Monitoring Regex Fix: PASS** — PR #2397 (pending)
+- **prod-facts.sh: ALL PASS** — All 5 checks pass
 - Production stable. Continue monitoring per POST-LAUNCH-CHECKS.md schedule.
-
-### Known Issue (Non-Blocking)
-
-- `/products` page shows "0 συνολικά" — Products API returns data; display-only issue (UI scope, not QA)
 
 ---
 
@@ -29,6 +25,12 @@
 (none)
 
 ### Recently Completed
+
+- ✅ **MONITORING-REGEX-01**: Fix prod-facts.sh false positive (2026-01-22)
+  - Root cause: `grep "0 συνολικά"` matched substring in "10 συνολικά"
+  - Fix: Use `grep -qE '\b0 συνολικά'` with word boundary
+  - PR #2397 (pending merge)
+  - This was NOT a UI bug — the page correctly shows "10 συνολικά"
 
 - ✅ **V1-QA-EXECUTE-01 Re-verification**: All 4 flows PASS (2026-01-22)
   - Flow A: Order #99, COD, €19.99

--- a/docs/OPS/PROD-FACTS-LAST.md
+++ b/docs/OPS/PROD-FACTS-LAST.md
@@ -1,8 +1,8 @@
 # PROD FACTS - Last Check
 
-**Last Updated**: 2026-01-22 12:48:38 UTC
-**Main HEAD**: `ad16783a`
-**Status**: ⚠️ PARTIAL (1 display issue, APIs OK)
+**Last Updated**: 2026-01-22 12:54:03 UTC
+**Main HEAD**: `fe5e62f0`
+**Status**: ✅ ALL SYSTEMS OPERATIONAL
 
 ---
 
@@ -21,7 +21,7 @@
 |----------|--------|---------|
 | Backend Health | ✅ 200 | `/api/healthz` returns OK |
 | Products API | ✅ 200 | `/api/v1/public/products` returns data |
-| Products List | ⚠️ 200 | `/products` shows "0 συνολικά" (display issue, API has data) |
+| Products List | ✅ 200 | `/products` displays products (not empty) |
 | Product Detail | ✅ 200 | `/products/1` shows product content |
 | Login Page | ✅ 200 | `/login` accessible (redirects to `https://dixis.gr/auth/login`) |
 
@@ -31,7 +31,7 @@
 
 - ✅ Backend health endpoint returns `"ok"`
 - ✅ Products API contains `"data"` field
-- ⚠️ Products list page shows "0 συνολικά" (UI display issue, backend data OK)
+- ✅ Products list page shows products (no empty state)
 - ✅ Product detail page contains expected content
 - ✅ Login page accessible (with or without redirect)
 

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -7,6 +7,37 @@
 
 ---
 
+## 2026-01-22 — Pass MONITORING-REGEX-01: Fix prod-facts.sh false positive
+
+**Status**: ✅ PASS — CLOSED
+
+Fixed false positive in prod-facts.sh where "10 συνολικά" was incorrectly flagged as "0 συνολικά".
+
+### Root Cause
+
+The grep pattern `"0 συνολικά"` did substring matching, so it matched the "0" within "10 συνολικά".
+
+### Fix
+
+Changed from: `grep -q "0 συνολικά"`
+Changed to: `grep -qE '\b0 συνολικά'`
+
+The `\b` word boundary ensures we only match when "0" is at the start of a word.
+
+### Evidence
+
+- **PR**: #2397
+- **Before**: prod-facts.sh falsely reported "0 συνολικά" when page showed "10 συνολικά"
+- **After**: prod-facts.sh correctly passes
+
+### Notes
+
+This was **NOT** a UI display bug. The `/products` page correctly shows "10 συνολικά" when there are 10 products. The issue was in the monitoring script's regex.
+
+**Monitoring Script Fix: PASS**
+
+---
+
 ## 2026-01-22 — Pass V1-QA-EXECUTE-01 Re-verification (4 flows PASS)
 
 **Status**: ✅ PASS — CLOSED
@@ -31,7 +62,6 @@ Re-executed all 4 V1 QA flows with reproducible API scripts and evidence capture
 
 - Email delivery is **code-verified** (OrderEmailService::sendOrderStatusNotification called)
 - Inbox verification is external/manual (does not block merge)
-- Products list page shows "0 συνολικά" — display issue, API data OK (outside QA scope)
 
 **V1 QA Re-verification: ALL 4 FLOWS PASS**
 

--- a/scripts/prod-facts.sh
+++ b/scripts/prod-facts.sh
@@ -69,7 +69,8 @@ if [[ "$status" == "200" ]]; then
     echo "✅ Products List Page: $status"
 
     # Check for empty state indicators
-    if echo "$response" | grep -q "0 συνολικά"; then
+    # Use word boundary (\b) to avoid matching "10 συνολικά" as "0 συνολικά"
+    if echo "$response" | grep -qE '\b0 συνολικά'; then
         echo "  ❌ Content check FAILED: Page shows '0 συνολικά' (no products)"
         EXIT_CODE=1
     elif echo "$response" | grep -q "Δεν υπάρχουν"; then


### PR DESCRIPTION
## Summary
- Fixed false positive in `prod-facts.sh` where "10 συνολικά" was incorrectly flagged as "0 συνολικά"

## Root Cause
The grep pattern `"0 συνολικά"` does substring matching, so it matched the "0" within "10 συνολικά".

## Fix
Changed from: `grep -q "0 συνολικά"`
Changed to: `grep -qE '\b0 συνολικά'`

The `\b` word boundary ensures we only match when "0" is at the start of a word, not part of "10", "20", "100", etc.

## Evidence

```bash
# Before fix:
./scripts/prod-facts.sh
# ❌ Content check FAILED: Page shows '0 συνολικά' (no products)

# After fix:
./scripts/prod-facts.sh  
# ✅ Content check passed: Products displayed (no empty state)
```

## Test Cases
| Input | Expected | Actual |
|-------|----------|--------|
| "10 συνολικά" | NOT MATCH | NOT MATCH ✅ |
| "0 συνολικά" | MATCH | MATCH ✅ |
| "20 συνολικά" | NOT MATCH | NOT MATCH ✅ |
| "100 συνολικά" | NOT MATCH | NOT MATCH ✅ |

## Test Plan
- [x] Regex edge cases validated
- [x] prod-facts.sh passes on production
- [x] No application code changed (script-only fix)