### PR TITLE
feat: Add order_shipping_lines table for multi-producer shipping

### DIFF
--- a/backend/app/Models/Order.php
+++ b/backend/app/Models/Order.php
@@ -72,6 +72,15 @@ class Order extends Model
     }
 
     /**
+     * Get the shipping lines for multi-producer orders.
+     * Pass MP-ORDERS-SHIPPING-V1: Per-producer shipping breakdown.
+     */
+    public function shippingLines()
+    {
+        return $this->hasMany(OrderShippingLine::class);
+    }
+
+    /**
      * Scope orders to include only those with items from a specific producer.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query

--- a/backend/app/Models/OrderShippingLine.php
+++ b/backend/app/Models/OrderShippingLine.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Pass MP-ORDERS-SHIPPING-V1: Per-producer shipping breakdown
+ *
+ * Stores shipping cost calculated per producer for multi-producer orders.
+ * Each order can have multiple shipping lines (one per producer).
+ *
+ * @property int $id
+ * @property int $order_id
+ * @property int $producer_id
+ * @property string $producer_name
+ * @property float $subtotal
+ * @property float $shipping_cost
+ * @property string|null $shipping_method
+ * @property bool $free_shipping_applied
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class OrderShippingLine extends Model
+{
+    protected $fillable = [
+        'order_id',
+        'producer_id',
+        'producer_name',
+        'subtotal',
+        'shipping_cost',
+        'shipping_method',
+        'free_shipping_applied',
+    ];
+
+    protected $casts = [
+        'subtotal' => 'decimal:2',
+        'shipping_cost' => 'decimal:2',
+        'free_shipping_applied' => 'boolean',
+    ];
+
+    /**
+     * Get the order this shipping line belongs to.
+     */
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    /**
+     * Get the producer for this shipping line.
+     */
+    public function producer(): BelongsTo
+    {
+        return $this->belongsTo(Producer::class);
+    }
+}

--- a/backend/database/migrations/2026_01_24_130000_create_order_shipping_lines_table.php
+++ b/backend/database/migrations/2026_01_24_130000_create_order_shipping_lines_table.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Pass MP-ORDERS-SHIPPING-V1: Create order_shipping_lines table
+ *
+ * Stores per-producer shipping breakdown for multi-producer orders.
+ * This is an ADDITIVE migration - no changes to existing tables.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('order_shipping_lines', function (Blueprint $table) {
+            $table->id();
+
+            // FK to orders - RESTRICT on delete to preserve order history
+            $table->unsignedBigInteger('order_id');
+            $table->foreign('order_id')
+                ->references('id')
+                ->on('orders')
+                ->onDelete('restrict');
+
+            // Producer info - store ID and name for history preservation
+            // FK to producers - SET NULL on delete (producer might be deactivated)
+            $table->unsignedBigInteger('producer_id');
+            $table->foreign('producer_id')
+                ->references('id')
+                ->on('producers')
+                ->onDelete('restrict');
+            $table->string('producer_name', 255);
+
+            // Shipping calculation fields
+            $table->decimal('subtotal', 10, 2)->comment('Sum of order items from this producer');
+            $table->decimal('shipping_cost', 10, 2)->comment('Calculated shipping for this producer');
+            $table->string('shipping_method', 50)->nullable()->comment('HOME, COURIER, etc.');
+            $table->boolean('free_shipping_applied')->default(false)->comment('True if subtotal >= threshold');
+
+            $table->timestamps();
+
+            // Indexes for common queries
+            $table->index('order_id');
+            $table->index('producer_id');
+            $table->index('created_at');
+
+            // Composite index for order detail lookups
+            $table->index(['order_id', 'producer_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('order_shipping_lines');
+    }
+};

--- a/backend/tests/Unit/OrderShippingLineTest.php
+++ b/backend/tests/Unit/OrderShippingLineTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Order;
+use App\Models\OrderShippingLine;
+use App\Models\Producer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * Pass MP-ORDERS-SHIPPING-V1: Schema smoke tests for order_shipping_lines
+ */
+class OrderShippingLineTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Verify the order_shipping_lines table exists after migration.
+     */
+    public function test_order_shipping_lines_table_exists(): void
+    {
+        $this->assertTrue(
+            Schema::hasTable('order_shipping_lines'),
+            'Table order_shipping_lines should exist after migration'
+        );
+    }
+
+    /**
+     * Verify the table has all required columns.
+     */
+    public function test_order_shipping_lines_has_required_columns(): void
+    {
+        $expectedColumns = [
+            'id',
+            'order_id',
+            'producer_id',
+            'producer_name',
+            'subtotal',
+            'shipping_cost',
+            'shipping_method',
+            'free_shipping_applied',
+            'created_at',
+            'updated_at',
+        ];
+
+        foreach ($expectedColumns as $column) {
+            $this->assertTrue(
+                Schema::hasColumn('order_shipping_lines', $column),
+                "Column '{$column}' should exist in order_shipping_lines table"
+            );
+        }
+    }
+
+    /**
+     * Verify OrderShippingLine model can be created.
+     */
+    public function test_can_create_order_shipping_line(): void
+    {
+        // Create required related records
+        $user = User::factory()->consumer()->create();
+        $producer = Producer::factory()->create(['name' => 'Test Producer']);
+
+        $order = Order::create([
+            'user_id' => $user->id,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'subtotal' => 50.00,
+            'shipping_cost' => 5.00,
+            'total' => 55.00,
+            'currency' => 'EUR',
+        ]);
+
+        $shippingLine = OrderShippingLine::create([
+            'order_id' => $order->id,
+            'producer_id' => $producer->id,
+            'producer_name' => $producer->name,
+            'subtotal' => 50.00,
+            'shipping_cost' => 5.00,
+            'shipping_method' => 'HOME',
+            'free_shipping_applied' => false,
+        ]);
+
+        $this->assertDatabaseHas('order_shipping_lines', [
+            'id' => $shippingLine->id,
+            'order_id' => $order->id,
+            'producer_id' => $producer->id,
+            'producer_name' => 'Test Producer',
+            'subtotal' => 50.00,
+            'shipping_cost' => 5.00,
+            'free_shipping_applied' => false,
+        ]);
+    }
+
+    /**
+     * Verify Order->shippingLines relationship works.
+     */
+    public function test_order_has_shipping_lines_relationship(): void
+    {
+        $user = User::factory()->consumer()->create();
+        $producer1 = Producer::factory()->create(['name' => 'Producer A']);
+        $producer2 = Producer::factory()->create(['name' => 'Producer B']);
+
+        $order = Order::create([
+            'user_id' => $user->id,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'subtotal' => 80.00,
+            'shipping_cost' => 8.00,
+            'total' => 88.00,
+            'currency' => 'EUR',
+        ]);
+
+        // Create two shipping lines for multi-producer order
+        OrderShippingLine::create([
+            'order_id' => $order->id,
+            'producer_id' => $producer1->id,
+            'producer_name' => $producer1->name,
+            'subtotal' => 50.00,
+            'shipping_cost' => 0.00,
+            'shipping_method' => 'HOME',
+            'free_shipping_applied' => true,
+        ]);
+
+        OrderShippingLine::create([
+            'order_id' => $order->id,
+            'producer_id' => $producer2->id,
+            'producer_name' => $producer2->name,
+            'subtotal' => 30.00,
+            'shipping_cost' => 8.00,
+            'shipping_method' => 'HOME',
+            'free_shipping_applied' => false,
+        ]);
+
+        // Refresh and check relationship
+        $order->refresh();
+        $this->assertCount(2, $order->shippingLines);
+        $this->assertEquals('Producer A', $order->shippingLines->first()->producer_name);
+    }
+}

--- a/docs/AGENT/PLANS/Pass-MP-ORDERS-SHIPPING-V1.md
+++ b/docs/AGENT/PLANS/Pass-MP-ORDERS-SHIPPING-V1.md
@@ -1,0 +1,316 @@
+# PLAN: Pass-MP-ORDERS-SHIPPING-V1
+
+**Date**: 2026-01-24
+**Status**: DRAFT — Awaiting Approval
+**Scope**: Enable multi-producer checkout with per-producer shipping (V1)
+**Supersedes**: HOTFIX-MP-CHECKOUT-GUARD-01 (temporary block)
+
+---
+
+## Goal
+
+Remove the temporary checkout block and enable real multi-producer checkout:
+1. Split checkout into per-producer suborders
+2. Calculate shipping per producer
+3. Single payment for entire order group
+4. Clear customer UX showing per-producer breakdown
+
+## Non-Goals
+
+- Producer dashboard changes (V2)
+- Advanced shipping carriers/rates (use existing zones)
+- Split payments (single payment covers all suborders)
+- International shipping
+- Weight-based pricing refinements
+- Time slot delivery
+
+---
+
+## Current State (Post-HOTFIX)
+
+| Component | Status |
+|-----------|--------|
+| Multi-producer cart | ✅ Enabled (items from N producers) |
+| Checkout UI | ❌ Blocked with Greek message |
+| Backend API | ❌ Returns 422 for N>1 producers |
+| Shipping calc | Single flat rate (not per-producer) |
+| Email timing | ✅ COD at creation, CARD after payment |
+
+---
+
+## Proposed Data Model (Minimal)
+
+### Option: Order Shipping Lines (Simpler V1)
+
+Keep existing `orders` table, add shipping breakdown:
+
+```sql
+-- New table
+CREATE TABLE order_shipping_lines (
+  id SERIAL PRIMARY KEY,
+  order_id INTEGER REFERENCES orders(id) ON DELETE CASCADE,
+  producer_id INTEGER NOT NULL,
+  producer_name VARCHAR(255),
+  subtotal DECIMAL(10,2) NOT NULL,
+  shipping_cost DECIMAL(10,2) NOT NULL,
+  shipping_method VARCHAR(50),
+  free_shipping_applied BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Index for lookups
+CREATE INDEX idx_osl_order_id ON order_shipping_lines(order_id);
+CREATE INDEX idx_osl_producer_id ON order_shipping_lines(producer_id);
+```
+
+**Why not Order Groups?**
+- V1 simplicity: Single order, single payment, single confirmation
+- Existing admin/producer dashboards work with filter by `order_items.producer_id`
+- Order Groups can be added in V2 if needed for fulfillment tracking
+
+---
+
+## API Changes
+
+### 1. Order Creation (`POST /api/v1/orders`)
+
+**Before (current)**: Rejects multi-producer with 422
+
+**After**:
+```json
+{
+  "items": [...],
+  "shipping_method": "HOME",
+  "shipping_address": {...},
+  "currency": "EUR"
+}
+
+// Response includes shipping breakdown
+{
+  "order": {
+    "id": 123,
+    "subtotal": 45.00,
+    "shipping_cost": 8.50,  // Sum of all producer shipping
+    "total": 53.50,
+    "shipping_lines": [
+      { "producer_id": 1, "producer_name": "Παπαδόπουλος", "subtotal": 27.00, "shipping_cost": 3.50 },
+      { "producer_id": 4, "producer_name": "Δημητρίου", "subtotal": 18.00, "shipping_cost": 5.00 }
+    ]
+  }
+}
+```
+
+### 2. Shipping Quote (`POST /api/v1/shipping/quote`)
+
+**New optional param**: `per_producer: true`
+
+```json
+{
+  "postal_code": "10552",
+  "items": [
+    { "product_id": 1, "quantity": 2, "producer_id": 1 },
+    { "product_id": 6, "quantity": 1, "producer_id": 4 }
+  ],
+  "per_producer": true
+}
+
+// Response
+{
+  "total_shipping": 8.50,
+  "producers": [
+    { "producer_id": 1, "subtotal": 27.00, "shipping": 3.50, "free": false },
+    { "producer_id": 4, "subtotal": 18.00, "shipping": 5.00, "free": false }
+  ]
+}
+```
+
+---
+
+## Payment Flow
+
+**Single payment for entire order** (no split payments):
+
+1. Customer completes checkout form
+2. Order created with all items, shipping_lines populated
+3. Payment initialized for `order.total` (products + all shipping)
+4. On payment success:
+   - Order status → `processing`
+   - Email sent to customer (single receipt)
+   - Separate email to each producer (their items only)
+
+---
+
+## Email Timing Rules
+
+| Payment Method | Customer Email | Producer Email(s) |
+|----------------|----------------|-------------------|
+| COD | On order creation | On order creation |
+| CARD | After payment confirmed | After payment confirmed |
+
+**Customer email**: Single receipt with all items grouped by producer
+**Producer email**: Only their items + their shipping portion
+
+---
+
+## Shipping Calculation V1 (Simple)
+
+### Rules
+
+1. **Group cart items by producer_id**
+2. **Per producer**:
+   - Calculate subtotal
+   - Look up shipping rate by customer postal zone
+   - If subtotal ≥ €35 → free shipping
+   - Store in `order_shipping_lines`
+3. **Total shipping** = sum of all producer shipping costs
+
+### Zone Lookup (Existing)
+
+Uses existing `shipping_zones` + `shipping_rates` tables:
+- Extract 2-digit prefix from postal code
+- Look up zone → get rate by method
+
+### Fallback (Existing)
+
+If zone not found: €3.50 (HOME), €4.50 (COURIER), €0 (PICKUP)
+
+### Future Validation
+
+Later pass: Compare calculated shipping vs real courier quotes (ACS, ELTA, Courier Center) to calibrate rates.
+
+---
+
+## Checkout UX Changes
+
+### Cart Page (Existing)
+
+No change needed - cart already shows items.
+
+### Checkout Page
+
+Remove blocking message, show grouped breakdown:
+
+```
+┌─────────────────────────────────────────┐
+│ Σύνοψη Παραγγελίας                      │
+├─────────────────────────────────────────┤
+│ Αγρόκτημα Παπαδόπουλος                  │
+│   Ελαιόλαδο Εξαιρετικό Παρθένο  €15.00 │
+│   Μέλι Θυμαρίσιο                 €12.00 │
+│   Υποσύνολο:                     €27.00 │
+│   Μεταφορικά:                     €3.50 │
+├─────────────────────────────────────────┤
+│ Οινοποιείο Δημητρίου                    │
+│   Κρασί Αγιωργίτικο             €18.00 │
+│   Υποσύνολο:                     €18.00 │
+│   Μεταφορικά:                     €5.00 │
+├─────────────────────────────────────────┤
+│ ΣΥΝΟΛΟ                           €53.50 │
+│ (Προϊόντα: €45.00 + Μεταφορικά: €8.50) │
+└─────────────────────────────────────────┘
+```
+
+---
+
+## Acceptance Criteria (Testable)
+
+### AC1: Order Creation
+- [ ] Multi-producer cart checkout succeeds (no 422)
+- [ ] Order created with correct total
+- [ ] `order_shipping_lines` populated per producer
+
+### AC2: Shipping Calculation
+- [ ] Each producer's shipping calculated independently
+- [ ] Free shipping applied if producer subtotal ≥ €35
+- [ ] Total shipping = sum of all producer shipping
+
+### AC3: Checkout UX
+- [ ] Items grouped by producer in order summary
+- [ ] Per-producer subtotal + shipping visible
+- [ ] Grand total clearly shown
+
+### AC4: Emails
+- [ ] Customer receives single receipt with breakdown
+- [ ] Each producer receives email with only their items
+- [ ] Emails sent at correct time (COD vs CARD)
+
+### AC5: Backward Compatibility
+- [ ] Single-producer orders work unchanged
+- [ ] Existing orders unaffected
+
+---
+
+## Minimal E2E Tests (3 Critical)
+
+### MPORDER1: Multi-producer checkout success
+```
+Given cart with items from 2 producers
+When user completes checkout (COD)
+Then order is created with correct totals
+And order has 2 shipping_lines
+And confirmation page shows grouped breakdown
+```
+
+### MPORDER2: Per-producer free shipping
+```
+Given cart: Producer A €40, Producer B €20
+When checkout
+Then Producer A shipping = €0 (free)
+And Producer B shipping = €X (charged)
+```
+
+### MPORDER3: Email breakdown
+```
+Given multi-producer order created
+When emails sent
+Then customer email shows all items grouped
+And producer A email shows only their items
+And producer B email shows only their items
+```
+
+---
+
+## Implementation Phases
+
+| Phase | Scope | Est. LOC | PR |
+|-------|-------|----------|-----|
+| 1. Schema | Migration: `order_shipping_lines` | ~60 | #1 |
+| 2. Backend | OrderController + shipping calc | ~200 | #2 |
+| 3. Frontend | Checkout grouped UI | ~180 | #3 |
+| 4. Emails | Per-producer email templates | ~100 | #4 |
+
+**Total**: ~540 LOC across 4 PRs (all ≤300 LOC)
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Migration breaks prod | Run on staging first, add index concurrently |
+| Existing orders affected | Migration only creates new table, no ALTER on orders |
+| Admin dashboard breaks | `shipping_lines` is additive, existing queries work |
+| Shipping total mismatch | Store breakdown + validate sum = total |
+
+---
+
+## Open Questions (Resolve Before Implementation)
+
+1. **PICKUP shipping**: If customer selects PICKUP, do all producers ship to same pickup point, or per-producer pickup?
+   - **Proposal**: V1 = single pickup point (customer picks from closest)
+
+2. **Producer without postal zone**: What if producer location not in shipping_zones?
+   - **Proposal**: Use fallback rates (existing behavior)
+
+3. **Order confirmation page**: New page needed or update existing?
+   - **Proposal**: Update existing `/checkout/success` to show grouped breakdown
+
+---
+
+## Decision Required
+
+**Approve this plan to proceed with Phase 1 (Schema)?**
+
+---
+
+_Pass-MP-ORDERS-SHIPPING-V1 | 2026-01-24_

--- a/docs/AGENT/SUMMARY/Pass-MP-ORDERS-SHIPPING-V1-01.md
+++ b/docs/AGENT/SUMMARY/Pass-MP-ORDERS-SHIPPING-V1-01.md
@@ -1,0 +1,69 @@
+# Summary: Pass-MP-ORDERS-SHIPPING-V1-01 (Schema)
+
+**Date**: 2026-01-24
+**Status**: COMPLETE
+**PR**: Pending
+
+---
+
+## What Changed
+
+Phase 1 of enabling multi-producer checkout: Created `order_shipping_lines` table to store per-producer shipping breakdown.
+
+---
+
+## Why
+
+The hotfix (HOTFIX-MP-CHECKOUT-GUARD-01) blocks multi-producer checkout because shipping is calculated as a single flat rate. To enable real multi-producer checkout, we need to track shipping per producer.
+
+---
+
+## Schema
+
+New table `order_shipping_lines`:
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| order_id | FK → orders | Parent order |
+| producer_id | FK → producers | Producer for this shipping line |
+| producer_name | VARCHAR | Denormalized for history |
+| subtotal | DECIMAL | Sum of items from this producer |
+| shipping_cost | DECIMAL | Calculated shipping for this producer |
+| shipping_method | VARCHAR | HOME, COURIER, etc. |
+| free_shipping_applied | BOOLEAN | True if subtotal >= €35 |
+
+---
+
+## Impact
+
+| Before | After |
+|--------|-------|
+| Single shipping_cost on order | Per-producer shipping_lines |
+| Can't track per-producer shipping | Each producer's shipping stored separately |
+| Checkout blocked for multi-producer | Schema ready for Phase 2 (backend logic) |
+
+---
+
+## Files
+
+| File | LOC |
+|------|-----|
+| Migration | ~60 |
+| Model | ~55 |
+| Order.php (relation) | +8 |
+| Unit tests | ~110 |
+| **Total** | ~233 |
+
+---
+
+## Next Phase
+
+Phase 2 (Backend): Update `OrderController.php` to:
+- Remove checkout block for multi-producer
+- Calculate per-producer shipping
+- Store `order_shipping_lines`
+- Return breakdown in API response
+
+---
+
+_Pass-MP-ORDERS-SHIPPING-V1-01 | 2026-01-24_

--- a/docs/AGENT/TASKS/Pass-MP-ORDERS-SHIPPING-V1-01.md
+++ b/docs/AGENT/TASKS/Pass-MP-ORDERS-SHIPPING-V1-01.md
@@ -1,0 +1,87 @@
+# Tasks: Pass-MP-ORDERS-SHIPPING-V1-01 (Schema)
+
+**Date**: 2026-01-24
+**Status**: COMPLETE
+**PR**: Pending
+
+---
+
+## Goal
+
+Phase 1 of MP-ORDERS-SHIPPING-V1: Create `order_shipping_lines` table for per-producer shipping breakdown.
+
+---
+
+## Tasks Completed
+
+| Task | Status |
+|------|--------|
+| Create migration: `order_shipping_lines` table | ✅ |
+| Add indexes (order_id, producer_id, created_at, composite) | ✅ |
+| Add FK constraints with RESTRICT on delete | ✅ |
+| Create `OrderShippingLine` model | ✅ |
+| Add `shippingLines` relationship to Order model | ✅ |
+| Create unit tests (4 tests) | ✅ |
+| Run tests locally (all pass) | ✅ |
+| Verify no regression in existing tests | ✅ |
+
+---
+
+## Schema Created
+
+```sql
+CREATE TABLE order_shipping_lines (
+  id BIGSERIAL PRIMARY KEY,
+  order_id BIGINT NOT NULL REFERENCES orders(id) ON DELETE RESTRICT,
+  producer_id BIGINT NOT NULL REFERENCES producers(id) ON DELETE RESTRICT,
+  producer_name VARCHAR(255) NOT NULL,
+  subtotal DECIMAL(10,2) NOT NULL,
+  shipping_cost DECIMAL(10,2) NOT NULL,
+  shipping_method VARCHAR(50),
+  free_shipping_applied BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP
+);
+
+-- Indexes
+CREATE INDEX idx_osl_order_id ON order_shipping_lines(order_id);
+CREATE INDEX idx_osl_producer_id ON order_shipping_lines(producer_id);
+CREATE INDEX idx_osl_created_at ON order_shipping_lines(created_at);
+CREATE INDEX idx_osl_order_producer ON order_shipping_lines(order_id, producer_id);
+```
+
+---
+
+## Files Created/Modified
+
+| File | Action |
+|------|--------|
+| `backend/database/migrations/2026_01_24_130000_create_order_shipping_lines_table.php` | Created |
+| `backend/app/Models/OrderShippingLine.php` | Created |
+| `backend/app/Models/Order.php` | Modified (added shippingLines relation) |
+| `backend/tests/Unit/OrderShippingLineTest.php` | Created |
+
+---
+
+## Tests Added
+
+| Test | Purpose |
+|------|---------|
+| `test_order_shipping_lines_table_exists` | Verify table exists after migration |
+| `test_order_shipping_lines_has_required_columns` | Verify all columns present |
+| `test_can_create_order_shipping_line` | Verify model CRUD works |
+| `test_order_has_shipping_lines_relationship` | Verify Order->shippingLines relation |
+
+---
+
+## Decisions Made
+
+| Decision | Choice |
+|----------|--------|
+| FK on delete for orders | RESTRICT (preserve history) |
+| FK on delete for producers | RESTRICT (preserve history) |
+| Store producer_name | Yes (denormalized for history) |
+
+---
+
+_Pass-MP-ORDERS-SHIPPING-V1-01 | 2026-01-24_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,25 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-24 (HOTFIX-MP-CHECKOUT-GUARD-01 + producerId fix)
+**Last Updated**: 2026-01-24 (MP-ORDERS-SHIPPING-V1-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~280 lines (target ≤250). ⚠️
+> **Current size**: ~295 lines (target ≤250). ⚠️
+
+---
+
+## 2026-01-24 — Pass MP-ORDERS-SHIPPING-V1-01: Schema for Per-Producer Shipping
+
+**Status**: 🔄 PENDING — PR Pending
+
+Phase 1 of enabling multi-producer checkout: Create `order_shipping_lines` table.
+
+**Changes**:
+- New table: `order_shipping_lines` (per-producer shipping breakdown)
+- New model: `OrderShippingLine`
+- New relation: `Order->shippingLines()`
+- Unit tests: 4 tests, all pass
+
+**Evidence**: Summary: `Pass-MP-ORDERS-SHIPPING-V1-01.md`
 
 ---
 


### PR DESCRIPTION
## Summary

Pass MP-ORDERS-SHIPPING-V1-01 (Phase 1 - Schema)

Creates infrastructure for per-producer shipping breakdown. This is the first step toward enabling real multi-producer checkout (removing the HOTFIX-MP-CHECKOUT-GUARD-01 block).

## Changes

| File | Purpose |
|------|---------|
| `backend/database/migrations/2026_01_24_130000_create_order_shipping_lines_table.php` | New table for per-producer shipping |
| `backend/app/Models/OrderShippingLine.php` | Eloquent model |
| `backend/app/Models/Order.php` | Added `shippingLines()` relation |
| `backend/tests/Unit/OrderShippingLineTest.php` | 4 unit tests |

## Schema

```sql
CREATE TABLE order_shipping_lines (
  id BIGSERIAL PRIMARY KEY,
  order_id BIGINT NOT NULL REFERENCES orders(id) ON DELETE RESTRICT,
  producer_id BIGINT NOT NULL REFERENCES producers(id) ON DELETE RESTRICT,
  producer_name VARCHAR(255) NOT NULL,
  subtotal DECIMAL(10,2) NOT NULL,
  shipping_cost DECIMAL(10,2) NOT NULL,
  shipping_method VARCHAR(50),
  free_shipping_applied BOOLEAN DEFAULT FALSE,
  created_at TIMESTAMP,
  updated_at TIMESTAMP
);
```

## Safety

- **Additive only**: No changes to existing tables
- **Reversible**: Down migration drops the new table
- **FK constraints**: RESTRICT on delete (preserves order history)

## Tests

- ✅ 4/4 unit tests pass
- ✅ No regression in existing tests (pre-existing failures unrelated)

## Next Phase

Phase 2 will update `OrderController.php` to calculate and store per-producer shipping.

---

**Generated-by**: Claude | Pass MP-ORDERS-SHIPPING-V1-01