### PR TITLE
test: Pass ORDERS-TOTALS-01 verify order totals pattern

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-ORDERS-TOTALS-01.md
+++ b/docs/AGENT/SUMMARY/Pass-ORDERS-TOTALS-01.md
@@ -1,0 +1,70 @@
+# Summary: Pass-ORDERS-TOTALS-01
+
+**Status**: VERIFIED (No bug)
+**Date**: 2026-01-23
+**PR**: #2420
+
+---
+
+## TL;DR
+
+Investigated "€26.99 pattern" in Orders UI. **No bug found.** The pattern is explained by QA tests using same test product (€19.99 + €5 shipping + €2 tax = €26.99). Real orders have 10+ unique totals.
+
+---
+
+## Result
+
+| Check | Status |
+|-------|--------|
+| Totals calculated correctly | ✅ subtotal + tax + shipping = total |
+| Data is real (not hardcoded) | ✅ 10 unique totals across 15 orders |
+| List/Detail totals match | ✅ Verified via API |
+| Frontend mapping correct | ✅ Uses safeMoney(order.total_amount) |
+
+---
+
+## Evidence
+
+### API Data Sample
+```
+Order #102: subtotal=19.99 + tax=2.00 + shipping=5.00 = total=26.99 ✅
+Order #98:  subtotal=9.99  + tax=1.00 + shipping=5.00 = total=15.99 ✅
+Order #97:  subtotal=12.50 + tax=0.00 + shipping=0.00 = total=12.50 ✅
+```
+
+### Diversity Check
+```
+Unique totals found: €7.48, €8.85, €9.99, €12.50, €15.99, €18.20, €19.98, €19.99, €26.98, €26.99
+Count: 10 unique values (proves real data)
+```
+
+### Test Proof Command
+```bash
+CI=true BASE_URL=https://dixis.gr npx playwright test order-totals-regression.spec.ts
+```
+**Result**: 5 passed (2.4s)
+
+### PR
+https://github.com/lomendor/Project-Dixis/pull/2420
+
+---
+
+## Risks / Next
+
+| Risk | Status |
+|------|--------|
+| None | Data is correct, tests added for regression |
+
+### Why €26.99 Appears Often
+
+QA automated tests (`V1-QA-EXECUTE-01`) create orders with:
+- Same test product: "QA V1 Product" @ €19.99
+- Standard shipping: €5.00
+- Standard tax: €2.00
+- **Total: €26.99**
+
+This is expected behavior for repeated QA test runs.
+
+---
+
+_Pass-ORDERS-TOTALS-01 | 2026-01-23_

--- a/docs/AGENT/TASKS/Pass-ORDERS-TOTALS-01.md
+++ b/docs/AGENT/TASKS/Pass-ORDERS-TOTALS-01.md
@@ -1,0 +1,65 @@
+# Task: Pass-ORDERS-TOTALS-01
+
+## What
+Investigate reported "€26.99 pattern" / inconsistent totals in Orders UI.
+
+## Status
+**VERIFIED** - No bug. Data is correct.
+
+## Scope
+- Investigate why many orders show same €26.99 total
+- Verify totals come from real data (not hardcoded/placeholder)
+- Verify subtotal + tax + shipping = total invariant holds
+- Add regression tests
+
+## Investigation
+
+### Hypothesis
+User reported seeing "πολλά €26.99" - suspected hardcoded/placeholder values.
+
+### Finding
+
+**No bug exists.** The €26.99 pattern is explained by:
+1. QA tests create orders with same test product (€19.99)
+2. With shipping (€5.00) + tax (€2.00) = €26.99
+3. This is expected behavior for repeated QA flows
+
+### Data Diversity Proof
+
+```
+Order totals grouped by value (15 orders):
+- €26.99 (3 orders) - QA tests with €19.99 product
+- €19.98 (2 orders) - 2 × €9.99 items
+- €9.99 (2 orders) - single €9.99 item
+- €8.85 (2 orders) - Organic Tomatoes
+- €18.20 (1 order) - Olive Oil
+- €7.48 (1 order) - Fresh Lettuce
+- Plus 4 other unique values
+```
+
+At least **10 unique totals** across 15 orders - proves real data variety.
+
+### Invariant Check (Order #102)
+```
+subtotal: 19.99
+tax_amount: 2.00
+shipping_amount: 5.00
+total: 26.99 (= 19.99 + 2.00 + 5.00) ✅
+```
+
+## Tests Added
+
+| Test | Purpose |
+|------|---------|
+| `Orders have diverse totals` | Proves ≥3 unique totals (not hardcoded) |
+| `Order list total matches detail total` | List and detail views show same amount |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `order-totals-regression.spec.ts` | Added 2 new tests |
+
+## Conclusion
+
+No bug. Order totals are calculated correctly from real order data. The "€26.99 pattern" is simply QA test data using the same test product.

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,36 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-23 (Producer IA Verification)
+**Last Updated**: 2026-01-23 (Order Totals Verification)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~600 lines (target ≤250).
+
+---
+
+## 2026-01-23 — Pass ORDERS-TOTALS-01: Order Totals Pattern Investigation
+
+**Status**: ✅ VERIFIED — NO BUG (PR #2420 pending)
+
+Investigation pass for reported "€26.99 pattern" in orders.
+
+### Finding
+
+**No bug exists.** The €26.99 pattern is explained by:
+- QA tests use same test product (€19.99)
+- With shipping (€5) + tax (€2) = €26.99
+- Real orders have 10+ unique totals
+
+### Tests Added
+
+| Test | Purpose |
+|------|---------|
+| `Orders have diverse totals` | Proves ≥3 unique totals |
+| `Order list total matches detail total` | List=Detail consistency |
+
+### Evidence
+- **PR**: #2420 (pending)
+- **Test**: `order-totals-regression.spec.ts`
+- **API Check**: 10 unique totals across 15 orders
 
 ---
 

--- a/frontend/tests/e2e/order-totals-regression.spec.ts
+++ b/frontend/tests/e2e/order-totals-regression.spec.ts
@@ -3,12 +3,13 @@ import { test, expect } from '@playwright/test';
 /**
  * Order Totals Regression Tests
  *
- * Pass: ORDERS-TOTALS-FIX-01
+ * Pass: ORDERS-TOTALS-FIX-01, ORDERS-TOTALS-01
  * Purpose: Ensure order totals display correctly (not €0.00 or "—")
  *
  * These tests verify that:
  * 1. Order list shows non-zero totals
  * 2. Order detail shows correct breakdown (subtotal + tax + shipping = total)
+ * 3. Totals are from real order data (not hardcoded/placeholder)
  */
 
 test.describe('Order Totals Regression @regression', () => {
@@ -132,5 +133,67 @@ test.describe('Order Totals Regression @regression', () => {
         ).toBeLessThanOrEqual(tolerance);
       }
     }
+  });
+
+  test('Orders have diverse totals (not all identical - proves real data)', async ({ request }) => {
+    // Pass ORDERS-TOTALS-01: Verify totals come from real orders, not hardcoded values
+    const response = await request.get('https://dixis.gr/api/v1/public/orders');
+    expect(response.ok()).toBeTruthy();
+
+    const data = await response.json();
+    const orders = data.data || [];
+
+    // Need at least 5 orders to check diversity
+    if (orders.length < 5) {
+      test.skip();
+      return;
+    }
+
+    // Collect unique totals from first 10 orders
+    const totals = orders.slice(0, 10).map((o: any) => parseFloat(o.total_amount || o.total || '0'));
+    const uniqueTotals = new Set(totals);
+
+    // Expect at least 3 different total values (proves not hardcoded)
+    expect(
+      uniqueTotals.size,
+      `Expected at least 3 unique totals among ${totals.length} orders, got ${uniqueTotals.size}: ${[...uniqueTotals].join(', ')}`
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  test('Order list total matches order detail total', async ({ request }) => {
+    // Pass ORDERS-TOTALS-01: Verify list view total matches detail view total
+    const listResponse = await request.get('https://dixis.gr/api/v1/public/orders');
+    expect(listResponse.ok()).toBeTruthy();
+
+    const listData = await listResponse.json();
+    const orders = listData.data || [];
+
+    if (orders.length === 0) {
+      test.skip();
+      return;
+    }
+
+    // Pick first order with a total
+    const orderFromList = orders.find((o: any) => parseFloat(o.total_amount || o.total || '0') > 0);
+    if (!orderFromList) {
+      test.skip();
+      return;
+    }
+
+    // Fetch same order detail
+    const detailResponse = await request.get(`https://dixis.gr/api/v1/public/orders/${orderFromList.id}`);
+    expect(detailResponse.ok()).toBeTruthy();
+
+    const detailData = await detailResponse.json();
+    const orderFromDetail = detailData.data || detailData;
+
+    // Compare totals
+    const listTotal = parseFloat(orderFromList.total_amount || orderFromList.total || '0');
+    const detailTotal = parseFloat(orderFromDetail.total_amount || orderFromDetail.total || '0');
+
+    expect(
+      listTotal,
+      `Order #${orderFromList.id}: list total (${listTotal}) should match detail total (${detailTotal})`
+    ).toEqual(detailTotal);
   });
 });


### PR DESCRIPTION
## Summary

Investigation pass for reported "€26.99 pattern" in Orders UI.

**Result: NO BUG FOUND**

The €26.99 pattern is explained by QA automated tests using same test product:
- Product: €19.99
- Shipping: €5.00
- Tax: €2.00
- **Total: €26.99**

Real orders have **10+ unique totals** - proves data is not hardcoded.

## Tests Added

| Test | Purpose |
|------|---------|
| `Orders have diverse totals` | Proves ≥3 unique totals exist |
| `Order list total matches detail total` | Verifies list=detail consistency |

## Evidence

### API Data Sample
```
Order #102: subtotal=19.99 + tax=2.00 + shipping=5.00 = total=26.99 ✅
Order #98:  subtotal=9.99  + tax=1.00 + shipping=5.00 = total=15.99 ✅
Order #90:  subtotal=18.20 + tax=0.00 + shipping=0.00 = total=18.20 ✅
```

### Unique Totals Found (15 orders)
€7.48, €8.85, €9.99, €12.50, €15.99, €18.20, €19.98, €19.99, €26.98, €26.99

### Local Test Proof
```bash
CI=true BASE_URL=https://dixis.gr npx playwright test order-totals-regression.spec.ts
# 5 passed (2.4s)
```

## Test plan

- [x] Local tests pass (5 tests)
- [ ] CI passes

---
_Generated by Claude | Pass ORDERS-TOTALS-01 | 2026-01-23_