### PR TITLE
fix: Pass CI-E2E-HEADER-NAV-01 fix cart testid in E2E test

### DIFF
--- a/docs/AGENT/SUMMARY/Proof-OPS-DEPLOY-SSH-RETRY-01.md
+++ b/docs/AGENT/SUMMARY/Proof-OPS-DEPLOY-SSH-RETRY-01.md
@@ -1,0 +1,113 @@
+# Proof: OPS-DEPLOY-SSH-RETRY-01 Deploy with Retry
+
+**Date**: 2026-01-22T23:17:47Z
+**Merged Commit**: `6f7e1499bacff4faac1f4f27a91f53e63b1658fc`
+**PR**: #2408
+**Result**: **PASS**
+
+---
+
+## Summary
+
+First production deploy with SSH retry + post-deploy proof completed successfully.
+
+| Check | Status |
+|-------|--------|
+| PR Merge | ✅ MERGED (squash) |
+| Deploy Frontend (VPS) | ✅ SUCCESS (3m47s) |
+| Deploy Backend (VPS) | ✅ SUCCESS (17s) |
+| prod-facts.sh | ✅ ALL CHECKS PASSED |
+| perf-baseline.sh | ✅ ALL < 300ms TTFB |
+| Health endpoint | ✅ `{"status":"ok"}` |
+
+---
+
+## Deploy Workflow Runs
+
+| Workflow | Run ID | Status | Duration |
+|----------|--------|--------|----------|
+| Deploy Frontend (VPS) | [21268269263](https://github.com/lomendor/Project-Dixis/actions/runs/21268269263) | SUCCESS | 3m47s |
+| Deploy Backend (VPS) | [21268269271](https://github.com/lomendor/Project-Dixis/actions/runs/21268269271) | SUCCESS | 17s |
+
+### Frontend Deploy Steps (all PASS)
+
+```
+✓ Precheck VPS env files (with retry)
+✓ Prepare VPS directory (with retry)
+✓ Deploy standalone to VPS (with retry)
+✓ Configure and start app
+✓ Post-deploy proof (prod == main)
+```
+
+The `(with retry)` suffix confirms the retry wrapper is active.
+
+---
+
+## Post-Deploy Verification
+
+### Health Endpoint
+
+```bash
+curl -sS https://dixis.gr/api/healthz
+```
+
+```json
+{
+  "status": "ok",
+  "database": "connected",
+  "payments": {"cod": "enabled", "card": {"flag": "enabled", "stripe_configured": true}},
+  "email": {"flag": "enabled", "mailer": "resend", "configured": true},
+  "timestamp": "2026-01-22T23:17:47.229434Z",
+  "version": "12.38.1"
+}
+```
+
+### prod-facts.sh
+
+```
+✅ Backend Health: 200
+✅ Products API: 200
+✅ Products List Page: 200
+✅ Product Detail Page: 200
+✅ Login Page: 200
+✅ ALL CHECKS PASSED
+```
+
+### perf-baseline.sh (key endpoints)
+
+| Endpoint | Median TTFB |
+|----------|-------------|
+| `/` (homepage) | 183ms |
+| `/products` | 180ms |
+| `/api/v1/public/products` | 256ms |
+
+All endpoints < 300ms threshold.
+
+---
+
+## Retry Configuration (Reference)
+
+From `.github/workflows/deploy-frontend.yml`:
+
+```yaml
+env:
+  SSH_RETRY_MAX: 3
+  SSH_RETRY_DELAY_SECONDS: 10
+
+- name: Deploy standalone to VPS (with retry)
+  uses: nick-fields/retry@v3
+  with:
+    timeout_minutes: 5
+    max_attempts: ${{ env.SSH_RETRY_MAX }}
+    retry_wait_seconds: ${{ env.SSH_RETRY_DELAY_SECONDS }}
+```
+
+---
+
+## Conclusion
+
+**PASS**: SSH retry mechanism deployed and operational. Post-deploy proof verifies production health automatically.
+
+---
+
+_Proof-OPS-DEPLOY-SSH-RETRY-01 | Agent: Claude_

--- a/docs/NEXT-7D.md
+++ b/docs/NEXT-7D.md
@@ -7,29 +7,34 @@
 
 ## Next Pass Recommendation
 
-- **OPS-DEPLOY-SSH-RETRY-01: WIP** — SSH retry + post-deploy proof (PR pending)
+- **CI-E2E-HEADER-NAV-01: QUEUED** — Fix pre-existing E2E test failure (header-cart testid)
+- **OPS-DEPLOY-SSH-RETRY-01: DONE** — SSH retry + post-deploy proof deployed
 - **Post-Launch Checks: ENABLED** — Automated daily monitoring via GitHub Actions
 - **V1 QA Execute: ALL 4 FLOWS PASS** — Full runbook execution complete
-- **V1 QA Runbook: DONE** — Consolidated runbook + E2E plan documented
 - **Perf Baseline: ALL PASS** — All endpoints < 300ms TTFB
-- Production stable. V1 QA COMPLETE. Monitoring automated.
+- Production stable. Deploy infrastructure hardened.
 
 ---
 
 ## Backlog (Post-V1)
 
 - ~~**Language toggle position**: Remove from header; place in footer~~ — **DONE** (Pass UI-HEADER-NAV-CLARITY-01)
+- **CI-E2E-HEADER-NAV-01**: Fix `header-nav.spec.ts` test (uses wrong testid `header-cart` → `nav-cart-guest`)
 
 ---
 
 ## In Progress
 
-- 🔄 **OPS-DEPLOY-SSH-RETRY-01**: SSH deploy retry + post-deploy proof
-  - SSH retry: 3 attempts, 10s delay
-  - Post-deploy proof: health check + homepage smoke
-  - Affected: `deploy-frontend.yml`, `deploy-backend.yml`
+(none)
 
 ### Recently Completed
+
+- ✅ **OPS-DEPLOY-SSH-RETRY-01**: SSH deploy retry + post-deploy proof (2026-01-23)
+  - PR #2408 merged (`6f7e1499`)
+  - Deploy Frontend run 21268269263: SUCCESS
+  - Deploy Backend run 21268269271: SUCCESS
+  - prod-facts: ALL PASS
+  - Proof: `docs/AGENT/SUMMARY/Proof-OPS-DEPLOY-SSH-RETRY-01.md`
 
 - ✅ **OPS-POST-LAUNCH-CHECKS-01**: Scheduled production monitoring (2026-01-22)
   - NEW: `post-launch-checks.yml` - daily comprehensive checks

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -9,7 +9,7 @@
 
 ## 2026-01-23 — Pass OPS-DEPLOY-SSH-RETRY-01: SSH Deploy Retry + Proof
 
-**Status**: 🔄 WIP
+**Status**: ✅ PASS — CLOSED
 
 Added automatic retry with backoff for SSH deploy steps + post-deploy proof.
 
@@ -26,10 +26,18 @@ Added automatic retry with backoff for SSH deploy steps + post-deploy proof.
 - **Proof**: Every deploy verifies prod health + logs commit SHA
 - **Action**: Uses `nick-fields/retry@v3` for reliable retry logic
 
+### First Deploy Results
+
+| Workflow | Run ID | Status |
+|----------|--------|--------|
+| Deploy Frontend | 21268269263 | SUCCESS (3m47s) |
+| Deploy Backend | 21268269271 | SUCCESS (17s) |
+
 ### Evidence
 
 - Summary: `docs/AGENT/SUMMARY/Pass-OPS-DEPLOY-SSH-RETRY-01.md`
-- PR: TBD
+- Proof: `docs/AGENT/SUMMARY/Proof-OPS-DEPLOY-SSH-RETRY-01.md`
+- PR: #2408 (merged `6f7e1499`)
 
 ---
 

--- a/frontend/tests/e2e/header-nav.spec.ts
+++ b/frontend/tests/e2e/header-nav.spec.ts
@@ -69,7 +69,9 @@ test.describe('Header Navigation - Guest @smoke', () => {
 
   test('cart icon is VISIBLE for guest (per NAVIGATION-V1.md)', async ({ page }) => {
     // Cart should be visible in header for guests
-    await expect(page.locator('[data-testid="header-cart"]')).toBeVisible();
+    // CartIcon uses role-specific testids: nav-cart-guest for guests
+    // Use .first() to avoid strict mode violation (desktop + mobile both have this testid)
+    await expect(page.locator('[data-testid="nav-cart-guest"]').first()).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary

Fix pre-existing E2E test failure in `header-nav.spec.ts`.

## Problem

The test was looking for `data-testid="header-cart"` but the `CartIcon` component uses role-specific testids:
- Guest: `nav-cart-guest`
- Consumer: `nav-cart`
- Admin: `nav-cart-admin`

The `header-cart` testid passed from `Header.tsx` was being ignored by the `CartIcon` component.

## Fix

Changed the test to use the correct testid:
```diff
- await expect(page.locator('[data-testid="header-cart"]')).toBeVisible();
+ await expect(page.locator('[data-testid="nav-cart-guest"]')).toBeVisible();
```

## Also Includes

- Proof doc for OPS-DEPLOY-SSH-RETRY-01 deploy verification
- STATE/NEXT-7D updates marking SSH retry pass as CLOSED

## Test Plan

- [ ] E2E (PostgreSQL) check should now PASS
- [ ] All other CI checks remain GREEN

---
Generated by Claude Code (Pass CI-E2E-HEADER-NAV-01)