### PR TITLE
fix: Pass MP-CHECKOUT-PAYMENT-01 payment success toast timing

### DIFF
--- a/backend/tests/Feature/OrderEmailTriggerRulesTest.php
+++ b/backend/tests/Feature/OrderEmailTriggerRulesTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\ConsumerOrderPlaced;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Producer;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * Tests for order email trigger rules.
+ *
+ * Pass MP-CHECKOUT-PAYMENT-01: Email should be sent:
+ * - COD orders: Immediately at order creation
+ * - Card orders: Only after payment is confirmed (not at order creation)
+ */
+class OrderEmailTriggerRulesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Mail::fake();
+        Config::set('notifications.email_enabled', true);
+    }
+
+    /**
+     * AC1: COD orders should trigger email immediately at order creation.
+     */
+    public function test_cod_order_triggers_email_at_creation(): void
+    {
+        $user = User::factory()->consumer()->create(['email' => 'consumer@test.com']);
+        $producerUser = User::factory()->create(['email' => 'producer@test.com']);
+        $producer = Producer::factory()->create(['user_id' => $producerUser->id]);
+        $product = Product::factory()->create([
+            'producer_id' => $producer->id,
+            'price' => 25.00,
+            'stock' => 100,
+        ]);
+
+        // Create COD order via the public endpoint (same as frontend checkout)
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/v1/public/orders', [
+                'items' => [
+                    ['product_id' => $product->id, 'quantity' => 1],
+                ],
+                'shipping_method' => 'HOME',
+                'currency' => 'EUR',
+                'payment_method' => 'COD',
+            ]);
+
+        $response->assertStatus(201);
+
+        // Verify consumer email was sent
+        Mail::assertSent(ConsumerOrderPlaced::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email);
+        });
+    }
+
+    /**
+     * AC2: Card orders should NOT trigger email at order creation.
+     * Email should only be sent after payment confirmation.
+     */
+    public function test_card_order_does_not_trigger_email_at_creation(): void
+    {
+        $user = User::factory()->consumer()->create(['email' => 'consumer@test.com']);
+        $producerUser = User::factory()->create(['email' => 'producer@test.com']);
+        $producer = Producer::factory()->create(['user_id' => $producerUser->id]);
+        $product = Product::factory()->create([
+            'producer_id' => $producer->id,
+            'price' => 25.00,
+            'stock' => 100,
+        ]);
+
+        // Create Card order via the public endpoint
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/v1/public/orders', [
+                'items' => [
+                    ['product_id' => $product->id, 'quantity' => 1],
+                ],
+                'shipping_method' => 'HOME',
+                'currency' => 'EUR',
+                'payment_method' => 'CARD',
+            ]);
+
+        $response->assertStatus(201);
+
+        // Verify NO email was sent (email comes after payment confirmation)
+        Mail::assertNotSent(ConsumerOrderPlaced::class);
+    }
+
+    /**
+     * AC2 (continued): Card order email is sent after payment confirmation.
+     * This simulates what PaymentController does after Stripe confirms payment.
+     */
+    public function test_card_order_email_sent_after_payment_confirmation(): void
+    {
+        $user = User::factory()->consumer()->create(['email' => 'consumer@test.com']);
+        $producerUser = User::factory()->create(['email' => 'producer@test.com']);
+        $producer = Producer::factory()->create(['user_id' => $producerUser->id]);
+        $product = Product::factory()->create([
+            'producer_id' => $producer->id,
+            'price' => 25.00,
+            'stock' => 100,
+        ]);
+
+        // Create Card order (without email trigger)
+        $order = Order::factory()->create([
+            'user_id' => $user->id,
+            'payment_method' => 'CARD',
+            'payment_status' => 'pending',
+            'status' => 'pending',
+            'total' => 28.50,
+        ]);
+
+        // Add an order item (required for email service to work)
+        OrderItem::factory()->create([
+            'order_id' => $order->id,
+            'product_id' => $product->id,
+            'producer_id' => $producer->id,
+        ]);
+
+        // Manually call email service (simulating what PaymentController does after confirmation)
+        $emailService = app(\App\Services\OrderEmailService::class);
+        $emailService->sendOrderPlacedNotifications($order);
+
+        // Verify email was sent
+        Mail::assertSent(ConsumerOrderPlaced::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email);
+        });
+    }
+}

--- a/docs/AGENT/PLANS/Pass-MP-CHECKOUT-PAYMENT-01.md
+++ b/docs/AGENT/PLANS/Pass-MP-CHECKOUT-PAYMENT-01.md
@@ -1,0 +1,109 @@
+# Plan: Pass-MP-CHECKOUT-PAYMENT-01
+
+**Date**: 2026-01-24
+**Status**: COMPLETE
+**Author**: Claude Code
+
+---
+
+## Goal
+
+Fix multi-producer checkout correctness issues:
+1. ~~Email confirmation sent at wrong time (before payment completes)~~ **VERIFIED: Already correct**
+2. ~~Payment confirmation endpoint returning 400 errors~~ **VERIFIED: Backend logic correct**
+3. UI showing success despite payment failures **FIXED**
+4. ~~Shipping displayed incorrectly for multi-producer orders~~ **VERIFIED: API correct, frontend uses shipping_amount**
+
+---
+
+## Non-Goals
+
+- UI redesign or new features
+- Payment provider changes (Stripe stays)
+- Refactoring routing or controller structure
+- Performance optimization
+
+---
+
+## Acceptance Criteria
+
+| AC | Description | Test | Status |
+|----|-------------|------|--------|
+| AC1 | COD orders: Email sent immediately at order creation | `test_cod_order_triggers_email_at_creation` | PASS |
+| AC2 | Card orders: Email sent ONLY after payment confirmed | `test_card_order_does_not_trigger_email_at_creation` | PASS |
+| AC3 | Payment confirm 400 error surfaces actionable error to user | Already handled in checkout page | PASS |
+| AC4 | UI does NOT show "success" when payment fails | Frontend fix: removed premature toast | PASS |
+| AC5 | shipping_total in response equals sum of shipping_lines | Existing `MultiProducerShippingTest` | PASS |
+| AC6 | Frontend displays correct shipping total for multi-producer | Uses `shipping_amount` from API | VERIFIED |
+
+---
+
+## Investigation Results
+
+### 1. Email Trigger Analysis
+- **OrderController.php (lines 250-263)**: Already has HOTFIX - only sends email for COD orders
+- **PaymentController.php (lines 131-142)**: Email sent after payment confirmation for Card
+- **Conclusion**: Backend email logic is CORRECT
+
+### 2. Payment Flow Analysis
+- **PaymentController.php**: Returns 400 when `$result['success']` is false (line 123-128)
+- **Frontend checkout**: Already handles 400 by setting error state
+- **BUG FOUND**: StripePaymentForm.tsx showed success toast BEFORE backend confirmation
+
+### 3. Shipping Display Analysis
+- **OrderResource.php**: Returns `shipping_amount`, `shipping_cost`, and `shipping_total` (for multi-producer)
+- **Thank-you page**: Uses `shipping_amount` or `shipping_cost` - correct for current flow
+- **Note**: Multi-producer checkout is blocked by HOTFIX, so `shipping_total` not yet needed
+
+---
+
+## Changes Made
+
+### Frontend
+1. **StripePaymentForm.tsx**: Removed premature success toast (line 51)
+   - Toast was shown BEFORE backend confirmed payment
+   - Now parent handles toast AFTER backend confirmation
+
+2. **checkout/page.tsx**: Added success toast after backend confirmation
+   - Imported `useToast` from ToastContext
+   - Added `showToast('success', ...)` after `confirmPayment` succeeds
+
+### Backend (Tests)
+3. **OrderEmailTriggerRulesTest.php**: 3 new tests documenting email trigger rules
+   - `test_cod_order_triggers_email_at_creation`
+   - `test_card_order_does_not_trigger_email_at_creation`
+   - `test_card_order_email_sent_after_payment_confirmation`
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking existing COD flow | Added regression test for COD email |
+| Payment webhook timing | Ensure email also triggers from webhook |
+| Frontend complexity | Minimal changes, focus on error handling |
+
+---
+
+## Definition of Done
+
+- [x] Backend: Email only sent for confirmed payments (Card) or at creation (COD) - **VERIFIED**
+- [x] Backend: Payment confirm endpoint handles errors gracefully - **VERIFIED**
+- [x] Frontend: Shows error message on payment failure (not success) - **FIXED**
+- [x] Frontend: Displays correct shipping total - **VERIFIED**
+- [x] Tests: 3 backend tests for email trigger rules - **ADDED**
+- [ ] CI: All tests green - **PENDING PR**
+- [ ] PR: Merged with ai-pass label - **PENDING**
+
+---
+
+## Evidence Required
+
+- [x] Test output showing email trigger rules: 3/3 pass
+- [x] Frontend fix: StripePaymentForm.tsx, checkout/page.tsx
+- [x] Shipping verified: API returns correct shipping_amount
+
+---
+
+_Pass-MP-CHECKOUT-PAYMENT-01 | 2026-01-24_

--- a/frontend/src/app/(storefront)/checkout/page.tsx
+++ b/frontend/src/app/(storefront)/checkout/page.tsx
@@ -7,6 +7,7 @@ import { paymentApi } from '@/lib/api/payment'
 import PaymentMethodSelector, { type PaymentMethod } from '@/components/checkout/PaymentMethodSelector'
 import { useAuth } from '@/hooks/useAuth'
 import { useTranslations } from '@/contexts/LocaleContext'
+import { useToast } from '@/contexts/ToastContext'
 import StripeProvider from '@/components/payment/StripeProvider'
 import StripePaymentForm from '@/components/payment/StripePaymentForm'
 
@@ -16,6 +17,7 @@ function CheckoutContent() {
   const clear = useCart(s => s.clear)
   const { isAuthenticated, user } = useAuth()
   const t = useTranslations()
+  const { showToast } = useToast()
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -48,6 +50,9 @@ function CheckoutContent() {
     try {
       // Confirm payment with backend
       await paymentApi.confirmPayment(pendingOrderId, paymentIntentId)
+      // Show success toast ONLY after backend confirms payment
+      // (Fix: Previously toast was shown in StripePaymentForm before backend confirmation)
+      showToast('success', 'Η πληρωμή ολοκληρώθηκε επιτυχώς')
       // Clear cart and redirect to success page
       clear()
       router.push(`/thank-you?id=${pendingOrderId}`)

--- a/frontend/src/components/payment/StripePaymentForm.tsx
+++ b/frontend/src/components/payment/StripePaymentForm.tsx
@@ -47,8 +47,9 @@ export default function StripePaymentForm({
         onPaymentError(errorMessage);
         showToast('error', errorMessage);
       } else if (paymentIntent && paymentIntent.status === 'succeeded') {
+        // Don't show success toast here - let parent confirm with backend first
+        // Parent's onPaymentSuccess handler will show success after backend confirmation
         onPaymentSuccess(paymentIntent.id);
-        showToast('success', 'Η πληρωμή ολοκληρώθηκε επιτυχώς');
       } else {
         onPaymentError('Η πληρωμή απαιτεί επιπλέον ενέργειες');
       }


### PR DESCRIPTION
## Summary
- Fix premature success toast in Stripe payment flow
- Add 3 backend tests for email trigger rules (COD vs Card)

## Problem
`StripePaymentForm.tsx` showed success toast immediately when Stripe confirmed payment, BEFORE backend confirmation. If backend confirmation failed (400 error), user already saw a success toast - misleading UX.

## Changes
- **StripePaymentForm.tsx**: Remove premature success toast (let parent handle)
- **checkout/page.tsx**: Add success toast AFTER backend `confirmPayment` succeeds
- **OrderEmailTriggerRulesTest.php**: 3 tests documenting email trigger rules

## Test plan
- [x] `test_cod_order_triggers_email_at_creation` - PASS
- [x] `test_card_order_does_not_trigger_email_at_creation` - PASS  
- [x] `test_card_order_email_sent_after_payment_confirmation` - PASS
- [x] Frontend builds successfully
- [x] All 8 related backend tests pass

## Evidence
- Plan: `docs/AGENT/PLANS/Pass-MP-CHECKOUT-PAYMENT-01.md`

---
Pass-MP-CHECKOUT-PAYMENT-01 | Generated by Claude Code