### PR TITLE
docs: Pass CI-NEON-COMPUTE-01 - audit shows Neon not used for CI

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-CI-NEON-COMPUTE-01.md
+++ b/docs/AGENT/SUMMARY/Pass-CI-NEON-COMPUTE-01.md
@@ -1,0 +1,87 @@
+# Summary: Pass-CI-NEON-COMPUTE-01
+
+**Status**: VERIFIED (No changes needed)
+**Date**: 2026-01-23
+**PR**: N/A (docs-only verification)
+
+---
+
+## TL;DR
+
+Audit shows **Neon is NOT used for CI E2E tests**. The "E2E (PostgreSQL)" job name is misleading - it uses SQLite via `.env.ci`. No Neon compute burn from tests.
+
+---
+
+## Result
+
+| Question | Answer |
+|----------|--------|
+| Does CI use Neon for E2E? | ❌ No |
+| What DB does E2E use? | SQLite (`file:./test.db`) |
+| Any Neon CU burn from CI? | ❌ No |
+| Changes needed? | ❌ None |
+
+---
+
+## Evidence
+
+### e2e-postgres.yml Analysis
+```yaml
+# Despite the name "E2E (PostgreSQL)", it loads .env.ci which has:
+DATABASE_URL=file:./test.db
+DIXIS_DATA_SRC=sqlite
+```
+
+### Neon Only Used For Deploys
+```bash
+grep -r "DATABASE_URL.*secrets" .github/workflows/
+# Results: Only prod-migration, staging-migration, prod-seed
+# These are deployment workflows, NOT test workflows
+```
+
+### pg-e2e.yml (Label-Gated PG Tests)
+Already uses GitHub Actions postgres service:
+```yaml
+services:
+  postgres:
+    image: postgres:15
+    env:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: dixis_e2e
+```
+
+---
+
+## Architecture (Verified)
+
+```
+CI E2E Tests:
+├── e2e-postgres.yml (PR checks)
+│   └── SQLite (.env.ci) - fast, zero Neon cost
+├── pg-e2e.yml (label-gated)
+│   └── GitHub Actions postgres service - zero Neon cost
+└── e2e-full.yml (nightly)
+    └── SQLite (.env.ci) - zero Neon cost
+
+Neon Usage (Deploy Only):
+├── prod-migration.yml → DATABASE_URL_PROD (Neon)
+├── staging-migration.yml → DATABASE_URL_STAGING (Neon)
+└── prod-seed.yml → DATABASE_URL_PROD (Neon)
+```
+
+---
+
+## Risks / Next
+
+| Risk | Status |
+|------|--------|
+| None | Architecture already optimized |
+
+### Potential Improvement (Low Priority)
+- Rename "E2E (PostgreSQL)" to "E2E (SQLite)" for clarity
+- Currently harmless but misleading
+
+---
+
+_Pass-CI-NEON-COMPUTE-01 | 2026-01-23_

--- a/docs/AGENT/TASKS/Pass-CI-NEON-COMPUTE-01.md
+++ b/docs/AGENT/TASKS/Pass-CI-NEON-COMPUTE-01.md
@@ -1,0 +1,53 @@
+# Task: Pass-CI-NEON-COMPUTE-01
+
+## What
+Reduce Neon compute burn by moving E2E PostgreSQL tests to GitHub Actions local postgres service.
+
+## Status
+**VERIFIED** - Already implemented. No changes needed.
+
+## Scope
+- Audit CI workflows for Neon usage
+- Move E2E tests from Neon to local postgres service
+- NO business logic changes
+
+## Investigation
+
+### Finding
+
+**Neon is NOT used for CI E2E tests.** Current architecture:
+
+| Workflow | DB Used | Notes |
+|----------|---------|-------|
+| `e2e-postgres.yml` ("E2E PostgreSQL") | SQLite | Uses `.env.ci` with `DATABASE_URL=file:./test.db` |
+| `pg-e2e.yml` (label-gated) | GitHub Actions postgres | Uses service container, label required |
+| `prod-migration.yml` | Neon (prod) | Deploy only, not tests |
+| `staging-migration.yml` | Neon (staging) | Deploy only, not tests |
+
+### Misleading Job Name
+
+The job "E2E (PostgreSQL)" in `e2e-postgres.yml` is **misleading** - it uses SQLite, not PostgreSQL:
+```yaml
+# .env.ci
+DATABASE_URL=file:./test.db
+DIXIS_DATA_SRC=sqlite
+```
+
+### Neon Usage Summary
+
+Neon secrets (`DATABASE_URL_PROD`, `DATABASE_URL_STAGING`) are used ONLY for:
+- Production migrations/deployments
+- Staging migrations/deployments
+
+**NOT for any CI test workflows.**
+
+## Files Changed
+
+None - verification pass only.
+
+## Conclusion
+
+No Neon compute burn from CI E2E tests. The architecture already uses:
+- SQLite for fast PR checks
+- GitHub Actions postgres service for label-gated PG-specific tests
+- Neon only for actual deployments

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,33 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-23 (Order Totals Verification)
+**Last Updated**: 2026-01-23 (CI Neon Compute Audit)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~600 lines (target ≤250).
+
+---
+
+## 2026-01-23 — Pass CI-NEON-COMPUTE-01: Neon Compute Audit
+
+**Status**: ✅ VERIFIED — Already Optimized (No changes needed)
+
+Audit of CI workflows for Neon usage.
+
+### Finding
+
+**Neon is NOT used for CI E2E tests.** Current architecture:
+- `e2e-postgres.yml` → SQLite (`.env.ci`)
+- `pg-e2e.yml` → GitHub Actions postgres service (label-gated)
+- Neon only for production/staging **deployments**
+
+### Misleading Name
+
+The job "E2E (PostgreSQL)" is misleading - it uses SQLite, not PostgreSQL.
+
+### Evidence
+- `grep` of all workflows shows no Neon secrets in test jobs
+- `.env.ci` has `DATABASE_URL=file:./test.db`
+- Docs: `docs/AGENT/SUMMARY/Pass-CI-NEON-COMPUTE-01.md`
 
 ---
 


### PR DESCRIPTION
## Summary

Audit pass for Neon compute burn from CI.

**Finding: Neon is NOT used for CI E2E tests.**

| Workflow | DB Used | Neon? |
|----------|---------|-------|
| `e2e-postgres.yml` | SQLite | ❌ |
| `pg-e2e.yml` | GitHub Actions postgres | ❌ |
| `e2e-full.yml` | SQLite | ❌ |
| `prod-migration.yml` | Neon (prod) | ✅ (deploy only) |
| `staging-migration.yml` | Neon (staging) | ✅ (deploy only) |

## Misleading Job Name

The job "E2E (PostgreSQL)" is misleading - it actually uses SQLite:
```env
# .env.ci
DATABASE_URL=file:./test.db
DIXIS_DATA_SRC=sqlite
```

## Changes

- Docs only (verification pass)
- No workflow changes needed

## Test plan

- [x] Docs compile
- [ ] CI passes

---
_Generated by Claude | Pass CI-NEON-COMPUTE-01 | 2026-01-23_