### PR TITLE
docs: Update HOTFIX-MP-CHECKOUT-GUARD-01 verification

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-HOTFIX-MP-CHECKOUT-GUARD-01.md
+++ b/docs/AGENT/SUMMARY/Pass-HOTFIX-MP-CHECKOUT-GUARD-01.md
@@ -72,6 +72,28 @@ When cart has items from multiple producers, checkout page shows:
 
 ---
 
+## Follow-up PR #2449
+
+**Bug Found**: Product detail page was NOT passing `producerId` to cart, making `isMultiProducerCart()` always return `false`.
+
+**Fix**:
+- `frontend/src/app/(storefront)/products/[id]/page.tsx` - Map `producer_id` from API
+- `frontend/src/app/(storefront)/products/[id]/ui/Add.tsx` - Pass `producerId` to cart
+
+---
+
+## Production Verification (2026-01-24)
+
+| Test | Result |
+|------|--------|
+| MPBLOCK1: Multi-producer blocked | ✅ Greek message shown |
+| MPBLOCK2: No API calls | ✅ No order/payment requests |
+| MPBLOCK3: Single-producer works | ✅ Checkout form shown |
+
+**Deployed commits**: Frontend `70dbe384`, Backend `bc65e630`
+
+---
+
 ## Next Steps
 
 This hotfix is temporary. Full solution requires:
@@ -81,4 +103,4 @@ This hotfix is temporary. Full solution requires:
 
 ---
 
-_Pass-HOTFIX-MP-CHECKOUT-GUARD-01 | 2026-01-24_
+_Pass-HOTFIX-MP-CHECKOUT-GUARD-01 | 2026-01-24 | PRs #2448, #2449_

--- a/docs/AGENT/TASKS/Pass-HOTFIX-MP-CHECKOUT-GUARD-01.md
+++ b/docs/AGENT/TASKS/Pass-HOTFIX-MP-CHECKOUT-GUARD-01.md
@@ -106,4 +106,30 @@ $emailService->sendOrderPlacedNotifications($order->fresh());
 
 ---
 
-_Pass-HOTFIX-MP-CHECKOUT-GUARD-01 | 2026-01-24_
+## Follow-up: PR #2449 (producerId Fix)
+
+**Bug Found**: Product detail page was NOT passing `producerId` to cart.
+
+| Task | Status |
+|------|--------|
+| Map `producer_id` in product detail page | ✅ |
+| Pass `producerId` to cart `add()` | ✅ |
+| TypeScript + build verification | ✅ |
+| Production deployment | ✅ |
+| Production E2E verification | ✅ 3/3 pass |
+
+---
+
+## Production Verification (2026-01-24)
+
+```
+Running 3 tests using 1 worker
+✅ MPBLOCK1: Multi-producer cart correctly blocked at checkout (new UI)
+✅ MPBLOCK2: No API calls made for multi-producer checkout
+✅ MPBLOCK3: Single-producer checkout works correctly
+3 passed (18.7s)
+```
+
+---
+
+_Pass-HOTFIX-MP-CHECKOUT-GUARD-01 | 2026-01-24 | PRs #2448, #2449_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,15 +1,15 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-24 (HOTFIX-MP-CHECKOUT-GUARD-01)
+**Last Updated**: 2026-01-24 (HOTFIX-MP-CHECKOUT-GUARD-01 + producerId fix)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~265 lines (target ≤250). ⚠️
+> **Current size**: ~280 lines (target ≤250). ⚠️
 
 ---
 
 ## 2026-01-24 — Pass HOTFIX-MP-CHECKOUT-GUARD-01: Block Multi-Producer Checkout
 
-**Status**: 🔄 PENDING — PR #2448 (auto-merge enabled)
+**Status**: ✅ PASS — MERGED (PR #2448, #2449) — **PROD VERIFIED**
 
 HOTFIX to prevent broken multi-producer checkout until order splitting is implemented.
 
@@ -22,6 +22,14 @@ HOTFIX to prevent broken multi-producer checkout until order splitting is implem
 - Frontend: Block checkout with Greek message when ≥2 producers
 - Backend: Server guard returns 422 `MULTI_PRODUCER_NOT_SUPPORTED_YET`
 - Email: Only send for COD at creation, for CARD after payment confirmation
+
+**Follow-up PR #2449**: Fixed `producerId` not being passed to cart from product detail page.
+
+**Production Proof** (2026-01-24):
+- ✅ MPBLOCK1: Multi-producer cart blocked with Greek message
+- ✅ MPBLOCK2: No API calls made for blocked checkout
+- ✅ MPBLOCK3: Single-producer checkout still works
+- ✅ Deployed: Frontend `70dbe384`, Backend `bc65e630`
 
 **Evidence**: Summary: `Pass-HOTFIX-MP-CHECKOUT-GUARD-01.md`
 


### PR DESCRIPTION
## Summary

Documentation update for Pass HOTFIX-MP-CHECKOUT-GUARD-01 production verification.

## Changes

- STATE.md: Mark hotfix as PROD VERIFIED
- SUMMARY: Add follow-up PR #2449 details + production proof
- TASKS: Add production E2E test results

## Evidence

Production E2E tests (2026-01-24):
- ✅ MPBLOCK1: Multi-producer cart correctly blocked at checkout
- ✅ MPBLOCK2: No API calls made for multi-producer checkout  
- ✅ MPBLOCK3: Single-producer checkout works correctly

---

**Generated-by**: Claude | Pass HOTFIX-MP-CHECKOUT-GUARD-01 verification