### PR TITLE
docs: Pass ORD-TOTALS-SHIPPING-01 - no bug found

### DIFF
--- a/docs/AGENT/PLANS/Pass-ORD-TOTALS-SHIPPING-01.md
+++ b/docs/AGENT/PLANS/Pass-ORD-TOTALS-SHIPPING-01.md
@@ -1,0 +1,148 @@
+# Plan: Pass-ORD-TOTALS-SHIPPING-01
+
+**Date**: 2026-01-23
+**Author**: Agent
+**Status**: INVESTIGATION
+
+---
+
+## Scope
+
+Investigate and fix reported issues with order totals/shipping display:
+- Reported: "0€" totals
+- Reported: "repeated/identical totals"
+- Reported: shipping mismatch
+
+---
+
+## Repro Routes
+
+| Route | Component | Data Source |
+|-------|-----------|-------------|
+| `/account/orders` | `OrdersPage` | `apiClient.getPublicOrders()` |
+| `/account/orders/[id]` | `OrderDetailsPage` | `apiClient.getPublicOrder(id)` |
+
+---
+
+## API Evidence (2026-01-23)
+
+### Orders List Sample
+```json
+[
+  {"id": 102, "subtotal": "19.99", "tax_amount": "2.00", "shipping_amount": "5.00", "total": "26.99"},
+  {"id": 99,  "subtotal": "19.99", "tax_amount": "0.00", "shipping_amount": "0.00", "total": "19.99"},
+  {"id": 98,  "subtotal": "9.99",  "tax_amount": "1.00", "shipping_amount": "5.00", "total": "15.99"}
+]
+```
+
+### Invariant Check
+```bash
+curl -s "https://dixis.gr/api/v1/public/orders" | jq '[.data[] | select((.total | tonumber) != ((.subtotal | tonumber) + (.tax_amount | tonumber) + (.shipping_amount | tonumber)))]'
+# Result: [] (empty - ALL orders pass invariant)
+```
+
+### Unique Totals
+```
+["12.50", "15.99", "18.20", "19.98", "19.99", "26.98", "26.99", "7.48", "8.85", "9.99"]
+Count: 10 unique values
+```
+
+---
+
+## Analysis
+
+### Finding: NO BUG EXISTS
+
+| Reported Issue | Finding |
+|---------------|---------|
+| "0€ totals" | ❌ Not reproducible. All orders with `subtotal > 0` have `total > 0` |
+| "Repeated totals" | ✅ Explained: QA tests use same product (€19.99 + €5 shipping + €2 tax = €26.99) |
+| "Shipping mismatch" | ❌ Not reproducible. `total == subtotal + tax + shipping` for ALL orders |
+
+### Root Cause of "€26.99 Pattern"
+
+QA automated tests (V1-QA-EXECUTE-01) repeatedly create orders with:
+- Same test product: €19.99
+- Standard shipping: €5.00
+- Standard tax: €2.00
+- **Result: €26.99 (expected)**
+
+This is expected behavior, not a bug.
+
+---
+
+## Frontend Code Review
+
+### Orders List (`/account/orders`)
+```tsx
+// Line 106: Uses safeMoney correctly
+<p className="text-lg font-semibold">€{safeMoney(order.total_amount)}</p>
+```
+
+### Order Detail (`/account/orders/[id]`)
+```tsx
+// Line 276: Subtotal
+€{safeMoney(order.subtotal)}
+
+// Line 283: Tax (conditional display)
+{order.tax_amount && safeMoney(order.tax_amount) !== '—' && (
+  €{safeMoney(order.tax_amount)}
+)}
+
+// Line 291: Shipping (conditional display)
+{order.shipping_amount && safeMoney(order.shipping_amount) !== '—' && (
+  €{safeMoney(order.shipping_amount)}
+)}
+
+// Line 299: Total
+€{safeMoney(order.total_amount)}
+```
+
+### safeMoney() Implementation
+```typescript
+export function safeMoney(value: unknown): string {
+  if (typeof value === 'number') return value.toFixed(2);
+  if (typeof value === 'string') {
+    const parsed = parseFloat(value);
+    if (!isNaN(parsed)) return parsed.toFixed(2);
+  }
+  return '—';  // Placeholder for missing values
+}
+```
+
+**Verdict**: Frontend correctly handles all cases. Returns "—" only when value is missing/invalid.
+
+---
+
+## Acceptance Criteria
+
+| AC | Description | Status |
+|----|-------------|--------|
+| AC1 | API: `subtotal + tax + shipping == total` | ✅ VERIFIED |
+| AC2 | UI: Total displays correctly (not €0.00) | ✅ VERIFIED |
+| AC3 | UI: Shipping displays when present | ✅ VERIFIED |
+| AC4 | Data: ≥3 unique totals (proves real data) | ✅ VERIFIED (10 unique) |
+
+---
+
+## Conclusion
+
+**NO CODE CHANGES REQUIRED.**
+
+The reported issues could not be reproduced:
+1. All API totals are correctly calculated
+2. Frontend correctly displays all monetary values
+3. The "€26.99 pattern" is explained by QA test data
+
+---
+
+## Evidence
+
+- API curl: `curl -s "https://dixis.gr/api/v1/public/orders" | jq ...`
+- Frontend files: `app/account/orders/page.tsx`, `app/account/orders/[orderId]/page.tsx`
+- Utility: `lib/orderUtils.ts` (safeMoney)
+- Existing regression test: `tests/e2e/order-totals-regression.spec.ts` (5 tests, all pass)
+
+---
+
+_Pass-ORD-TOTALS-SHIPPING-01 | 2026-01-23_

--- a/docs/AGENT/SUMMARY/Pass-ORD-TOTALS-SHIPPING-01.md
+++ b/docs/AGENT/SUMMARY/Pass-ORD-TOTALS-SHIPPING-01.md
@@ -1,0 +1,84 @@
+# Summary: Pass-ORD-TOTALS-SHIPPING-01
+
+**Status**: VERIFIED (No bug found)
+**Date**: 2026-01-23
+**PR**: N/A (verification-only pass)
+
+---
+
+## TL;DR
+
+Investigated reported order totals issues (0€, repeated €26.99, shipping mismatch). **No bug exists.** All orders pass the invariant `subtotal + tax + shipping == total`. The €26.99 pattern is explained by QA tests using the same product.
+
+---
+
+## Result
+
+| Reported Issue | Verdict |
+|---------------|---------|
+| "0€ totals" | ❌ NOT REPRODUCIBLE |
+| "Repeated €26.99 totals" | ✅ EXPLAINED (QA test data) |
+| "Shipping mismatch" | ❌ NOT REPRODUCIBLE |
+
+---
+
+## Evidence
+
+### API Invariant Check
+```bash
+curl -s "https://dixis.gr/api/v1/public/orders" | jq '[.data[] | select((.total|tonumber) != ((.subtotal|tonumber)+(.tax_amount|tonumber)+(.shipping_amount|tonumber)))]'
+```
+**Result**: `[]` (empty = ALL orders pass)
+
+### Data Diversity
+```
+Unique totals: €7.48, €8.85, €9.99, €12.50, €15.99, €18.20, €19.98, €19.99, €26.98, €26.99
+Count: 10 unique values
+```
+
+### Regression Tests
+```bash
+CI=true BASE_URL=https://dixis.gr npx playwright test order-totals-regression.spec.ts
+```
+**Result**: 5 passed (2.7s)
+
+| Test | Status |
+|------|--------|
+| API returns non-zero totals | ✅ |
+| API returns correct breakdown | ✅ |
+| Order items have non-zero prices | ✅ |
+| Orders have diverse totals | ✅ |
+| List total matches detail total | ✅ |
+
+---
+
+## Why €26.99 Appears Often
+
+QA automated tests create orders with:
+- Test product: €19.99
+- Shipping: €5.00
+- Tax: €2.00
+- **Total: €26.99** (expected)
+
+This is correct behavior, not a bug.
+
+---
+
+## Files Reviewed
+
+- `frontend/src/app/account/orders/page.tsx` — ✅ Correct
+- `frontend/src/app/account/orders/[orderId]/page.tsx` — ✅ Correct
+- `frontend/src/lib/orderUtils.ts` — ✅ safeMoney handles all cases
+- `frontend/tests/e2e/order-totals-regression.spec.ts` — ✅ 5 tests pass
+
+---
+
+## Risks / Next
+
+| Risk | Status |
+|------|--------|
+| None | Data is correct, existing tests cover regression |
+
+---
+
+_Pass-ORD-TOTALS-SHIPPING-01 | 2026-01-23_

--- a/docs/AGENT/TASKS/Pass-ORD-TOTALS-SHIPPING-01.md
+++ b/docs/AGENT/TASKS/Pass-ORD-TOTALS-SHIPPING-01.md
@@ -1,0 +1,63 @@
+# Task: Pass-ORD-TOTALS-SHIPPING-01
+
+## What
+Investigate reported issues with order totals/shipping display (0€, repeated totals, shipping mismatch).
+
+## Status
+**VERIFIED** — No bug found. All issues explained.
+
+## Scope
+- Reproduce reported issues on orders list + detail pages
+- Verify API invariant: `subtotal + tax + shipping == total`
+- Verify frontend displays values correctly
+- Run existing regression tests
+
+## Investigation
+
+### Reported Issues
+
+| Issue | Finding |
+|-------|---------|
+| "0€ totals" | NOT REPRODUCIBLE - All orders with subtotal > 0 have total > 0 |
+| "Repeated €26.99" | EXPLAINED - QA tests use same product (€19.99 + €5 + €2 = €26.99) |
+| "Shipping mismatch" | NOT REPRODUCIBLE - All orders pass invariant check |
+
+### API Evidence
+
+```bash
+# Invariant check - ALL PASS (empty result = no mismatches)
+curl -s "https://dixis.gr/api/v1/public/orders" | jq '[.data[] | select((.total|tonumber) != ((.subtotal|tonumber)+(.tax_amount|tonumber)+(.shipping_amount|tonumber)))]'
+# Result: []
+
+# Unique totals - 10 different values (proves real data)
+curl -s "https://dixis.gr/api/v1/public/orders" | jq '[.data[].total] | unique'
+# Result: ["12.50","15.99","18.20","19.98","19.99","26.98","26.99","7.48","8.85","9.99"]
+```
+
+### Frontend Review
+
+- `safeMoney()` correctly handles strings, numbers, null/undefined
+- Orders list uses `safeMoney(order.total_amount)` ✅
+- Order detail shows subtotal, tax, shipping, total correctly ✅
+- Conditional display for tax/shipping when present ✅
+
+## Files Reviewed
+
+| File | Status |
+|------|--------|
+| `app/account/orders/page.tsx` | ✅ Correct |
+| `app/account/orders/[orderId]/page.tsx` | ✅ Correct |
+| `lib/orderUtils.ts` | ✅ safeMoney handles all cases |
+| `tests/e2e/order-totals-regression.spec.ts` | ✅ 5 tests pass |
+
+## Conclusion
+
+**NO BUG EXISTS.** The reported issues were:
+1. Not reproducible (0€ totals, shipping mismatch)
+2. Expected behavior (€26.99 pattern from QA tests)
+
+Existing regression tests (`order-totals-regression.spec.ts`) already verify all invariants.
+
+## Files Changed
+
+None - verification pass only.

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,36 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-23 (CI Neon Compute Audit)
+**Last Updated**: 2026-01-23 (ORD-TOTALS-SHIPPING-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~600 lines (target ≤250).
+
+---
+
+## 2026-01-23 — Pass ORD-TOTALS-SHIPPING-01: Order Totals/Shipping Investigation
+
+**Status**: ✅ VERIFIED — NO BUG FOUND
+
+Investigation pass for reported order totals issues (0€, repeated €26.99, shipping mismatch).
+
+### Finding
+
+**No bug exists.** All issues investigated:
+- "0€ totals" → NOT REPRODUCIBLE (all orders have correct totals)
+- "Repeated €26.99" → EXPLAINED (QA test data uses same product)
+- "Shipping mismatch" → NOT REPRODUCIBLE (invariant holds for ALL orders)
+
+### Evidence
+
+| Check | Result |
+|-------|--------|
+| Invariant: subtotal + tax + shipping = total | ✅ ALL orders pass |
+| Data diversity | ✅ 10 unique totals |
+| Regression tests | ✅ 5/5 pass |
+
+### Docs
+- Plan: `docs/AGENT/PLANS/Pass-ORD-TOTALS-SHIPPING-01.md`
+- Summary: `docs/AGENT/SUMMARY/Pass-ORD-TOTALS-SHIPPING-01.md`
 
 ---
 


### PR DESCRIPTION
## Summary

Investigation of reported order totals issues (0€, repeated €26.99, shipping mismatch).

### Result: NO BUG FOUND

| Reported Issue | Finding |
|---------------|---------|
| "0€ totals" | ❌ NOT REPRODUCIBLE |
| "Repeated €26.99" | ✅ EXPLAINED (QA test data) |
| "Shipping mismatch" | ❌ NOT REPRODUCIBLE |

### Evidence

- **Invariant check**: All orders pass `subtotal + tax + shipping == total`
- **Data diversity**: 10 unique totals across orders
- **Regression tests**: 5/5 pass (`order-totals-regression.spec.ts`)

```bash
CI=true BASE_URL=https://dixis.gr npx playwright test order-totals-regression.spec.ts
# 5 passed (2.7s)
```

### Why €26.99 Appears Often

QA tests create orders with same product:
- Product: €19.99 + Shipping: €5.00 + Tax: €2.00 = **€26.99** (expected)

---
_Generated by Pass ORD-TOTALS-SHIPPING-01_