### PR TITLE
feat: Pass MP-ORDERS-SCHEMA-01 schema + model

### DIFF
--- a/backend/app/Models/CheckoutSession.php
+++ b/backend/app/Models/CheckoutSession.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Pass MP-ORDERS-SCHEMA-01: CheckoutSession Model
+ *
+ * Parent entity for multi-producer checkout. Links N child orders
+ * to a single Stripe PaymentIntent.
+ *
+ * @property int $id
+ * @property int|null $user_id
+ * @property string|null $stripe_payment_intent_id
+ * @property string $subtotal
+ * @property string $shipping_total
+ * @property string $total
+ * @property string $status
+ * @property string $currency
+ * @property int $order_count
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class CheckoutSession extends Model
+{
+    use HasFactory;
+
+    // Status constants
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_PAYMENT_PROCESSING = 'payment_processing';
+    public const STATUS_PAID = 'paid';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_CANCELLED = 'cancelled';
+
+    protected $fillable = [
+        'user_id',
+        'stripe_payment_intent_id',
+        'subtotal',
+        'shipping_total',
+        'total',
+        'status',
+        'currency',
+        'order_count',
+    ];
+
+    protected $casts = [
+        'subtotal' => 'decimal:2',
+        'shipping_total' => 'decimal:2',
+        'total' => 'decimal:2',
+        'order_count' => 'integer',
+    ];
+
+    /**
+     * Get the user that owns the checkout session.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get all child orders for this checkout session.
+     */
+    public function orders(): HasMany
+    {
+        return $this->hasMany(Order::class);
+    }
+
+    /**
+     * Check if the checkout session is multi-producer.
+     */
+    public function isMultiProducer(): bool
+    {
+        return $this->order_count > 1;
+    }
+
+    /**
+     * Check if payment has been confirmed.
+     */
+    public function isPaid(): bool
+    {
+        return $this->status === self::STATUS_PAID;
+    }
+
+    /**
+     * Mark the session and all child orders as paid.
+     */
+    public function markAsPaid(): void
+    {
+        $this->update(['status' => self::STATUS_PAID]);
+
+        $this->orders()->update([
+            'payment_status' => 'paid',
+        ]);
+    }
+
+    /**
+     * Mark the session and all child orders as failed.
+     */
+    public function markAsFailed(): void
+    {
+        $this->update(['status' => self::STATUS_FAILED]);
+
+        $this->orders()->update([
+            'payment_status' => 'failed',
+        ]);
+    }
+
+    /**
+     * Recalculate totals from child orders.
+     */
+    public function recalculateTotals(): void
+    {
+        $orders = $this->orders()->get();
+
+        $this->update([
+            'subtotal' => $orders->sum('subtotal'),
+            'shipping_total' => $orders->sum('shipping_cost'),
+            'total' => $orders->sum('total'),
+            'order_count' => $orders->count(),
+        ]);
+    }
+}

--- a/backend/app/Models/Order.php
+++ b/backend/app/Models/Order.php
@@ -11,6 +11,8 @@ class Order extends Model
 
     protected $fillable = [
         'user_id',
+        'checkout_session_id',
+        'is_child_order',
         'status',
         'payment_status',
         'payment_method',
@@ -39,6 +41,7 @@ class Order extends Model
         'shipping_cost' => 'decimal:2',
         'total' => 'decimal:2',
         'refunded_at' => 'datetime',
+        'is_child_order' => 'boolean',
         // Legacy fields - keep for backward compatibility
         'tax_amount' => 'decimal:2',
         'shipping_amount' => 'decimal:2',
@@ -53,6 +56,23 @@ class Order extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the checkout session this order belongs to (for multi-producer orders).
+     * Pass MP-ORDERS-SCHEMA-01: Parent-child order relationship.
+     */
+    public function checkoutSession()
+    {
+        return $this->belongsTo(CheckoutSession::class);
+    }
+
+    /**
+     * Check if this order is part of a multi-producer checkout.
+     */
+    public function isChildOrder(): bool
+    {
+        return $this->is_child_order === true;
     }
 
     /**

--- a/backend/database/migrations/2026_01_25_140000_create_checkout_sessions_table.php
+++ b/backend/database/migrations/2026_01_25_140000_create_checkout_sessions_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Pass MP-ORDERS-SCHEMA-01: Create checkout_sessions table
+ *
+ * Parent entity for multi-producer checkout. Links N child orders
+ * to a single Stripe PaymentIntent.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('checkout_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+
+            // Stripe payment integration
+            $table->string('stripe_payment_intent_id')->nullable()->index();
+
+            // Totals (sum of all child orders)
+            $table->decimal('subtotal', 10, 2)->default(0);
+            $table->decimal('shipping_total', 10, 2)->default(0);
+            $table->decimal('total', 10, 2)->default(0);
+
+            // Status
+            $table->enum('status', [
+                'pending',           // Created, waiting for payment
+                'payment_processing', // Payment submitted, waiting for confirmation
+                'paid',              // Payment confirmed
+                'failed',            // Payment failed
+                'cancelled',         // User cancelled
+            ])->default('pending');
+
+            // Metadata
+            $table->string('currency', 3)->default('EUR');
+            $table->unsignedTinyInteger('order_count')->default(0);
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('checkout_sessions');
+    }
+};

--- a/backend/database/migrations/2026_01_25_140001_add_checkout_session_id_to_orders_table.php
+++ b/backend/database/migrations/2026_01_25_140001_add_checkout_session_id_to_orders_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Pass MP-ORDERS-SCHEMA-01: Add checkout_session_id FK to orders
+ *
+ * Links child orders to parent CheckoutSession for multi-producer checkout.
+ * Nullable to maintain backward compatibility with standalone orders.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            // FK to parent checkout session (nullable for backward compatibility)
+            $table->foreignId('checkout_session_id')
+                ->nullable()
+                ->after('user_id')
+                ->constrained('checkout_sessions')
+                ->nullOnDelete();
+
+            // Flag to distinguish child orders from standalone orders
+            $table->boolean('is_child_order')->default(false)->after('checkout_session_id');
+
+            // Index for efficient queries by session
+            $table->index(['checkout_session_id', 'is_child_order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropIndex(['checkout_session_id', 'is_child_order']);
+            $table->dropConstrainedForeignId('checkout_session_id');
+            $table->dropColumn('is_child_order');
+        });
+    }
+};

--- a/backend/tests/Unit/CheckoutSessionTest.php
+++ b/backend/tests/Unit/CheckoutSessionTest.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\CheckoutSession;
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Pass MP-ORDERS-SCHEMA-01: CheckoutSession Unit Tests
+ *
+ * Tests for the CheckoutSession model and its relationships.
+ */
+class CheckoutSessionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function checkout_sessions_table_exists(): void
+    {
+        $this->assertTrue(
+            \Schema::hasTable('checkout_sessions'),
+            'checkout_sessions table should exist'
+        );
+    }
+
+    /** @test */
+    public function checkout_sessions_has_required_columns(): void
+    {
+        $columns = \Schema::getColumnListing('checkout_sessions');
+
+        $this->assertContains('id', $columns);
+        $this->assertContains('user_id', $columns);
+        $this->assertContains('stripe_payment_intent_id', $columns);
+        $this->assertContains('subtotal', $columns);
+        $this->assertContains('shipping_total', $columns);
+        $this->assertContains('total', $columns);
+        $this->assertContains('status', $columns);
+        $this->assertContains('currency', $columns);
+        $this->assertContains('order_count', $columns);
+        $this->assertContains('created_at', $columns);
+        $this->assertContains('updated_at', $columns);
+    }
+
+    /** @test */
+    public function orders_table_has_checkout_session_columns(): void
+    {
+        $columns = \Schema::getColumnListing('orders');
+
+        $this->assertContains('checkout_session_id', $columns);
+        $this->assertContains('is_child_order', $columns);
+    }
+
+    /** @test */
+    public function can_create_checkout_session(): void
+    {
+        $session = CheckoutSession::create([
+            'subtotal' => 50.00,
+            'shipping_total' => 7.00,
+            'total' => 57.00,
+            'status' => CheckoutSession::STATUS_PENDING,
+            'currency' => 'EUR',
+            'order_count' => 2,
+        ]);
+
+        $this->assertDatabaseHas('checkout_sessions', [
+            'id' => $session->id,
+            'subtotal' => 50.00,
+            'shipping_total' => 7.00,
+            'total' => 57.00,
+            'status' => 'pending',
+            'order_count' => 2,
+        ]);
+    }
+
+    /** @test */
+    public function checkout_session_belongs_to_user(): void
+    {
+        $user = User::factory()->create();
+        $session = CheckoutSession::create([
+            'user_id' => $user->id,
+            'subtotal' => 50.00,
+            'shipping_total' => 0,
+            'total' => 50.00,
+        ]);
+
+        $this->assertInstanceOf(User::class, $session->user);
+        $this->assertEquals($user->id, $session->user->id);
+    }
+
+    /** @test */
+    public function checkout_session_has_many_orders(): void
+    {
+        $user = User::factory()->create();
+        $session = CheckoutSession::create([
+            'user_id' => $user->id,
+            'subtotal' => 50.00,
+            'shipping_total' => 7.00,
+            'total' => 57.00,
+            'order_count' => 2,
+        ]);
+
+        // Create 2 child orders
+        $order1 = Order::create([
+            'user_id' => $user->id,
+            'checkout_session_id' => $session->id,
+            'is_child_order' => true,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'payment_method' => 'card',
+            'subtotal' => 30.00,
+            'shipping_cost' => 3.50,
+            'total' => 33.50,
+        ]);
+
+        $order2 = Order::create([
+            'user_id' => $user->id,
+            'checkout_session_id' => $session->id,
+            'is_child_order' => true,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'payment_method' => 'card',
+            'subtotal' => 20.00,
+            'shipping_cost' => 3.50,
+            'total' => 23.50,
+        ]);
+
+        $this->assertCount(2, $session->orders);
+        $this->assertTrue($session->orders->contains($order1));
+        $this->assertTrue($session->orders->contains($order2));
+    }
+
+    /** @test */
+    public function order_belongs_to_checkout_session(): void
+    {
+        $user = User::factory()->create();
+        $session = CheckoutSession::create([
+            'user_id' => $user->id,
+            'subtotal' => 30.00,
+            'shipping_total' => 3.50,
+            'total' => 33.50,
+            'order_count' => 1,
+        ]);
+
+        $order = Order::create([
+            'user_id' => $user->id,
+            'checkout_session_id' => $session->id,
+            'is_child_order' => true,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'payment_method' => 'card',
+            'subtotal' => 30.00,
+            'shipping_cost' => 3.50,
+            'total' => 33.50,
+        ]);
+
+        $this->assertInstanceOf(CheckoutSession::class, $order->checkoutSession);
+        $this->assertEquals($session->id, $order->checkoutSession->id);
+        $this->assertTrue($order->isChildOrder());
+    }
+
+    /** @test */
+    public function is_multi_producer_returns_correct_value(): void
+    {
+        $singleProducerSession = CheckoutSession::create([
+            'subtotal' => 30.00,
+            'shipping_total' => 0,
+            'total' => 30.00,
+            'order_count' => 1,
+        ]);
+
+        $multiProducerSession = CheckoutSession::create([
+            'subtotal' => 50.00,
+            'shipping_total' => 7.00,
+            'total' => 57.00,
+            'order_count' => 2,
+        ]);
+
+        $this->assertFalse($singleProducerSession->isMultiProducer());
+        $this->assertTrue($multiProducerSession->isMultiProducer());
+    }
+
+    /** @test */
+    public function mark_as_paid_updates_session_and_orders(): void
+    {
+        $user = User::factory()->create();
+        $session = CheckoutSession::create([
+            'user_id' => $user->id,
+            'subtotal' => 50.00,
+            'shipping_total' => 7.00,
+            'total' => 57.00,
+            'status' => CheckoutSession::STATUS_PAYMENT_PROCESSING,
+            'order_count' => 2,
+        ]);
+
+        $order1 = Order::create([
+            'user_id' => $user->id,
+            'checkout_session_id' => $session->id,
+            'is_child_order' => true,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'payment_method' => 'card',
+            'subtotal' => 30.00,
+            'shipping_cost' => 3.50,
+            'total' => 33.50,
+        ]);
+
+        $order2 = Order::create([
+            'user_id' => $user->id,
+            'checkout_session_id' => $session->id,
+            'is_child_order' => true,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'payment_method' => 'card',
+            'subtotal' => 20.00,
+            'shipping_cost' => 3.50,
+            'total' => 23.50,
+        ]);
+
+        $session->markAsPaid();
+
+        $session->refresh();
+        $order1->refresh();
+        $order2->refresh();
+
+        $this->assertEquals(CheckoutSession::STATUS_PAID, $session->status);
+        $this->assertTrue($session->isPaid());
+        $this->assertEquals('paid', $order1->payment_status);
+        $this->assertEquals('paid', $order2->payment_status);
+    }
+
+    /** @test */
+    public function recalculate_totals_sums_child_orders(): void
+    {
+        $user = User::factory()->create();
+        $session = CheckoutSession::create([
+            'user_id' => $user->id,
+            'subtotal' => 0,
+            'shipping_total' => 0,
+            'total' => 0,
+            'order_count' => 0,
+        ]);
+
+        Order::create([
+            'user_id' => $user->id,
+            'checkout_session_id' => $session->id,
+            'is_child_order' => true,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'payment_method' => 'card',
+            'subtotal' => 40.00,
+            'shipping_cost' => 0.00, // Free shipping (>= €35)
+            'total' => 40.00,
+        ]);
+
+        Order::create([
+            'user_id' => $user->id,
+            'checkout_session_id' => $session->id,
+            'is_child_order' => true,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'payment_method' => 'card',
+            'subtotal' => 18.00,
+            'shipping_cost' => 3.50,
+            'total' => 21.50,
+        ]);
+
+        $session->recalculateTotals();
+        $session->refresh();
+
+        $this->assertEquals('58.00', $session->subtotal);
+        $this->assertEquals('3.50', $session->shipping_total);
+        $this->assertEquals('61.50', $session->total);
+        $this->assertEquals(2, $session->order_count);
+    }
+
+    /** @test */
+    public function standalone_order_has_null_checkout_session(): void
+    {
+        $user = User::factory()->create();
+
+        $order = Order::create([
+            'user_id' => $user->id,
+            'checkout_session_id' => null,
+            'is_child_order' => false,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'payment_method' => 'card',
+            'subtotal' => 30.00,
+            'shipping_cost' => 3.50,
+            'total' => 33.50,
+        ]);
+
+        $this->assertNull($order->checkoutSession);
+        $this->assertFalse($order->isChildOrder());
+    }
+}

--- a/docs/AGENT/SUMMARY/Pass-MP-ORDERS-SCHEMA-01.md
+++ b/docs/AGENT/SUMMARY/Pass-MP-ORDERS-SCHEMA-01.md
@@ -1,0 +1,87 @@
+# Summary: Pass-MP-ORDERS-SCHEMA-01
+
+**Date**: 2026-01-25
+**Status**: ✅ COMPLETE
+**PR**: Pending
+
+---
+
+## TL;DR
+
+Phase 1 of multi-producer order splitting. Created `checkout_sessions` table and linked to `orders` via FK. All 11 unit tests pass.
+
+---
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `create_checkout_sessions_table.php` | NEW migration - parent table for multi-producer checkout |
+| `add_checkout_session_id_to_orders_table.php` | NEW migration - FK + is_child_order flag |
+| `CheckoutSession.php` | NEW model with relations and helpers |
+| `Order.php` | MODIFIED - added checkoutSession() relation |
+| `CheckoutSessionTest.php` | NEW - 11 unit tests |
+
+---
+
+## Architecture
+
+```
+CheckoutSession (parent)
+    ├── user_id (FK)
+    ├── stripe_payment_intent_id
+    ├── subtotal, shipping_total, total
+    ├── status (pending → paid)
+    └── orders[] (hasMany)
+
+Order (child)
+    ├── checkout_session_id (FK, nullable)
+    ├── is_child_order (boolean)
+    └── checkoutSession() (belongsTo)
+```
+
+---
+
+## Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `CheckoutSession::isMultiProducer()` | Returns true if order_count > 1 |
+| `CheckoutSession::markAsPaid()` | Updates session + all child orders to paid |
+| `CheckoutSession::recalculateTotals()` | Sums child order amounts |
+| `Order::isChildOrder()` | Returns is_child_order boolean |
+| `Order::checkoutSession()` | BelongsTo relationship |
+
+---
+
+## Test Evidence
+
+```
+PASS  Tests\Unit\CheckoutSessionTest
+✓ checkout sessions table exists
+✓ checkout sessions has required columns
+✓ orders table has checkout session columns
+✓ can create checkout session
+✓ checkout session belongs to user
+✓ checkout session has many orders
+✓ order belongs to checkout session
+✓ is multi producer returns correct value
+✓ mark as paid updates session and orders
+✓ recalculate totals sums child orders
+✓ standalone order has null checkout session
+
+Tests: 11 passed (35 assertions)
+```
+
+---
+
+## Next Phase
+
+Phase 2: Backend Order Splitting
+- Modify `OrderController@store` to detect multi-producer carts
+- Create CheckoutSession + child Orders atomically
+- Create single Stripe PaymentIntent
+
+---
+
+_Pass-MP-ORDERS-SCHEMA-01 | 2026-01-25 | COMPLETE ✅_

--- a/docs/AGENT/TASKS/Pass-MP-ORDERS-SCHEMA-01.md
+++ b/docs/AGENT/TASKS/Pass-MP-ORDERS-SCHEMA-01.md
@@ -1,0 +1,88 @@
+# Tasks: Pass-MP-ORDERS-SCHEMA-01
+
+**Date**: 2026-01-25
+**Status**: COMPLETE
+**PR**: Pending
+
+---
+
+## Goal
+
+Phase 1 of multi-producer order splitting: Create database schema and models for CheckoutSession parent-child architecture.
+
+---
+
+## Tasks
+
+| # | Task | Status |
+|---|------|--------|
+| 1 | Create `checkout_sessions` table migration | ✅ |
+| 2 | Add `checkout_session_id` FK to orders | ✅ |
+| 3 | Add `is_child_order` boolean to orders | ✅ |
+| 4 | Create `CheckoutSession` model | ✅ |
+| 5 | Add `checkoutSession()` relation to Order | ✅ |
+| 6 | Write unit tests for schema | ✅ |
+| 7 | Write unit tests for relationships | ✅ |
+| 8 | Run migrations | ✅ |
+| 9 | Verify all tests pass | ✅ |
+
+---
+
+## Schema Changes
+
+### New Table: `checkout_sessions`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | bigint | Primary key |
+| user_id | bigint nullable | FK to users |
+| stripe_payment_intent_id | string nullable | Stripe PI ID |
+| subtotal | decimal(10,2) | Sum of child order subtotals |
+| shipping_total | decimal(10,2) | Sum of child order shipping |
+| total | decimal(10,2) | Grand total |
+| status | enum | pending, payment_processing, paid, failed, cancelled |
+| currency | string(3) | EUR default |
+| order_count | tinyint | Number of child orders |
+| timestamps | | created_at, updated_at |
+
+### Modified Table: `orders`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| checkout_session_id | bigint nullable | FK to checkout_sessions |
+| is_child_order | boolean | true if part of multi-producer checkout |
+
+---
+
+## Test Results
+
+```
+✓ checkout sessions table exists
+✓ checkout sessions has required columns
+✓ orders table has checkout session columns
+✓ can create checkout session
+✓ checkout session belongs to user
+✓ checkout session has many orders
+✓ order belongs to checkout session
+✓ is multi producer returns correct value
+✓ mark as paid updates session and orders
+✓ recalculate totals sums child orders
+✓ standalone order has null checkout session
+
+Tests: 11 passed (35 assertions)
+Duration: 0.52s
+```
+
+---
+
+## Files Changed
+
+- `backend/database/migrations/2026_01_25_140000_create_checkout_sessions_table.php` (NEW)
+- `backend/database/migrations/2026_01_25_140001_add_checkout_session_id_to_orders_table.php` (NEW)
+- `backend/app/Models/CheckoutSession.php` (NEW)
+- `backend/app/Models/Order.php` (MODIFIED: +relations, +fillable)
+- `backend/tests/Unit/CheckoutSessionTest.php` (NEW)
+
+---
+
+_Pass-MP-ORDERS-SCHEMA-01 | 2026-01-25_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,29 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-25 (MP-ORDERS-SHIPPING-V1-PLAN-01)
+**Last Updated**: 2026-01-25 (MP-ORDERS-SCHEMA-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~240 lines (target ≤250). ✅
+> **Current size**: ~260 lines (target ≤250). ⚠️
+
+---
+
+## 2026-01-25 — Pass MP-ORDERS-SCHEMA-01: Schema + Model (Phase 1)
+
+**Status**: ✅ COMPLETE
+
+Phase 1 of multi-producer order splitting: Database schema and models.
+
+**Changes**:
+- NEW table: `checkout_sessions` (parent entity for multi-producer checkout)
+- NEW columns on `orders`: `checkout_session_id` FK, `is_child_order` boolean
+- NEW model: `CheckoutSession` with relations and helpers
+- MODIFIED: `Order` model with `checkoutSession()` relation
+
+**Tests**: 11 passed (35 assertions)
+
+**Evidence**:
+- Tasks: `docs/AGENT/TASKS/Pass-MP-ORDERS-SCHEMA-01.md`
+- Summary: `docs/AGENT/SUMMARY/Pass-MP-ORDERS-SCHEMA-01.md`
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 1 of multi-producer order splitting: Database schema and models for CheckoutSession parent-child architecture.

## Changes

| File | Change |
|------|--------|
| `create_checkout_sessions_table.php` | NEW migration - parent table |
| `add_checkout_session_id_to_orders_table.php` | NEW migration - FK + flag |
| `CheckoutSession.php` | NEW model with relations |
| `Order.php` | MODIFIED - added checkoutSession() |
| `CheckoutSessionTest.php` | NEW - 11 unit tests |

## Schema

```
CheckoutSession (parent)
    ├── user_id (FK)
    ├── stripe_payment_intent_id
    ├── subtotal, shipping_total, total
    ├── status (pending → paid)
    └── orders[] (hasMany)

Order (child)
    ├── checkout_session_id (FK, nullable)
    ├── is_child_order (boolean)
    └── checkoutSession() (belongsTo)
```

## Test Evidence

```
Tests: 11 passed (35 assertions)
Duration: 0.52s
```

## Test Plan

- [x] Migrations run successfully
- [x] 11 unit tests pass
- [x] Existing OrderShippingLine tests still pass (4/4)
- [x] Backward compatible (checkout_session_id nullable)

Part of: Pass-MP-ORDERS-SHIPPING-V1-PLAN-01