### PR TITLE
fix: Pass producerId to cart for multi-producer detection

### DIFF
--- a/frontend/src/app/(storefront)/products/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/page.tsx
@@ -35,7 +35,10 @@ async function getProductById(id: string) {
       isActive: raw.is_active !== false,
       category: raw.category,
       imageUrl: raw.image_url,
-      producer: raw.producer ? { name: raw.producer.name } : null
+      producer: raw.producer ? { name: raw.producer.name } : null,
+      // Pass HOTFIX-MP-CHECKOUT-GUARD-01: Include producer_id for multi-producer cart detection
+      producerId: raw.producer_id || raw.producer?.id || null,
+      producerName: raw.producer?.name || null
     };
   } catch {
     return null;

--- a/frontend/src/app/(storefront)/products/[id]/ui/Add.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/ui/Add.tsx
@@ -3,7 +3,8 @@ import { useCart } from '@/lib/cart';
 import { useState } from 'react';
 
 interface AddProps {
-  product: { id: string; title: string; price: number };
+  // Pass HOTFIX-MP-CHECKOUT-GUARD-01: Include producerId for multi-producer cart detection
+  product: { id: string; title: string; price: number; producerId?: string | number | null; producerName?: string | null };
   translations: {
     addToCart: string;
     cartAdded: string;
@@ -21,10 +22,13 @@ export default function Add({ product, translations }: AddProps) {
     // Convert price to cents for consistency with products list
     const priceCents = Math.round(Number(product.price || 0) * 100);
 
+    // Pass HOTFIX-MP-CHECKOUT-GUARD-01: Include producerId for multi-producer cart detection
     add({
       id: String(product.id),
       title: product.title,
       priceCents: priceCents,
+      producerId: product.producerId ? String(product.producerId) : undefined,
+      producerName: product.producerName || undefined,
     });
 
     setAdded(true);


### PR DESCRIPTION
## Summary

HOTFIX follow-up for HOTFIX-MP-CHECKOUT-GUARD-01 (#2448).

The multi-producer checkout guard depends on `producerId` being present in cart items, but the product detail page was NOT passing `producer_id` to the cart when users clicked "Add to Cart".

**Impact**: Without this fix, `isMultiProducerCart()` always returns `false` because cart items never have `producerId` set, making the frontend checkout guard completely ineffective.

## Changes

- `frontend/src/app/(storefront)/products/[id]/page.tsx` - Map `producer_id` and `producer.name` from API response
- `frontend/src/app/(storefront)/products/[id]/ui/Add.tsx` - Pass `producerId` to cart `add()` function

## Evidence

Before fix: Cart items have no `producerId` → `isMultiProducerCart()` = `false` → checkout not blocked
After fix: Cart items have `producerId` → `isMultiProducerCart()` = `true` for multi-producer carts → checkout blocked

## Test Plan

- [ ] Add products from 2 different producers to cart via product detail page
- [ ] Navigate to /checkout
- [ ] Verify blocking message appears: "Πολλαπλοί Παραγωγοί στο Καλάθι"
- [ ] Verify E2E test MPBLOCK1 passes with new blocking UI

---

**Generated-by**: Claude | Pass HOTFIX-MP-CHECKOUT-GUARD-01 follow-up