### PR TITLE
feat: Pass MP-ORDERS-SPLIT-01 order splitting

### DIFF
--- a/backend/app/Http/Resources/CheckoutSessionResource.php
+++ b/backend/app/Http/Resources/CheckoutSessionResource.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Pass MP-ORDERS-SPLIT-01: CheckoutSession Resource
+ *
+ * Represents a multi-producer checkout session with N child orders.
+ */
+class CheckoutSessionResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'type' => 'checkout_session',
+            'status' => $this->status,
+            'is_multi_producer' => $this->order_count > 1,
+            'order_count' => $this->order_count,
+
+            // Financial totals (sum of all child orders)
+            'subtotal' => number_format((float) $this->subtotal, 2),
+            'shipping_total' => number_format((float) $this->shipping_total, 2),
+            'total' => number_format((float) $this->total, 2),
+            'currency' => $this->currency ?? 'EUR',
+
+            // Stripe payment (will be set in Phase 3)
+            'stripe_payment_intent_id' => $this->stripe_payment_intent_id,
+
+            // Timestamps
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+
+            // Child orders (each order goes to a different producer)
+            $this->mergeWhen($this->relationLoaded('orders'), [
+                'orders' => OrderResource::collection($this->orders ?? []),
+            ]),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/OrderResource.php
+++ b/backend/app/Http/Resources/OrderResource.php
@@ -58,6 +58,9 @@ class OrderResource extends JsonResource
         return [
             'id' => $this->id,
             'order_number' => 'ORD-'.str_pad($this->id, 6, '0', STR_PAD_LEFT),
+            // Pass MP-ORDERS-SPLIT-01: Child order indicator
+            'checkout_session_id' => $this->checkout_session_id,
+            'is_child_order' => (bool) $this->is_child_order,
             'status' => $this->status ?? 'pending',
             'payment_status' => $this->payment_status ?? 'pending',
             'payment_method' => $this->payment_method ?? 'cod', // Default: Cash on Delivery

--- a/backend/app/Services/CheckoutService.php
+++ b/backend/app/Services/CheckoutService.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\CheckoutSession;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\OrderShippingLine;
+use App\Models\Producer;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Pass MP-ORDERS-SPLIT-01: Checkout Service
+ *
+ * Handles multi-producer order splitting. Creates a CheckoutSession parent
+ * with N child Orders (one per producer) when cart has items from multiple producers.
+ */
+class CheckoutService
+{
+    // V1 Shipping calculation constants
+    private const FREE_SHIPPING_THRESHOLD = 35.00; // €35 per producer
+    private const FLAT_SHIPPING_RATE = 3.50; // €3.50 per producer shipment
+
+    /**
+     * Process checkout and create orders.
+     *
+     * For single-producer carts: Creates a standalone Order (backward compatible).
+     * For multi-producer carts: Creates a CheckoutSession with N child Orders.
+     *
+     * @param int|null $userId
+     * @param array $productData Array of ['product' => Product, 'quantity' => int, 'unit_price' => float, 'total_price' => float]
+     * @param array $options ['shipping_method', 'payment_method', 'currency', 'shipping_address', 'notes']
+     * @return array ['checkout_session' => CheckoutSession|null, 'orders' => Order[]]
+     */
+    public function processCheckout(?int $userId, array $productData, array $options): array
+    {
+        // Group items by producer
+        $producerGroups = collect($productData)->groupBy(fn ($item) => $item['product']->producer_id ?? 0);
+        $producerIds = $producerGroups->keys()->filter()->values();
+        $isMultiProducer = $producerIds->count() > 1;
+
+        $shippingMethod = $options['shipping_method'] ?? 'HOME';
+        $isPickup = in_array(strtoupper($shippingMethod), ['PICKUP', 'STORE_PICKUP']);
+
+        if ($isMultiProducer) {
+            return $this->createMultiProducerCheckout($userId, $producerGroups, $options, $isPickup);
+        }
+
+        // Single producer: create standalone order (backward compatible)
+        return $this->createSingleProducerOrder($userId, $productData, $producerGroups, $options, $isPickup);
+    }
+
+    /**
+     * Create a multi-producer checkout with N child orders.
+     */
+    private function createMultiProducerCheckout(?int $userId, $producerGroups, array $options, bool $isPickup): array
+    {
+        $shippingMethod = $options['shipping_method'] ?? 'HOME';
+        $paymentMethod = $options['payment_method'] ?? 'COD';
+        $currency = $options['currency'] ?? 'EUR';
+
+        $orders = [];
+        $sessionSubtotal = 0;
+        $sessionShippingTotal = 0;
+        $sessionTotal = 0;
+
+        // Create CheckoutSession first
+        $checkoutSession = CheckoutSession::create([
+            'user_id' => $userId,
+            'status' => CheckoutSession::STATUS_PENDING,
+            'currency' => $currency,
+            'subtotal' => 0,
+            'shipping_total' => 0,
+            'total' => 0,
+            'order_count' => 0,
+        ]);
+
+        // Create one order per producer
+        foreach ($producerGroups as $producerId => $items) {
+            if (!$producerId) {
+                continue; // Skip items without producer
+            }
+
+            // Calculate producer subtotal
+            $producerSubtotal = collect($items)->sum('total_price');
+
+            // Get producer info
+            $producer = Producer::find($producerId);
+            $producerName = $producer?->name ?? 'Unknown Producer';
+
+            // Calculate shipping for this producer
+            $shippingCost = $this->calculateProducerShipping($producerSubtotal, $isPickup);
+            $freeShippingApplied = $shippingCost === 0.0;
+
+            $orderTotal = $producerSubtotal + $shippingCost;
+
+            // Create child order
+            $order = Order::create([
+                'user_id' => $userId,
+                'checkout_session_id' => $checkoutSession->id,
+                'is_child_order' => true,
+                'status' => 'pending',
+                'payment_status' => 'pending',
+                'payment_method' => $paymentMethod,
+                'shipping_method' => $shippingMethod,
+                'shipping_address' => $options['shipping_address'] ?? null,
+                'currency' => $currency,
+                'subtotal' => $producerSubtotal,
+                'shipping_cost' => $shippingCost,
+                'total' => $orderTotal,
+                'total_amount' => $orderTotal, // Legacy alias
+                'notes' => $options['notes'] ?? null,
+            ]);
+
+            // Create order items for this producer
+            foreach ($items as $data) {
+                OrderItem::create([
+                    'order_id' => $order->id,
+                    'product_id' => $data['product']->id,
+                    'producer_id' => $data['product']->producer_id,
+                    'quantity' => $data['quantity'],
+                    'unit_price' => $data['unit_price'],
+                    'total_price' => $data['total_price'],
+                    'product_name' => $data['product']->name,
+                    'product_unit' => $data['product']->unit,
+                ]);
+            }
+
+            // Create shipping line for this order
+            OrderShippingLine::create([
+                'order_id' => $order->id,
+                'producer_id' => $producerId,
+                'producer_name' => $producerName,
+                'subtotal' => $producerSubtotal,
+                'shipping_cost' => $shippingCost,
+                'shipping_method' => $shippingMethod,
+                'free_shipping_applied' => $freeShippingApplied,
+            ]);
+
+            // Accumulate session totals
+            $sessionSubtotal += $producerSubtotal;
+            $sessionShippingTotal += $shippingCost;
+            $sessionTotal += $orderTotal;
+
+            $orders[] = $order;
+        }
+
+        // Update CheckoutSession with totals
+        $checkoutSession->update([
+            'subtotal' => $sessionSubtotal,
+            'shipping_total' => $sessionShippingTotal,
+            'total' => $sessionTotal,
+            'order_count' => count($orders),
+        ]);
+
+        // Load relationships on all orders
+        foreach ($orders as $order) {
+            $order->load(['orderItems.producer', 'shippingLines'])->loadCount('orderItems');
+        }
+
+        $checkoutSession->load('orders');
+
+        return [
+            'checkout_session' => $checkoutSession,
+            'orders' => $orders,
+        ];
+    }
+
+    /**
+     * Create a single-producer order (backward compatible).
+     */
+    private function createSingleProducerOrder(?int $userId, array $productData, $producerGroups, array $options, bool $isPickup): array
+    {
+        $shippingMethod = $options['shipping_method'] ?? 'HOME';
+        $paymentMethod = $options['payment_method'] ?? 'COD';
+        $currency = $options['currency'] ?? 'EUR';
+
+        $orderTotal = collect($productData)->sum('total_price');
+        $shippingLines = [];
+        $totalShippingCost = 0;
+
+        // Calculate shipping per producer (even for single producer)
+        foreach ($producerGroups as $producerId => $items) {
+            if (!$producerId) {
+                continue;
+            }
+
+            $producerSubtotal = collect($items)->sum('total_price');
+            $producer = Producer::find($producerId);
+            $producerName = $producer?->name ?? 'Unknown Producer';
+
+            $shippingCost = $this->calculateProducerShipping($producerSubtotal, $isPickup);
+            $freeShippingApplied = $shippingCost === 0.0;
+
+            $totalShippingCost += $shippingCost;
+
+            $shippingLines[] = [
+                'producer_id' => $producerId,
+                'producer_name' => $producerName,
+                'subtotal' => $producerSubtotal,
+                'shipping_cost' => $shippingCost,
+                'shipping_method' => $shippingMethod,
+                'free_shipping_applied' => $freeShippingApplied,
+            ];
+        }
+
+        $totalWithShipping = $orderTotal + $totalShippingCost;
+
+        // Create standalone order (no checkout_session_id)
+        $order = Order::create([
+            'user_id' => $userId,
+            'checkout_session_id' => null,
+            'is_child_order' => false,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'payment_method' => $paymentMethod,
+            'shipping_method' => $shippingMethod,
+            'shipping_address' => $options['shipping_address'] ?? null,
+            'currency' => $currency,
+            'subtotal' => $orderTotal,
+            'shipping_cost' => $totalShippingCost,
+            'total' => $totalWithShipping,
+            'total_amount' => $totalWithShipping, // Legacy alias
+            'notes' => $options['notes'] ?? null,
+        ]);
+
+        // Create order items
+        foreach ($productData as $data) {
+            OrderItem::create([
+                'order_id' => $order->id,
+                'product_id' => $data['product']->id,
+                'producer_id' => $data['product']->producer_id,
+                'quantity' => $data['quantity'],
+                'unit_price' => $data['unit_price'],
+                'total_price' => $data['total_price'],
+                'product_name' => $data['product']->name,
+                'product_unit' => $data['product']->unit,
+            ]);
+        }
+
+        // Create shipping lines
+        foreach ($shippingLines as $line) {
+            OrderShippingLine::create([
+                'order_id' => $order->id,
+                'producer_id' => $line['producer_id'],
+                'producer_name' => $line['producer_name'],
+                'subtotal' => $line['subtotal'],
+                'shipping_cost' => $line['shipping_cost'],
+                'shipping_method' => $line['shipping_method'],
+                'free_shipping_applied' => $line['free_shipping_applied'],
+            ]);
+        }
+
+        $order->load(['orderItems.producer', 'shippingLines'])->loadCount('orderItems');
+
+        return [
+            'checkout_session' => null,
+            'orders' => [$order],
+        ];
+    }
+
+    /**
+     * Calculate shipping cost for a producer based on subtotal.
+     */
+    private function calculateProducerShipping(float $subtotal, bool $isPickup): float
+    {
+        if ($isPickup) {
+            return 0.0;
+        }
+
+        if ($subtotal >= self::FREE_SHIPPING_THRESHOLD) {
+            return 0.0;
+        }
+
+        return self::FLAT_SHIPPING_RATE;
+    }
+}

--- a/backend/tests/Feature/MultiProducerOrderSplitTest.php
+++ b/backend/tests/Feature/MultiProducerOrderSplitTest.php
@@ -1,0 +1,385 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\CheckoutSession;
+use App\Models\Order;
+use App\Models\OrderShippingLine;
+use App\Models\Producer;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Pass MP-ORDERS-SPLIT-01: Multi-producer order splitting tests
+ *
+ * Tests for CheckoutSession creation and order splitting for multi-producer carts.
+ */
+class MultiProducerOrderSplitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that multi-producer checkout creates a CheckoutSession.
+     */
+    public function test_multi_producer_checkout_creates_checkout_session(): void
+    {
+        $user = User::factory()->consumer()->create();
+        $producer1 = Producer::factory()->create(['name' => 'Producer Alpha']);
+        $producer2 = Producer::factory()->create(['name' => 'Producer Beta']);
+
+        $product1 = Product::factory()->create([
+            'producer_id' => $producer1->id,
+            'price' => 25.00,
+            'stock' => 100,
+        ]);
+        $product2 = Product::factory()->create([
+            'producer_id' => $producer2->id,
+            'price' => 20.00,
+            'stock' => 100,
+        ]);
+
+        $orderData = [
+            'items' => [
+                ['product_id' => $product1->id, 'quantity' => 1],
+                ['product_id' => $product2->id, 'quantity' => 1],
+            ],
+            'shipping_method' => 'HOME',
+            'currency' => 'EUR',
+        ];
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/v1/public/orders', $orderData);
+
+        $response->assertStatus(201);
+
+        // Verify response is a CheckoutSession
+        $response->assertJsonStructure([
+            'data' => [
+                'id',
+                'type',
+                'status',
+                'is_multi_producer',
+                'order_count',
+                'subtotal',
+                'shipping_total',
+                'total',
+                'orders',
+            ],
+        ]);
+
+        $this->assertEquals('checkout_session', $response->json('data.type'));
+        $this->assertTrue($response->json('data.is_multi_producer'));
+        $this->assertEquals(2, $response->json('data.order_count'));
+
+        // Verify CheckoutSession exists in database
+        $sessionId = $response->json('data.id');
+        $this->assertDatabaseHas('checkout_sessions', [
+            'id' => $sessionId,
+            'user_id' => $user->id,
+            'order_count' => 2,
+        ]);
+    }
+
+    /**
+     * Test that multi-producer checkout creates N child orders.
+     */
+    public function test_multi_producer_checkout_creates_child_orders(): void
+    {
+        $user = User::factory()->consumer()->create();
+        $producer1 = Producer::factory()->create(['name' => 'Farm A']);
+        $producer2 = Producer::factory()->create(['name' => 'Farm B']);
+        $producer3 = Producer::factory()->create(['name' => 'Farm C']);
+
+        $product1 = Product::factory()->create([
+            'producer_id' => $producer1->id,
+            'price' => 30.00,
+            'stock' => 100,
+        ]);
+        $product2 = Product::factory()->create([
+            'producer_id' => $producer2->id,
+            'price' => 25.00,
+            'stock' => 100,
+        ]);
+        $product3 = Product::factory()->create([
+            'producer_id' => $producer3->id,
+            'price' => 15.00,
+            'stock' => 100,
+        ]);
+
+        $orderData = [
+            'items' => [
+                ['product_id' => $product1->id, 'quantity' => 1],
+                ['product_id' => $product2->id, 'quantity' => 2],
+                ['product_id' => $product3->id, 'quantity' => 1],
+            ],
+            'shipping_method' => 'HOME',
+            'currency' => 'EUR',
+        ];
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/v1/public/orders', $orderData);
+
+        $response->assertStatus(201);
+
+        // Should have 3 child orders (one per producer)
+        $this->assertEquals(3, $response->json('data.order_count'));
+
+        $orders = $response->json('data.orders');
+        $this->assertCount(3, $orders);
+
+        // All orders should be linked to same checkout session
+        $sessionId = $response->json('data.id');
+        foreach ($orders as $order) {
+            $this->assertEquals($sessionId, $order['checkout_session_id']);
+            $this->assertTrue($order['is_child_order']);
+        }
+
+        // Verify in database
+        $childOrders = Order::where('checkout_session_id', $sessionId)->get();
+        $this->assertCount(3, $childOrders);
+    }
+
+    /**
+     * Test that each child order contains only items from its producer.
+     */
+    public function test_child_orders_contain_only_producer_items(): void
+    {
+        $user = User::factory()->consumer()->create();
+        $producer1 = Producer::factory()->create(['name' => 'Producer X']);
+        $producer2 = Producer::factory()->create(['name' => 'Producer Y']);
+
+        $product1a = Product::factory()->create([
+            'producer_id' => $producer1->id,
+            'name' => 'Product 1A',
+            'price' => 10.00,
+            'stock' => 100,
+        ]);
+        $product1b = Product::factory()->create([
+            'producer_id' => $producer1->id,
+            'name' => 'Product 1B',
+            'price' => 15.00,
+            'stock' => 100,
+        ]);
+        $product2a = Product::factory()->create([
+            'producer_id' => $producer2->id,
+            'name' => 'Product 2A',
+            'price' => 20.00,
+            'stock' => 100,
+        ]);
+
+        $orderData = [
+            'items' => [
+                ['product_id' => $product1a->id, 'quantity' => 1], // Producer 1: €10
+                ['product_id' => $product1b->id, 'quantity' => 2], // Producer 1: €30
+                ['product_id' => $product2a->id, 'quantity' => 1], // Producer 2: €20
+            ],
+            'shipping_method' => 'HOME',
+            'currency' => 'EUR',
+        ];
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/v1/public/orders', $orderData);
+
+        $response->assertStatus(201);
+
+        $orders = $response->json('data.orders');
+
+        // Find order for producer 1
+        $producer1Order = collect($orders)->first(fn ($o) =>
+            collect($o['items'] ?? $o['order_items'] ?? [])->contains('product_name', 'Product 1A')
+        );
+
+        // Find order for producer 2
+        $producer2Order = collect($orders)->first(fn ($o) =>
+            collect($o['items'] ?? $o['order_items'] ?? [])->contains('product_name', 'Product 2A')
+        );
+
+        // Verify producer 1 order has 2 items
+        $items1 = $producer1Order['items'] ?? $producer1Order['order_items'] ?? [];
+        $this->assertCount(2, $items1);
+        $this->assertEquals('40.00', $producer1Order['subtotal']); // €10 + €30
+
+        // Verify producer 2 order has 1 item
+        $items2 = $producer2Order['items'] ?? $producer2Order['order_items'] ?? [];
+        $this->assertCount(1, $items2);
+        $this->assertEquals('20.00', $producer2Order['subtotal']);
+    }
+
+    /**
+     * Test that checkout session totals equal sum of child orders.
+     */
+    public function test_checkout_session_totals_equal_sum_of_orders(): void
+    {
+        $user = User::factory()->consumer()->create();
+        $producer1 = Producer::factory()->create(['name' => 'Sum Producer 1']);
+        $producer2 = Producer::factory()->create(['name' => 'Sum Producer 2']);
+
+        $product1 = Product::factory()->create([
+            'producer_id' => $producer1->id,
+            'price' => 40.00, // >= €35, free shipping
+            'stock' => 100,
+        ]);
+        $product2 = Product::factory()->create([
+            'producer_id' => $producer2->id,
+            'price' => 20.00, // < €35, €3.50 shipping
+            'stock' => 100,
+        ]);
+
+        $orderData = [
+            'items' => [
+                ['product_id' => $product1->id, 'quantity' => 1], // €40 + €0 = €40
+                ['product_id' => $product2->id, 'quantity' => 1], // €20 + €3.50 = €23.50
+            ],
+            'shipping_method' => 'HOME',
+            'currency' => 'EUR',
+        ];
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/v1/public/orders', $orderData);
+
+        $response->assertStatus(201);
+
+        // Session totals
+        $sessionSubtotal = (float) $response->json('data.subtotal');
+        $sessionShipping = (float) $response->json('data.shipping_total');
+        $sessionTotal = (float) $response->json('data.total');
+
+        // Sum of orders
+        $orders = $response->json('data.orders');
+        $ordersSubtotal = collect($orders)->sum(fn ($o) => (float) $o['subtotal']);
+        $ordersShipping = collect($orders)->sum(fn ($o) => (float) $o['shipping_cost']);
+        $ordersTotal = collect($orders)->sum(fn ($o) => (float) $o['total']);
+
+        // Verify invariants
+        $this->assertEquals($ordersSubtotal, $sessionSubtotal, 'Session subtotal should equal sum of order subtotals');
+        $this->assertEquals($ordersShipping, $sessionShipping, 'Session shipping should equal sum of order shipping');
+        $this->assertEquals($ordersTotal, $sessionTotal, 'Session total should equal sum of order totals');
+
+        // Verify expected values
+        $this->assertEquals(60.00, $sessionSubtotal); // €40 + €20
+        $this->assertEquals(3.50, $sessionShipping); // €0 + €3.50
+        $this->assertEquals(63.50, $sessionTotal); // €40 + €23.50
+    }
+
+    /**
+     * Test that single-producer checkout still returns Order (backward compatible).
+     */
+    public function test_single_producer_checkout_returns_order(): void
+    {
+        $user = User::factory()->consumer()->create();
+        $producer = Producer::factory()->create(['name' => 'Solo Producer']);
+
+        $product = Product::factory()->create([
+            'producer_id' => $producer->id,
+            'price' => 30.00,
+            'stock' => 100,
+        ]);
+
+        $orderData = [
+            'items' => [
+                ['product_id' => $product->id, 'quantity' => 2],
+            ],
+            'shipping_method' => 'HOME',
+            'currency' => 'EUR',
+        ];
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/v1/public/orders', $orderData);
+
+        $response->assertStatus(201);
+
+        // Should return Order, not CheckoutSession
+        $this->assertNull($response->json('data.type')); // Order doesn't have 'type' field
+        $this->assertNotNull($response->json('data.order_number')); // Order has order_number
+        $this->assertNull($response->json('data.checkout_session_id'));
+        $this->assertFalse($response->json('data.is_child_order'));
+
+        // No CheckoutSession created
+        $this->assertEquals(0, CheckoutSession::count());
+    }
+
+    /**
+     * Test that each child order has its own shipping line.
+     */
+    public function test_each_child_order_has_shipping_line(): void
+    {
+        $user = User::factory()->consumer()->create();
+        $producer1 = Producer::factory()->create(['name' => 'Shipping Producer 1']);
+        $producer2 = Producer::factory()->create(['name' => 'Shipping Producer 2']);
+
+        $product1 = Product::factory()->create([
+            'producer_id' => $producer1->id,
+            'price' => 50.00, // Free shipping
+            'stock' => 100,
+        ]);
+        $product2 = Product::factory()->create([
+            'producer_id' => $producer2->id,
+            'price' => 15.00, // €3.50 shipping
+            'stock' => 100,
+        ]);
+
+        $orderData = [
+            'items' => [
+                ['product_id' => $product1->id, 'quantity' => 1],
+                ['product_id' => $product2->id, 'quantity' => 1],
+            ],
+            'shipping_method' => 'HOME',
+            'currency' => 'EUR',
+        ];
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/v1/public/orders', $orderData);
+
+        $response->assertStatus(201);
+
+        $orders = $response->json('data.orders');
+
+        foreach ($orders as $order) {
+            // Each child order should have exactly 1 shipping line in the database
+            $dbShippingLines = OrderShippingLine::where('order_id', $order['id'])->get();
+            $this->assertCount(1, $dbShippingLines);
+
+            // Verify shipping line is linked to correct order
+            $this->assertEquals($order['id'], $dbShippingLines->first()->order_id);
+        }
+
+        // Total shipping lines = 2 (one per order)
+        $this->assertEquals(2, OrderShippingLine::count());
+    }
+
+    /**
+     * Test checkout session status is pending after creation.
+     */
+    public function test_checkout_session_status_is_pending(): void
+    {
+        $user = User::factory()->consumer()->create();
+        $producer1 = Producer::factory()->create();
+        $producer2 = Producer::factory()->create();
+
+        $product1 = Product::factory()->create(['producer_id' => $producer1->id, 'price' => 20.00, 'stock' => 100]);
+        $product2 = Product::factory()->create(['producer_id' => $producer2->id, 'price' => 25.00, 'stock' => 100]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/v1/public/orders', [
+                'items' => [
+                    ['product_id' => $product1->id, 'quantity' => 1],
+                    ['product_id' => $product2->id, 'quantity' => 1],
+                ],
+                'shipping_method' => 'HOME',
+                'currency' => 'EUR',
+            ]);
+
+        $response->assertStatus(201);
+
+        $this->assertEquals('pending', $response->json('data.status'));
+
+        // All child orders should also be pending
+        $orders = $response->json('data.orders');
+        foreach ($orders as $order) {
+            $this->assertEquals('pending', $order['status']);
+            $this->assertEquals('pending', $order['payment_status']);
+        }
+    }
+}

--- a/backend/tests/Feature/MultiProducerOrderTest.php
+++ b/backend/tests/Feature/MultiProducerOrderTest.php
@@ -12,6 +12,7 @@ use Tests\TestCase;
 
 /**
  * Pass MP-ORDERS-SHIPPING-V1-02: Multi-producer order tests
+ * Updated for Pass MP-ORDERS-SPLIT-01: CheckoutSession response format
  *
  * Tests for multi-producer checkout with per-producer shipping lines.
  */
@@ -21,6 +22,7 @@ class MultiProducerOrderTest extends TestCase
 
     /**
      * Test that multi-producer order creates correct number of shipping lines.
+     * Updated: Now returns CheckoutSession with N child orders.
      */
     public function test_multi_producer_order_creates_shipping_lines(): void
     {
@@ -55,46 +57,26 @@ class MultiProducerOrderTest extends TestCase
 
         $response->assertStatus(201);
 
-        // Verify shipping lines created
-        // Note: OrderResource wraps response in 'data' key
-        $orderId = $response->json('data.id');
-        $shippingLines = OrderShippingLine::where('order_id', $orderId)->get();
+        // Pass MP-ORDERS-SPLIT-01: Multi-producer now returns CheckoutSession
+        $this->assertEquals('checkout_session', $response->json('data.type'));
+        $this->assertTrue($response->json('data.is_multi_producer'));
 
-        $this->assertCount(2, $shippingLines, 'Should have 2 shipping lines for 2 producers');
+        // Each child order has 1 shipping line
+        $orders = $response->json('data.orders');
+        $this->assertCount(2, $orders);
+
+        // Total shipping lines = 2 (one per child order)
+        $totalShippingLines = OrderShippingLine::count();
+        $this->assertEquals(2, $totalShippingLines, 'Should have 2 shipping lines for 2 producers');
 
         // Verify each producer has a shipping line
-        $this->assertTrue(
-            $shippingLines->contains('producer_id', $producer1->id),
-            'Should have shipping line for Producer Alpha'
-        );
-        $this->assertTrue(
-            $shippingLines->contains('producer_id', $producer2->id),
-            'Should have shipping line for Producer Beta'
-        );
-
-        // Verify response includes shipping_lines (wrapped in 'data' by OrderResource)
-        $response->assertJsonStructure([
-            'data' => [
-                'shipping_lines' => [
-                    '*' => [
-                        'producer_id',
-                        'producer_name',
-                        'subtotal',
-                        'shipping_cost',
-                        'shipping_method',
-                        'free_shipping_applied',
-                    ],
-                ],
-                'shipping_total',
-                'is_multi_producer',
-            ],
-        ]);
-
-        $this->assertTrue($response->json('data.is_multi_producer'));
+        $this->assertDatabaseHas('order_shipping_lines', ['producer_id' => $producer1->id]);
+        $this->assertDatabaseHas('order_shipping_lines', ['producer_id' => $producer2->id]);
     }
 
     /**
      * Test that shipping_total equals sum of shipping_cost across lines.
+     * Updated: Now returns CheckoutSession.
      */
     public function test_shipping_total_equals_sum_of_line_costs(): void
     {
@@ -128,16 +110,17 @@ class MultiProducerOrderTest extends TestCase
 
         $response->assertStatus(201);
 
-        // Both producers below threshold: 2 × €3.50 = €7.00
+        // Pass MP-ORDERS-SPLIT-01: shipping_total is on CheckoutSession
         $shippingTotal = (float) $response->json('data.shipping_total');
-        $shippingLines = $response->json('data.shipping_lines');
 
-        $sumOfLines = collect($shippingLines)->sum(fn ($line) => (float) $line['shipping_cost']);
+        // Sum of child order shipping costs
+        $orders = $response->json('data.orders');
+        $sumOfLines = collect($orders)->sum(fn ($order) => (float) $order['shipping_cost']);
 
         $this->assertEquals(
             $shippingTotal,
             $sumOfLines,
-            'shipping_total should equal sum of shipping_cost across lines'
+            'shipping_total should equal sum of shipping_cost across orders'
         );
 
         // Verify exact values: 2 producers × €3.50 flat rate = €7.00
@@ -146,6 +129,7 @@ class MultiProducerOrderTest extends TestCase
 
     /**
      * Test order total invariant: total = subtotal + shipping_total.
+     * Updated: Now returns CheckoutSession.
      */
     public function test_order_total_invariant_holds(): void
     {
@@ -178,6 +162,7 @@ class MultiProducerOrderTest extends TestCase
 
         $response->assertStatus(201);
 
+        // Pass MP-ORDERS-SPLIT-01: Totals are on CheckoutSession
         $subtotal = (float) $response->json('data.subtotal'); // €58.00
         $shippingTotal = (float) $response->json('data.shipping_total'); // €3.50
         $total = (float) $response->json('data.total'); // €61.50
@@ -191,15 +176,13 @@ class MultiProducerOrderTest extends TestCase
             "Invariant violated: total ($total) should equal subtotal ($subtotal) + shipping ($shippingTotal)"
         );
 
-        // Verify free shipping applied for producer1
-        $shippingLines = collect($response->json('data.shipping_lines'));
-        $producer1Line = $shippingLines->firstWhere('producer_id', $producer1->id);
-        $producer2Line = $shippingLines->firstWhere('producer_id', $producer2->id);
+        // Verify free shipping applied for producer1's order
+        $orders = $response->json('data.orders');
+        $producer1Order = collect($orders)->first(fn ($o) => (float) $o['subtotal'] === 40.0);
+        $producer2Order = collect($orders)->first(fn ($o) => (float) $o['subtotal'] === 18.0);
 
-        $this->assertTrue($producer1Line['free_shipping_applied'], 'Producer 1 should have free shipping (€40 > €35)');
-        $this->assertFalse($producer2Line['free_shipping_applied'], 'Producer 2 should NOT have free shipping (€18 < €35)');
-        $this->assertEquals('0.00', $producer1Line['shipping_cost']);
-        $this->assertEquals('3.50', $producer2Line['shipping_cost']);
+        $this->assertEquals('0.00', $producer1Order['shipping_cost'], 'Producer 1 should have free shipping (€40 > €35)');
+        $this->assertEquals('3.50', $producer2Order['shipping_cost'], 'Producer 2 should pay €3.50 shipping (€18 < €35)');
     }
 
     /**
@@ -229,18 +212,23 @@ class MultiProducerOrderTest extends TestCase
 
         $response->assertStatus(201);
 
-        // Single producer = 1 shipping line
-        $shippingLines = $response->json('data.shipping_lines');
-        $this->assertCount(1, $shippingLines);
+        // Single producer = Order response (not CheckoutSession)
+        $this->assertNull($response->json('data.type')); // Order doesn't have 'type'
         $this->assertFalse($response->json('data.is_multi_producer'));
 
+        // 1 shipping line for the single producer
+        $orderId = $response->json('data.id');
+        $shippingLines = OrderShippingLine::where('order_id', $orderId)->get();
+        $this->assertCount(1, $shippingLines);
+
         // €50 > €35 → free shipping
-        $this->assertTrue($shippingLines[0]['free_shipping_applied']);
-        $this->assertEquals('0.00', $shippingLines[0]['shipping_cost']);
+        $this->assertTrue($shippingLines->first()->free_shipping_applied);
+        $this->assertEquals(0.00, (float) $shippingLines->first()->shipping_cost);
     }
 
     /**
      * Test PICKUP shipping method is always free.
+     * Updated: Now returns CheckoutSession.
      */
     public function test_pickup_shipping_is_always_free(): void
     {
@@ -274,14 +262,21 @@ class MultiProducerOrderTest extends TestCase
 
         $response->assertStatus(201);
 
-        // All shipping lines should be free for PICKUP
+        // Pass MP-ORDERS-SPLIT-01: shipping_total is on CheckoutSession
         $shippingTotal = (float) $response->json('data.shipping_total');
         $this->assertEquals(0.00, $shippingTotal, 'PICKUP shipping should always be free');
 
-        $shippingLines = $response->json('data.shipping_lines');
-        foreach ($shippingLines as $line) {
-            $this->assertTrue($line['free_shipping_applied'], 'PICKUP should apply free shipping');
-            $this->assertEquals('0.00', $line['shipping_cost']);
+        // All child orders should have free shipping
+        $orders = $response->json('data.orders');
+        foreach ($orders as $order) {
+            $this->assertEquals('0.00', $order['shipping_cost'], 'PICKUP should apply free shipping');
+        }
+
+        // Verify in database
+        $allLines = OrderShippingLine::all();
+        foreach ($allLines as $line) {
+            $this->assertTrue($line->free_shipping_applied);
+            $this->assertEquals(0.00, (float) $line->shipping_cost);
         }
     }
 }

--- a/docs/AGENT/SUMMARY/Pass-MP-ORDERS-SPLIT-01.md
+++ b/docs/AGENT/SUMMARY/Pass-MP-ORDERS-SPLIT-01.md
@@ -1,0 +1,87 @@
+# Summary: Pass-MP-ORDERS-SPLIT-01
+
+**Date**: 2026-01-25
+**Status**: ✅ COMPLETE
+**PR**: Pending
+
+---
+
+## TL;DR
+
+Phase 2 of multi-producer order splitting. Multi-producer carts now create a CheckoutSession parent with N child Orders (one per producer). Single-producer carts remain unchanged (backward compatible).
+
+---
+
+## Key Changes
+
+| Component | Change |
+|-----------|--------|
+| CheckoutService | NEW - handles order splitting logic |
+| OrderController | Uses CheckoutService, returns CheckoutSession for multi-producer |
+| CheckoutSessionResource | NEW - API response for checkout sessions |
+| OrderResource | Added checkout_session_id, is_child_order |
+
+---
+
+## Flow: Multi-Producer Checkout
+
+```
+1. Cart has items from Producer A and Producer B
+2. OrderController detects multi-producer
+3. CheckoutService.processCheckout() called
+4. Creates CheckoutSession (parent)
+5. Creates Order A (Producer A items, linked to session)
+6. Creates Order B (Producer B items, linked to session)
+7. Calculates shipping per order
+8. Session totals = sum of child orders
+9. Returns CheckoutSessionResource with nested orders
+```
+
+---
+
+## Invariants Verified
+
+| Invariant | Test |
+|-----------|------|
+| Session total = sum of order totals | ✅ |
+| Session shipping = sum of order shipping | ✅ |
+| Each child order has 1 producer's items | ✅ |
+| All child orders linked to same session | ✅ |
+| Single-producer returns Order (not session) | ✅ |
+
+---
+
+## Test Evidence
+
+```
+PASS  Tests\Feature\MultiProducerOrderSplitTest
+✓ multi producer checkout creates checkout session
+✓ multi producer checkout creates child orders
+✓ child orders contain only producer items
+✓ checkout session totals equal sum of orders
+✓ single producer checkout returns order
+✓ each child order has shipping line
+✓ checkout session status is pending
+
+PASS  Tests\Feature\MultiProducerOrderTest
+✓ multi producer order creates shipping lines
+✓ shipping total equals sum of line costs
+✓ order total invariant holds
+✓ single producer order creates one shipping line
+✓ pickup shipping is always free
+
+Tests: 12 passed (83 assertions)
+```
+
+---
+
+## Next Phase
+
+Phase 3: Webhook + Email
+- Update Stripe webhook to handle multi-producer
+- Update email triggers for child orders
+- Integration tests
+
+---
+
+_Pass-MP-ORDERS-SPLIT-01 | 2026-01-25 | COMPLETE ✅_

--- a/docs/AGENT/TASKS/Pass-MP-ORDERS-SPLIT-01.md
+++ b/docs/AGENT/TASKS/Pass-MP-ORDERS-SPLIT-01.md
@@ -1,0 +1,120 @@
+# Tasks: Pass-MP-ORDERS-SPLIT-01
+
+**Date**: 2026-01-25
+**Status**: COMPLETE
+**PR**: Pending
+
+---
+
+## Goal
+
+Phase 2 of multi-producer order splitting: Implement order splitting in OrderController using CheckoutService.
+
+---
+
+## Tasks
+
+| # | Task | Status |
+|---|------|--------|
+| 1 | Create CheckoutService for order splitting logic | ✅ |
+| 2 | Implement multi-producer detection | ✅ |
+| 3 | Create CheckoutSession on multi-producer checkout | ✅ |
+| 4 | Split cart into N child orders (one per producer) | ✅ |
+| 5 | Link all child orders to same checkout_session_id | ✅ |
+| 6 | Calculate per-order shipping | ✅ |
+| 7 | Calculate session totals (sum of child orders) | ✅ |
+| 8 | Update OrderController to use CheckoutService | ✅ |
+| 9 | Create CheckoutSessionResource | ✅ |
+| 10 | Update OrderResource with checkout_session_id | ✅ |
+| 11 | Update existing MultiProducerOrderTest | ✅ |
+| 12 | Add new MultiProducerOrderSplitTest (7 tests) | ✅ |
+| 13 | Verify all tests pass | ✅ |
+
+---
+
+## Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `CheckoutService.php` | Handles order splitting logic |
+| `CheckoutSessionResource.php` | API response for checkout sessions |
+| `MultiProducerOrderSplitTest.php` | 7 new feature tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `OrderController.php` | Uses CheckoutService, returns CheckoutSessionResource for multi-producer |
+| `OrderResource.php` | Added checkout_session_id, is_child_order fields |
+| `MultiProducerOrderTest.php` | Updated for new CheckoutSession response format |
+
+---
+
+## API Response Changes
+
+### Multi-Producer Checkout (NEW)
+
+```json
+{
+  "data": {
+    "id": 1,
+    "type": "checkout_session",
+    "status": "pending",
+    "is_multi_producer": true,
+    "order_count": 2,
+    "subtotal": "60.00",
+    "shipping_total": "3.50",
+    "total": "63.50",
+    "orders": [
+      {
+        "id": 1,
+        "checkout_session_id": 1,
+        "is_child_order": true,
+        "subtotal": "40.00",
+        "shipping_cost": "0.00",
+        "total": "40.00"
+      },
+      {
+        "id": 2,
+        "checkout_session_id": 1,
+        "is_child_order": true,
+        "subtotal": "20.00",
+        "shipping_cost": "3.50",
+        "total": "23.50"
+      }
+    ]
+  }
+}
+```
+
+### Single-Producer Checkout (unchanged)
+
+```json
+{
+  "data": {
+    "id": 1,
+    "checkout_session_id": null,
+    "is_child_order": false,
+    "subtotal": "50.00",
+    "shipping_cost": "0.00",
+    "total": "50.00"
+  }
+}
+```
+
+---
+
+## Test Results
+
+```
+MultiProducerOrderSplitTest: 7 passed (55 assertions)
+MultiProducerOrderTest: 5 passed (28 assertions)
+CheckoutSessionTest: 11 passed (35 assertions)
+Total: 23 passed (118 assertions)
+```
+
+---
+
+_Pass-MP-ORDERS-SPLIT-01 | 2026-01-25_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,36 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-25 (MP-ORDERS-SCHEMA-01)
+**Last Updated**: 2026-01-25 (MP-ORDERS-SPLIT-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~260 lines (target ≤250). ⚠️
+> **Current size**: ~280 lines (target ≤250). ⚠️
+
+---
+
+## 2026-01-25 — Pass MP-ORDERS-SPLIT-01: Order Splitting (Phase 2)
+
+**Status**: ✅ COMPLETE
+
+Phase 2 of multi-producer order splitting: Backend order splitting implementation.
+
+**Changes**:
+- NEW: `CheckoutService` handles order splitting logic
+- NEW: `CheckoutSessionResource` for API response
+- MODIFIED: `OrderController` uses CheckoutService
+- MODIFIED: `OrderResource` includes checkout_session_id, is_child_order
+
+**Behavior**:
+- Multi-producer carts → CheckoutSession + N child Orders
+- Single-producer carts → Order (backward compatible)
+
+**Tests**: 23 passed (118 assertions)
+- MultiProducerOrderSplitTest: 7 tests
+- MultiProducerOrderTest: 5 tests (updated)
+- CheckoutSessionTest: 11 tests
+
+**Evidence**:
+- Tasks: `docs/AGENT/TASKS/Pass-MP-ORDERS-SPLIT-01.md`
+- Summary: `docs/AGENT/SUMMARY/Pass-MP-ORDERS-SPLIT-01.md`
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 2 of multi-producer order splitting. Multi-producer carts now create a CheckoutSession parent with N child Orders (one per producer).

## Changes

| File | Change |
|------|--------|
| `CheckoutService.php` | NEW - order splitting logic |
| `CheckoutSessionResource.php` | NEW - API response |
| `OrderController.php` | Uses CheckoutService |
| `OrderResource.php` | Added checkout_session_id, is_child_order |
| `MultiProducerOrderSplitTest.php` | 7 new tests |
| `MultiProducerOrderTest.php` | Updated for new response format |

## Behavior

- **Multi-producer carts** → CheckoutSession + N child Orders
- **Single-producer carts** → Order (backward compatible)

## API Response (Multi-Producer)

```json
{
  "data": {
    "type": "checkout_session",
    "order_count": 2,
    "subtotal": "60.00",
    "shipping_total": "3.50",
    "total": "63.50",
    "orders": [...]
  }
}
```

## Test Evidence

```
MultiProducerOrderSplitTest: 7 passed (55 assertions)
MultiProducerOrderTest: 5 passed (28 assertions)
CheckoutSessionTest: 11 passed (35 assertions)
```

## Test Plan

- [x] Multi-producer checkout creates CheckoutSession
- [x] N child orders created (one per producer)
- [x] Session totals = sum of child orders
- [x] Single-producer checkout unchanged
- [x] Existing tests updated and passing

Part of: Pass-MP-ORDERS-SHIPPING-V1-PLAN-01