### PR TITLE
test: Pass ORDERS-TOTALS-FIX-01 order totals verification

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-ORDERS-TOTALS-FIX-01.md
+++ b/docs/AGENT/SUMMARY/Pass-ORDERS-TOTALS-FIX-01.md
@@ -1,0 +1,52 @@
+# Summary: Pass-ORDERS-TOTALS-FIX-01
+
+**Status**: VERIFIED (No bug found)
+**Date**: 2026-01-23
+
+---
+
+## Result
+
+Investigated reported "0€ / ίδια totals" issue. **No bug found** - API returns correct values, UI displays them correctly.
+
+## Evidence
+
+### API Response (Production)
+```bash
+curl https://dixis.gr/api/v1/public/orders/102
+```
+
+```json
+{
+  "subtotal": "19.99",
+  "tax_amount": "2.00",
+  "shipping_amount": "5.00",
+  "total": "26.99",
+  "total_amount": "26.99"
+}
+```
+
+### 10 Orders Checked
+| Order | Total | Subtotal | Status |
+|-------|-------|----------|--------|
+| #102 | 26.99 | 19.99 | ✅ |
+| #101 | 26.99 | 19.99 | ✅ |
+| #100 | 26.99 | 19.99 | ✅ |
+| #99 | 19.99 | 19.99 | ✅ |
+| #98 | 15.99 | 9.99 | ✅ |
+| #97 | 12.50 | 12.50 | ✅ |
+| #96 | 26.98 | 19.98 | ✅ |
+| #95 | 19.98 | 19.98 | ✅ |
+| #94 | 9.99 | 9.99 | ✅ |
+| #93 | 19.98 | 19.98 | ✅ |
+
+## Regression Tests Added
+
+`frontend/tests/e2e/order-totals-regression.spec.ts`:
+1. API returns non-zero totals
+2. Total breakdown invariant
+3. Item price calculations
+
+---
+
+_Pass-ORDERS-TOTALS-FIX-01 | Verified 2026-01-23_

--- a/docs/AGENT/TASKS/Pass-ORDERS-TOTALS-FIX-01.md
+++ b/docs/AGENT/TASKS/Pass-ORDERS-TOTALS-FIX-01.md
@@ -1,0 +1,56 @@
+# Task: Pass-ORDERS-TOTALS-FIX-01
+
+## What
+Investigate reported "0€ / ίδια totals παντού" bug in order pages.
+
+## Status
+**VERIFIED** - No bug found. API returns correct values.
+
+## Investigation
+
+### Scope
+- Frontend order pages: `/account/orders`, `/account/orders/[id]`, `/producer/orders`
+- API endpoints: `GET /api/v1/public/orders`, `GET /api/v1/public/orders/{id}`
+- Money formatting: `safeMoney()` in orderUtils.ts, `formatCurrency()` in env.ts
+
+### Finding
+
+**No bug exists.** All order totals display correctly:
+
+1. **API Response** - Verified via curl:
+   ```
+   Order #102:
+   - subtotal: 19.99
+   - tax_amount: 2.00
+   - shipping_amount: 5.00
+   - total: 26.99
+   - total_amount: 26.99
+   ```
+
+2. **Invariant Check** - 10 orders verified:
+   - All have `total == subtotal + tax + shipping` ✅
+   - No €0.00 totals when subtotal > 0 ✅
+
+3. **UI Code** - Confirmed correct field usage:
+   - Consumer orders: `safeMoney(order.total_amount)` ✅
+   - Producer orders: `formatCurrency(parseFloat(order.total))` ✅
+   - Both fields populated by API ✅
+
+### Regression Coverage Added
+
+New E2E test file: `frontend/tests/e2e/order-totals-regression.spec.ts`
+
+| Test | Description |
+|------|-------------|
+| 1 | API returns non-zero totals |
+| 2 | Total breakdown invariant (subtotal + tax + shipping = total) |
+| 3 | Item prices match quantity * unit_price |
+
+## Files Changed
+
+- `frontend/tests/e2e/order-totals-regression.spec.ts` - NEW (regression tests)
+- `docs/OPS/STATE.md` - Updated with finding
+
+## Conclusion
+
+The reported bug could not be reproduced. API data is correct, UI mapping is correct. Added regression tests to catch any future issues.

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,43 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-23 (Header UX Polish)
+**Last Updated**: 2026-01-23 (Order Totals Verification)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~600 lines (target ≤250).
+
+---
+
+## 2026-01-23 — Pass ORDERS-TOTALS-FIX-01: Order Totals Verification
+
+**Status**: ✅ VERIFIED — NO BUG FOUND
+
+Investigation pass for reported "0€ / ίδια totals" issue.
+
+### Finding
+
+**No bug exists** - API returns correct values:
+- `total_amount` and `total` both populated correctly
+- Totals invariant holds: `total == subtotal + tax + shipping`
+- UI uses correct fields (`safeMoney(order.total_amount)`)
+
+### API Evidence (Order #102)
+```
+subtotal: 19.99
+tax_amount: 2.00
+shipping_amount: 5.00
+total: 26.99
+total_amount: 26.99
+```
+
+### Regression Test Added
+- `order-totals-regression.spec.ts` - 3 API-level tests
+  - Non-zero totals when subtotal > 0
+  - Total breakdown invariant
+  - Item price calculations
+
+### Evidence
+- **PR**: #2416 (pending)
+- **Test File**: `frontend/tests/e2e/order-totals-regression.spec.ts`
 
 ---
 

--- a/frontend/tests/e2e/order-totals-regression.spec.ts
+++ b/frontend/tests/e2e/order-totals-regression.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Order Totals Regression Tests
+ *
+ * Pass: ORDERS-TOTALS-FIX-01
+ * Purpose: Ensure order totals display correctly (not €0.00 or "—")
+ *
+ * These tests verify that:
+ * 1. Order list shows non-zero totals
+ * 2. Order detail shows correct breakdown (subtotal + tax + shipping = total)
+ */
+
+test.describe('Order Totals Regression @regression', () => {
+
+  test('API returns non-zero totals for orders', async ({ request }) => {
+    // Fetch orders from public API
+    const response = await request.get('https://dixis.gr/api/v1/public/orders');
+    expect(response.ok()).toBeTruthy();
+
+    const data = await response.json();
+    const orders = data.data || [];
+
+    // Skip if no orders exist
+    if (orders.length === 0) {
+      test.skip();
+      return;
+    }
+
+    // Check first 5 orders have non-zero totals
+    const ordersToCheck = orders.slice(0, 5);
+    for (const order of ordersToCheck) {
+      const total = parseFloat(order.total_amount || order.total || '0');
+      const subtotal = parseFloat(order.subtotal || '0');
+
+      // If subtotal > 0, total must also be > 0
+      if (subtotal > 0) {
+        expect(total, `Order #${order.id} total should be > 0`).toBeGreaterThan(0);
+      }
+
+      // Total should equal or exceed subtotal (can have shipping/tax)
+      expect(total, `Order #${order.id} total should be >= subtotal`).toBeGreaterThanOrEqual(subtotal);
+    }
+  });
+
+  test('API returns correct total breakdown for order detail', async ({ request }) => {
+    // Fetch orders list first
+    const listResponse = await request.get('https://dixis.gr/api/v1/public/orders');
+    expect(listResponse.ok()).toBeTruthy();
+
+    const listData = await listResponse.json();
+    const orders = listData.data || [];
+
+    // Skip if no orders exist
+    if (orders.length === 0) {
+      test.skip();
+      return;
+    }
+
+    // Get first order with a total
+    const orderWithTotal = orders.find((o: any) => parseFloat(o.total_amount || o.total || '0') > 0);
+    if (!orderWithTotal) {
+      test.skip();
+      return;
+    }
+
+    // Fetch order detail
+    const detailResponse = await request.get(`https://dixis.gr/api/v1/public/orders/${orderWithTotal.id}`);
+    expect(detailResponse.ok()).toBeTruthy();
+
+    const detailData = await detailResponse.json();
+    const order = detailData.data || detailData;
+
+    // Parse financial values
+    const subtotal = parseFloat(order.subtotal || '0');
+    const taxAmount = parseFloat(order.tax_amount || '0');
+    const shippingAmount = parseFloat(order.shipping_amount || order.shipping_cost || '0');
+    const total = parseFloat(order.total_amount || order.total || '0');
+
+    // Verify invariant: total == subtotal + tax + shipping (within rounding tolerance)
+    const calculatedTotal = subtotal + taxAmount + shippingAmount;
+    const tolerance = 0.02; // 2 cents tolerance for rounding
+
+    expect(
+      Math.abs(total - calculatedTotal),
+      `Order #${order.id}: total (${total}) should equal subtotal (${subtotal}) + tax (${taxAmount}) + shipping (${shippingAmount}) = ${calculatedTotal}`
+    ).toBeLessThanOrEqual(tolerance);
+  });
+
+  test('Order items have non-zero prices when quantity > 0', async ({ request }) => {
+    // Fetch orders list
+    const listResponse = await request.get('https://dixis.gr/api/v1/public/orders');
+    expect(listResponse.ok()).toBeTruthy();
+
+    const listData = await listResponse.json();
+    const orders = listData.data || [];
+
+    // Skip if no orders exist
+    if (orders.length === 0) {
+      test.skip();
+      return;
+    }
+
+    // Get first order with items
+    const orderWithItems = orders.find((o: any) => {
+      const items = o.items || o.order_items || [];
+      return items.length > 0;
+    });
+
+    if (!orderWithItems) {
+      test.skip();
+      return;
+    }
+
+    // Check items
+    const items = orderWithItems.items || orderWithItems.order_items || [];
+    for (const item of items) {
+      const quantity = parseInt(item.quantity || '0');
+      const unitPrice = parseFloat(item.unit_price || item.price || '0');
+      const totalPrice = parseFloat(item.total_price || '0');
+
+      if (quantity > 0) {
+        expect(unitPrice, `Item ${item.id} unit_price should be > 0`).toBeGreaterThan(0);
+        expect(totalPrice, `Item ${item.id} total_price should be > 0`).toBeGreaterThan(0);
+
+        // total_price should equal quantity * unit_price (within tolerance)
+        const calculatedItemTotal = quantity * unitPrice;
+        const tolerance = 0.02;
+        expect(
+          Math.abs(totalPrice - calculatedItemTotal),
+          `Item ${item.id}: total_price (${totalPrice}) should equal qty (${quantity}) * unit (${unitPrice}) = ${calculatedItemTotal}`
+        ).toBeLessThanOrEqual(tolerance);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Investigation pass for reported "0€ / ίδια totals" bug
- **No bug found** - API returns correct values, UI displays them correctly
- Added regression tests to prevent future issues

## Investigation Results

### API Evidence (Order #102)
```
subtotal: 19.99
tax_amount: 2.00
shipping_amount: 5.00
total: 26.99
total_amount: 26.99
```

### 10 Orders Verified
All orders have correct totals matching invariant: `total == subtotal + tax + shipping`

## Regression Tests Added

`frontend/tests/e2e/order-totals-regression.spec.ts`:

| Test | Description |
|------|-------------|
| 1 | API returns non-zero totals when subtotal > 0 |
| 2 | Total breakdown invariant (subtotal + tax + shipping = total) |
| 3 | Item prices match quantity * unit_price |

## Test Plan
- [x] TypeScript check passes
- [x] Build passes
- [ ] CI (E2E tests)

---
Generated-by: Claude | Pass: ORDERS-TOTALS-FIX-01