### PR TITLE
fix: Pass UX-HEADER-CLEANUP-02 header cleanup and remove duplicate nav

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-UX-HEADER-CLEANUP-02.md
+++ b/docs/AGENT/SUMMARY/Pass-UX-HEADER-CLEANUP-02.md
@@ -1,0 +1,77 @@
+# Pass UX-HEADER-CLEANUP-02: Header Cleanup
+
+**Date**: 2026-01-22T18:45:00Z
+**Commit**: TBD (pending merge)
+**Pass ID**: UX-HEADER-CLEANUP-02
+
+---
+
+## TL;DR
+
+Cleaned up header: increased logo size to 44px, centered primary nav, improved spacing, and removed duplicate Navigation component from 9 pages that was causing double headers.
+
+---
+
+## Changes Made
+
+### Header.tsx Updates
+
+| Change | Before | After |
+|--------|--------|-------|
+| Logo height | 36px | 44px |
+| Primary nav position | `ml-8` (left-aligned) | `flex-1 justify-center` (centered) |
+| Primary nav gap | `gap-6` | `gap-8` |
+| Right side gap | `gap-3` | `gap-4` |
+
+### Removed Duplicate Navigation
+
+The old `Navigation.tsx` component was still being used in 9 pages **in addition to** the `Header` component in `layout.tsx`, causing double navigation bars.
+
+**Files cleaned up:**
+1. `frontend/src/app/HomeClient.tsx`
+2. `frontend/src/app/admin/analytics/AnalyticsContent.tsx`
+3. `frontend/src/app/orders/page.tsx`
+4. `frontend/src/app/orders/[id]/page.tsx`
+5. `frontend/src/app/producer/analytics/page.tsx`
+6. `frontend/src/app/producer/dashboard/page.tsx`
+7. `frontend/src/app/producer/orders/page.tsx`
+8. `frontend/src/app/producer/orders/[id]/page.tsx`
+9. `frontend/src/app/test-error/page.tsx`
+
+---
+
+## NOT Changed (Already Correct)
+
+- Language switcher: Already in footer (not in header)
+- Order tracking: Already in footer (not in header)
+- No vertical dividers found in Header.tsx
+- Role-based menu items: Working correctly
+- Cart visibility: Working correctly (hidden for producers)
+
+---
+
+## Verification
+
+- TypeScript: `npx tsc --noEmit` - PASS
+- Build: `npm run build` - PASS
+- E2E tests: Rely on CI (backend required)
+
+---
+
+## Artifacts
+
+- `frontend/src/components/layout/Header.tsx` (UPDATED)
+- 9 page files (Navigation import removed)
+- `docs/AGENT/SUMMARY/Pass-UX-HEADER-CLEANUP-02.md` (this file)
+
+---
+
+## Impact
+
+- **Visual**: Larger logo (44px vs 36px), centered navigation, better spacing
+- **UX**: No more double headers on producer/admin/orders pages
+- **Code**: -27 lines removed (cleaner codebase)
+
+---
+
+**Pass Status: COMPLETE**

--- a/frontend/src/app/HomeClient.tsx
+++ b/frontend/src/app/HomeClient.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import Link from 'next/link';
 import ProductImage from '@/components/product/ProductImage';
 import { apiClient, Product } from '@/lib/api';
-import Navigation from '@/components/Navigation';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import ErrorState from '@/components/ErrorState';
 import EmptyState from '@/components/EmptyState';
@@ -266,8 +265,6 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
           }}
         />
       )}
-      
-      <Navigation />
       
       <main id="main-content" data-testid="main-content" className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Hero Section - Mobile First */}

--- a/frontend/src/app/admin/analytics/AnalyticsContent.tsx
+++ b/frontend/src/app/admin/analytics/AnalyticsContent.tsx
@@ -1,14 +1,11 @@
 'use client';
 
 import Link from 'next/link';
-import Navigation from '@/components/Navigation';
 import AnalyticsDashboard from '@/components/analytics/AnalyticsDashboard';
 
 export default function AnalyticsContent() {
   return (
     <div className="min-h-screen bg-gray-50">
-      <Navigation />
-
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Breadcrumb */}
         <nav className="flex mb-8" data-testid="breadcrumb">

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -5,7 +5,6 @@ import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { apiClient, Order } from '@/lib/api';
 import { formatShippingAddress, hasShippingAddress } from '@/lib/orderUtils';
-import Navigation from '@/components/Navigation';
 import { useAuth } from '@/contexts/AuthContext';
 
 export default function OrderDetails() {
@@ -77,8 +76,6 @@ export default function OrderDetails() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Navigation />
-      
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Back Button */}
         <div className="mb-6">

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { apiClient, Order } from '@/lib/api';
-import Navigation from '@/components/Navigation';
 import { useAuth } from '@/contexts/AuthContext';
 
 export default function OrdersList() {
@@ -77,8 +76,6 @@ export default function OrdersList() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Navigation />
-
       <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
         <div className="mb-8">

--- a/frontend/src/app/producer/analytics/page.tsx
+++ b/frontend/src/app/producer/analytics/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import Navigation from '@/components/Navigation';
 import ProducerAnalyticsDashboard from '@/components/producer/ProducerAnalyticsDashboard';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -40,8 +39,6 @@ export default function ProducerAnalytics() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Navigation />
-
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Breadcrumb */}
         <nav className="flex mb-8" data-testid="breadcrumb">

--- a/frontend/src/app/producer/dashboard/page.tsx
+++ b/frontend/src/app/producer/dashboard/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { apiClient, ProducerStats, Product } from '@/lib/api';
-import Navigation from '@/components/Navigation';
 import AuthGuard from '@/components/AuthGuard';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTranslations } from '@/contexts/LocaleContext';
@@ -99,8 +98,6 @@ export default function ProducerDashboard() {
   return (
     <AuthGuard requireAuth={true} requireRole="producer">
       <div className="min-h-screen bg-gray-50">
-        <Navigation />
-
         <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8" data-testid="producer-dashboard">
         {/* Header */}
         <div className="mb-8">

--- a/frontend/src/app/producer/orders/[id]/page.tsx
+++ b/frontend/src/app/producer/orders/[id]/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { apiClient, ProducerOrder } from '@/lib/api';
-import Navigation from '@/components/Navigation';
 import AuthGuard from '@/components/AuthGuard';
 import { formatCurrency } from '@/env';
 
@@ -145,8 +144,6 @@ export default function ProducerOrderDetailsPage() {
   return (
     <AuthGuard requireAuth={true} requireRole="producer">
       <div className="min-h-screen bg-gray-50">
-        <Navigation />
-
         <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {/* Back Link */}
           <Link

--- a/frontend/src/app/producer/orders/page.tsx
+++ b/frontend/src/app/producer/orders/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { apiClient, ProducerOrder } from '@/lib/api';
-import Navigation from '@/components/Navigation';
 import AuthGuard from '@/components/AuthGuard';
 import { formatCurrency } from '@/env';
 import { useTranslations } from '@/contexts/LocaleContext';
@@ -156,8 +155,6 @@ export default function ProducerOrdersPage() {
   return (
     <AuthGuard requireAuth={true} requireRole="producer">
       <div className="min-h-screen bg-gray-50" data-testid="producer-orders-page">
-        <Navigation />
-
         <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {/* Header */}
           <div className="mb-6">

--- a/frontend/src/app/test-error/page.tsx
+++ b/frontend/src/app/test-error/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import Navigation from '@/components/Navigation';
 import { useErrorBoundaryTest } from '@/components/ErrorBoundary';
 import { useAnalytics } from '@/lib/analytics';
 import { usePageAnalytics } from '@/hooks/usePageAnalytics';
@@ -61,8 +60,6 @@ export default function TestErrorPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Navigation />
-      
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
         <div className="mb-8">

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -46,17 +46,17 @@ export default function Header() {
   return (
     <header className="border-b border-neutral-200 bg-white/95 backdrop-blur-sm supports-[backdrop-filter]:bg-white/80 sticky top-0 z-40">
       <div className="max-w-6xl mx-auto px-4 h-16 flex items-center justify-between">
-        {/* Logo - bigger (h-9 = 36px), always visible, links to home */}
+        {/* Logo - 44px height, always visible, links to home */}
         <Link
           href="/"
           className="flex-shrink-0 flex items-center hover:opacity-90 transition-opacity touch-manipulation active:opacity-80"
           data-testid="header-logo"
         >
-          <Logo height={36} title="Dixis" />
+          <Logo height={44} title="Dixis" />
         </Link>
 
-        {/* Desktop Primary Navigation */}
-        <nav className="hidden md:flex items-center gap-6 ml-8" data-testid="header-primary-nav">
+        {/* Desktop Primary Navigation - centered with flex-1 */}
+        <nav className="hidden md:flex items-center justify-center flex-1 gap-8" data-testid="header-primary-nav">
           {navLinks.map((link) => (
             <Link
               key={link.href}
@@ -69,7 +69,7 @@ export default function Header() {
         </nav>
 
         {/* Desktop Right Side: Utilities + Auth */}
-        <div className="hidden md:flex items-center gap-3">
+        <div className="hidden md:flex items-center gap-4">
           {/* Notification Bell - only for authenticated users */}
           {isAuthenticated && <NotificationBell />}
 


### PR DESCRIPTION
## Summary

Header cleanup and removal of duplicate Navigation component causing double headers.

## Changes

### Header.tsx Improvements

| Change | Before | After |
|--------|--------|-------|
| Logo height | 36px | **44px** |
| Primary nav | `ml-8` (left) | `flex-1 justify-center` (centered) |
| Nav gap | `gap-6` | `gap-8` |
| Right side gap | `gap-3` | `gap-4` |

### Duplicate Navigation Removed (9 pages)

These pages were importing the old `Navigation.tsx` component **in addition to** the `Header` component from `layout.tsx`, causing double navigation bars:

- `HomeClient.tsx`
- `admin/analytics/AnalyticsContent.tsx`
- `orders/page.tsx`, `orders/[id]/page.tsx`
- `producer/analytics/page.tsx`
- `producer/dashboard/page.tsx`
- `producer/orders/page.tsx`, `producer/orders/[id]/page.tsx`
- `test-error/page.tsx`

## NOT Changed (Already Correct)

- Language switcher (already in footer)
- Order tracking (already in footer)
- Role-based menu items
- Cart visibility (hidden for producers)

## Verification

- [x] TypeScript: `npx tsc --noEmit` - PASS
- [x] Build: `npm run build` - PASS
- [ ] E2E tests (CI)

## Test Plan

- [ ] Logo is visible at 44px on desktop and mobile
- [ ] Primary nav is centered
- [ ] No double headers on producer/admin/orders pages
- [ ] All data-testid attributes preserved

## Stats

- 10 files changed
- -27 lines (removed duplicate code)

---
Pass ID: UX-HEADER-CLEANUP-02