### PR TITLE
docs: Pass-DOCS-STATE-HYGIENE-01 archive old STATE entries

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-DOCS-STATE-HYGIENE-01.md
+++ b/docs/AGENT/SUMMARY/Pass-DOCS-STATE-HYGIENE-01.md
@@ -1,0 +1,81 @@
+# Summary: Pass-DOCS-STATE-HYGIENE-01
+
+**Date**: 2026-01-25
+**Status**: ✅ COMPLETE
+**PR**: Pending
+
+---
+
+## TL;DR
+
+Archived 5 old pass entries from STATE.md to meet ≤250 line target. No data lost.
+
+**Before**: 281 lines ⚠️
+**After**: 204 lines ✅
+
+---
+
+## Archived Entries
+
+Moved to `docs/OPS/STATE-ARCHIVE/STATE-2026-01-24-early.md`:
+
+| Entry | PR |
+|-------|-----|
+| CI Note: E2E (PostgreSQL) Non-Required Failure | n/a |
+| Pass DOCS-ARCHIVE-CLEANUP-01 | #2442 |
+| Pass UI-ROLE-NAV-SHELL-01 | #2441 |
+| Pass SHIP-MULTI-DISCOVERY-01 | #2440 |
+| Pass UI-SHELL-HEADER-FOOTER-01 | #2437 |
+
+---
+
+## Evidence
+
+### Line Count Verification
+
+```bash
+$ wc -l docs/OPS/STATE.md
+     204 docs/OPS/STATE.md
+```
+
+### Archive Created
+
+```
+docs/OPS/STATE-ARCHIVE/STATE-2026-01-24-early.md (77 lines)
+```
+
+### Index Updated
+
+```
+docs/OPS/STATE-ARCHIVE/INDEX.md
++ STATE-2026-01-24-early.md | 2026-01-24 | CI Note, DOCS-ARCHIVE, UI-ROLE-NAV...
+```
+
+---
+
+## Kept in STATE.md (10 entries)
+
+1. MP-PROD-VERIFY-04
+2. MP-CHECKOUT-PROD-TRUTH-03
+3. MP-MULTI-PRODUCER-CHECKOUT-02
+4. MP-CHECKOUT-PAYMENT-01
+5. MP-ORDERS-SHIPPING-V1-02
+6. MP-ORDERS-SHIPPING-V1-01
+7. HOTFIX-MP-CHECKOUT-GUARD-01
+8. SHIP-MULTI-PRODUCER-E2E-01
+9. SHIP-MULTI-PRODUCER-ENABLE-01
+10. SHIP-MULTI-PRODUCER-PLAN-01
+
+All from 2026-01-24, per archive policy (~2 days).
+
+---
+
+## Files Changed
+
+- `docs/OPS/STATE.md` — Reduced 281 → 204 lines
+- `docs/OPS/STATE-ARCHIVE/STATE-2026-01-24-early.md` — Created
+- `docs/OPS/STATE-ARCHIVE/INDEX.md` — Updated
+
+---
+
+_Pass-DOCS-STATE-HYGIENE-01 | 2026-01-25_

--- a/docs/AGENT/TASKS/Pass-DOCS-STATE-HYGIENE-01.md
+++ b/docs/AGENT/TASKS/Pass-DOCS-STATE-HYGIENE-01.md
@@ -1,0 +1,60 @@
+# Tasks: Pass-DOCS-STATE-HYGIENE-01
+
+**Date**: 2026-01-25
+**Status**: COMPLETE
+
+---
+
+## What
+
+Archive old entries from `docs/OPS/STATE.md` to keep it ≤250 lines per archive policy.
+
+## Why
+
+- STATE.md was 281 lines (target ≤250)
+- Header showed ⚠️ warning about size
+- Faster agent boot with smaller STATE.md
+- No data lost — just moved to archive
+
+## How
+
+1. Identified entries older than core 2026-01-24 passes
+2. Moved 5 entries to `docs/OPS/STATE-ARCHIVE/STATE-2026-01-24-early.md`:
+   - CI Note: E2E (PostgreSQL) Non-Required Failure
+   - Pass DOCS-ARCHIVE-CLEANUP-01
+   - Pass UI-ROLE-NAV-SHELL-01
+   - Pass SHIP-MULTI-DISCOVERY-01
+   - Pass UI-SHELL-HEADER-FOOTER-01
+3. Updated `STATE-ARCHIVE/INDEX.md` with new archive file
+4. Reduced STATE.md from 281 → 204 lines
+
+---
+
+## Completed Tasks
+
+- [x] Read current STATE.md (281 lines)
+- [x] Identify entries to archive
+- [x] Create `STATE-ARCHIVE/STATE-2026-01-24-early.md`
+- [x] Update `STATE-ARCHIVE/INDEX.md`
+- [x] Update STATE.md (remove archived entries)
+- [x] Verify line count ≤250
+- [x] Create TASKS document
+- [x] Create SUMMARY document
+- [x] Commit and push
+- [x] Create PR with ai-pass label
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `docs/OPS/STATE.md` | Reduced 281 → 204 lines |
+| `docs/OPS/STATE-ARCHIVE/STATE-2026-01-24-early.md` | Created (77 lines) |
+| `docs/OPS/STATE-ARCHIVE/INDEX.md` | Added new archive entry |
+| `docs/AGENT/TASKS/Pass-DOCS-STATE-HYGIENE-01.md` | Created |
+| `docs/AGENT/SUMMARY/Pass-DOCS-STATE-HYGIENE-01.md` | Created |
+
+---
+
+_Pass-DOCS-STATE-HYGIENE-01 | 2026-01-25_

--- a/docs/OPS/STATE-ARCHIVE/INDEX.md
+++ b/docs/OPS/STATE-ARCHIVE/INDEX.md
@@ -6,6 +6,7 @@ Historical pass records archived from `docs/OPS/STATE.md`.
 
 | File | Period | Notes |
 |------|--------|-------|
+| [STATE-2026-01-24-early.md](STATE-2026-01-24-early.md) | 2026-01-24 | CI Note, DOCS-ARCHIVE, UI-ROLE-NAV, SHIP-MULTI-DISCOVERY, UI-SHELL |
 | [STATE-2026-01-17-early.md](STATE-2026-01-17-early.md) | 2026-01-17 | Passes before PROD-UNBLOCK-01 |
 | [STATE-2026-01-16.md](STATE-2026-01-16.md) | 2026-01-16 | NOTIFICATIONS-01, EN-LANGUAGE-01, SEARCH-FTS-01, etc. |
 | [STATE-2026-01-14-15.md](STATE-2026-01-14-15.md) | 2026-01-14 to 2026-01-15 | SEC-* passes, TEST-COVERAGE-01, SEC-UDEV-01 |

--- a/docs/OPS/STATE-ARCHIVE/STATE-2026-01-24-early.md
+++ b/docs/OPS/STATE-ARCHIVE/STATE-2026-01-24-early.md
@@ -1,0 +1,86 @@
+# STATE Archive: 2026-01-24 (Early)
+
+Archived from `docs/OPS/STATE.md` on 2026-01-25.
+
+---
+
+## CI Note: E2E (PostgreSQL) Non-Required Failure
+
+**Observed**: 2026-01-24 on PR #2440, #2441
+
+The `E2E (PostgreSQL)` workflow failed but is **non-required** for merge. PRs merged successfully via auto-merge. This workflow runs against a PostgreSQL backend (vs SQLite in main CI) and may have flakiness. No action required unless it becomes blocking.
+
+**Run links**:
+- [#2441 E2E-PG](https://github.com/lomendor/Project-Dixis/actions/runs/21312989256/job/61351896715)
+- [#2440 E2E-PG](https://github.com/lomendor/Project-Dixis/actions/runs/21312521868/job/61350824424)
+
+---
+
+## 2026-01-24 — Pass DOCS-ARCHIVE-CLEANUP-01: Agent Docs Housekeeping
+
+**Status**: ✅ PASS — MERGED (PR #2442)
+
+Archived 50 old Pass files (pre-2026-01-22) to `docs/ARCHIVE/AGENT-2026-01/`.
+
+**Changes**:
+- Archived: 29 SUMMARY, 18 TASKS, 3 PLANS files
+- Remaining: 34 SUMMARY, 26 TASKS, 11 PLANS
+
+**Evidence**: Summary: `Pass-DOCS-ARCHIVE-CLEANUP-01.md`
+
+---
+
+## 2026-01-24 — Pass UI-ROLE-NAV-SHELL-01: UI Role Navigation Verification
+
+**Status**: ✅ PASS — MERGED (PR #2441)
+
+Audited UI shell — already compliant from previous passes. Added 8 new E2E tests for logo behavior, mobile stability, and footer correctness.
+
+**Changes**:
+- New: `ui-role-nav-shell.spec.ts` (8 tests)
+
+**E2E Tests**: 8/8 pass (14 total UI shell tests)
+
+**Evidence**: Summary: `Pass-UI-ROLE-NAV-SHELL-01.md`
+
+---
+
+## 2026-01-24 — Pass SHIP-MULTI-DISCOVERY-01: Shipping & Multi-Producer Discovery
+
+**Status**: ✅ PASS — MERGED (PR #2440)
+
+Discovery audit for shipping calculation and multi-producer checkout capability. Created 4 spec documents.
+
+**Key Findings**:
+- Shipping engine adequate for MVP (zone-based, €35 free threshold)
+- Multi-producer: Schema supports it, application blocks it (~20 LOC guards)
+- To enable multi-producer: Remove client+server guards
+
+**Deliverables**:
+- `docs/PRODUCT/SHIPPING/SHIPPING-FACTS.md`
+- `docs/PRODUCT/SHIPPING/SHIPPING-ENGINE-MVP-SPEC.md`
+- `docs/PRODUCT/ORDERS/MULTI-PRODUCER-FACTS.md`
+- `docs/PRODUCT/ORDERS/MULTI-PRODUCER-MVP-SPEC.md`
+
+**Evidence**: Summary: `Pass-SHIP-MULTI-DISCOVERY-01.md`
+
+---
+
+## 2026-01-24 — Pass UI-SHELL-HEADER-FOOTER-01: UI Shell Stabilization
+
+**Status**: ✅ PASS — MERGED (PR #2437)
+
+Stabilized Header/Footer. Removed "Παρακολούθηση Παραγγελίας" from footer. Made cart visible for ALL roles (including producers). 6 E2E tests verify per-role visibility.
+
+**Changes**:
+- Footer: Removed order tracking link
+- CartIcon: Cart now visible for producers too
+- New: `ui-shell-header-footer.spec.ts` (6 tests)
+
+**E2E Tests**: 6/6 pass
+
+**Evidence**: Footer.tsx, CartIcon.tsx | Summary: `Pass-UI-SHELL-HEADER-FOOTER-01.md`
+
+---
+
+_Archived by Pass-DOCS-STATE-HYGIENE-01 on 2026-01-25_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,9 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-24 (MP-PROD-VERIFY-04)
+**Last Updated**: 2026-01-25 (DOCS-STATE-HYGIENE-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~370 lines (target ≤250). ⚠️
+> **Current size**: ~200 lines (target ≤250). ✅
 
 ---
 
@@ -200,81 +200,4 @@ Planning pass for multi-producer checkout and realistic shipping calculation. De
 
 ---
 
-## CI Note: E2E (PostgreSQL) Non-Required Failure
-
-**Observed**: 2026-01-24 on PR #2440, #2441
-
-The `E2E (PostgreSQL)` workflow failed but is **non-required** for merge. PRs merged successfully via auto-merge. This workflow runs against a PostgreSQL backend (vs SQLite in main CI) and may have flakiness. No action required unless it becomes blocking.
-
-**Run links**:
-- [#2441 E2E-PG](https://github.com/lomendor/Project-Dixis/actions/runs/21312989256/job/61351896715)
-- [#2440 E2E-PG](https://github.com/lomendor/Project-Dixis/actions/runs/21312521868/job/61350824424)
-
----
-
-## 2026-01-24 — Pass DOCS-ARCHIVE-CLEANUP-01: Agent Docs Housekeeping
-
-**Status**: ✅ PASS — MERGED (PR #2442)
-
-Archived 50 old Pass files (pre-2026-01-22) to `docs/ARCHIVE/AGENT-2026-01/`.
-
-**Changes**:
-- Archived: 29 SUMMARY, 18 TASKS, 3 PLANS files
-- Remaining: 34 SUMMARY, 26 TASKS, 11 PLANS
-
-**Evidence**: Summary: `Pass-DOCS-ARCHIVE-CLEANUP-01.md`
-
----
-
-## 2026-01-24 — Pass UI-ROLE-NAV-SHELL-01: UI Role Navigation Verification
-
-**Status**: ✅ PASS — MERGED (PR #2441)
-
-Audited UI shell — already compliant from previous passes. Added 8 new E2E tests for logo behavior, mobile stability, and footer correctness.
-
-**Changes**:
-- New: `ui-role-nav-shell.spec.ts` (8 tests)
-
-**E2E Tests**: 8/8 pass (14 total UI shell tests)
-
-**Evidence**: Summary: `Pass-UI-ROLE-NAV-SHELL-01.md`
-
----
-
-## 2026-01-24 — Pass SHIP-MULTI-DISCOVERY-01: Shipping & Multi-Producer Discovery
-
-**Status**: ✅ PASS — MERGED (PR #2440)
-
-Discovery audit for shipping calculation and multi-producer checkout capability. Created 4 spec documents.
-
-**Key Findings**:
-- Shipping engine adequate for MVP (zone-based, €35 free threshold)
-- Multi-producer: Schema supports it, application blocks it (~20 LOC guards)
-- To enable multi-producer: Remove client+server guards
-
-**Deliverables**:
-- `docs/PRODUCT/SHIPPING/SHIPPING-FACTS.md`
-- `docs/PRODUCT/SHIPPING/SHIPPING-ENGINE-MVP-SPEC.md`
-- `docs/PRODUCT/ORDERS/MULTI-PRODUCER-FACTS.md`
-- `docs/PRODUCT/ORDERS/MULTI-PRODUCER-MVP-SPEC.md`
-
-**Evidence**: Summary: `Pass-SHIP-MULTI-DISCOVERY-01.md`
-
----
-
-## 2026-01-24 — Pass UI-SHELL-HEADER-FOOTER-01: UI Shell Stabilization
-
-**Status**: ✅ PASS — MERGED (PR #2437)
-
-Stabilized Header/Footer. Removed "Παρακολούθηση Παραγγελίας" from footer. Made cart visible for ALL roles (including producers). 6 E2E tests verify per-role visibility.
-
-**Changes**:
-- Footer: Removed order tracking link
-- CartIcon: Cart now visible for producers too
-- New: `ui-shell-header-footer.spec.ts` (6 tests)
-
-**E2E Tests**: 6/6 pass
-
-**Evidence**: Footer.tsx, CartIcon.tsx | Summary: `Pass-UI-SHELL-HEADER-FOOTER-01.md`
-
----
+_For older passes, see: `docs/OPS/STATE-ARCHIVE/`_


### PR DESCRIPTION
## Summary

Reduced `docs/OPS/STATE.md` from 281 to 204 lines (target ≤250).

## Archived Entries

Moved to `docs/OPS/STATE-ARCHIVE/STATE-2026-01-24-early.md`:

| Entry | PR |
|-------|-----|
| CI Note: E2E (PostgreSQL) Non-Required Failure | n/a |
| Pass DOCS-ARCHIVE-CLEANUP-01 | #2442 |
| Pass UI-ROLE-NAV-SHELL-01 | #2441 |
| Pass SHIP-MULTI-DISCOVERY-01 | #2440 |
| Pass UI-SHELL-HEADER-FOOTER-01 | #2437 |

## Result

- **Before**: 281 lines ⚠️
- **After**: 204 lines ✅

No data lost — just moved to archive per existing policy.

## Test plan

- [x] Verify STATE.md ≤250 lines
- [x] Verify archive file created
- [x] Verify INDEX.md updated
- [x] Only docs changes (no code)