### PR TITLE
docs: Pass ORDERS-500-HYDRATION-01 completion docs

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-ORDERS-500-HYDRATION-01.md
+++ b/docs/AGENT/SUMMARY/Pass-ORDERS-500-HYDRATION-01.md
@@ -1,0 +1,70 @@
+# Summary: Pass-ORDERS-500-HYDRATION-01
+
+**Date**: 2026-01-25
+**Status**: COMPLETE
+**PR**: #2482
+
+---
+
+## TL;DR
+
+Fixed 500 error on `/api/v1/public/orders` by correcting the path in `vps-migrate.yml` and running pending database migrations on production.
+
+---
+
+## Problem
+
+`GET https://dixis.gr/api/v1/public/orders` returned HTTP 500 with an HTML error page. This caused:
+- React hydration errors (#418) on frontend
+- Potential auth redirect loops when orders page tried to fetch data
+
+---
+
+## Root Cause
+
+The `vps-migrate.yml` GitHub workflow used the wrong backend path:
+- **Wrong**: `/var/www/dixis/backend`
+- **Correct**: `/var/www/dixis/current/backend`
+
+This mismatch meant that migrations from the multi-producer checkout feature (PRs #2456, #2476, #2477) were never applied to production, even though the code was deployed.
+
+**Missing schema elements**:
+- `order_shipping_lines` table (for per-producer shipping)
+- `checkout_sessions` table (for multi-producer parent entity)
+- `orders.checkout_session_id` column (FK to checkout session)
+- `orders.is_child_order` column (child order flag)
+
+When `OrderController@index` tried to eager-load the `shippingLines` relation or `OrderResource` tried to access `checkout_session_id`, the database threw an error because those tables/columns didn't exist.
+
+---
+
+## Solution
+
+1. **PR #2482**: Changed path in `vps-migrate.yml` (2 occurrences)
+2. **Ran vps-migrate workflow**: Applied 3 pending migrations to production
+
+---
+
+## Evidence
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Pending migrations | 3 | 0 |
+| `GET /api/v1/public/orders` | HTTP 500 | HTTP 200 |
+| Response type | HTML error | JSON |
+
+**Migration batch**: All 3 migrations ran as batch 7 in ~315ms total.
+
+---
+
+## Prevention
+
+The path mismatch existed because:
+1. `deploy-backend.yml` uses `/var/www/dixis/current/backend` (correct)
+2. `vps-migrate.yml` was created separately and used old path
+
+Going forward, any new VPS workflows should reference the canonical path from `deploy-backend.yml`.
+
+---
+
+_Pass-ORDERS-500-HYDRATION-01 | 2026-01-25 | COMPLETE_

--- a/docs/AGENT/TASKS/Pass-ORDERS-500-HYDRATION-01.md
+++ b/docs/AGENT/TASKS/Pass-ORDERS-500-HYDRATION-01.md
@@ -1,0 +1,90 @@
+# Tasks: Pass-ORDERS-500-HYDRATION-01
+
+**Date**: 2026-01-25
+**Status**: COMPLETE
+**PR**: #2482
+
+---
+
+## Goal
+
+Fix 500 error on `GET /api/v1/public/orders` endpoint caused by missing database migrations.
+
+---
+
+## Tasks
+
+| # | Task | Status |
+|---|------|--------|
+| 1 | Identify root cause of 500 error | DONE |
+| 2 | Fix vps-migrate.yml path | DONE |
+| 3 | Create PR #2482 | DONE |
+| 4 | Merge PR | DONE |
+| 5 | Run migrate:status (before) | DONE |
+| 6 | Run migrate --force | DONE |
+| 7 | Run migrate:status (after) | DONE |
+| 8 | Verify endpoint returns 200 | DONE |
+| 9 | Update STATE.md | DONE |
+| 10 | Create pass documentation | DONE |
+
+---
+
+## Root Cause Analysis
+
+**Symptom**: `GET https://dixis.gr/api/v1/public/orders` → 500 Internal Server Error (HTML)
+
+**Investigation**:
+1. Checked `OrderController@index` - eager loads `shippingLines` relation
+2. Checked `OrderResource` - accesses `checkout_session_id`, `is_child_order`
+3. Found 3 migrations from Jan 24-25 were PENDING on production
+4. Found `vps-migrate.yml` uses wrong path: `/var/www/dixis/backend`
+5. Actual backend path: `/var/www/dixis/current/backend`
+
+**Root Cause**: Workflow path mismatch prevented migrations from running.
+
+---
+
+## Changes
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `.github/workflows/vps-migrate.yml` | Fixed path: `/var/www/dixis/backend` → `/var/www/dixis/current/backend` |
+
+---
+
+## Evidence
+
+### Before Migration
+```
+2026_01_24_130000_create_order_shipping_lines_table ................ Pending
+2026_01_25_140000_create_checkout_sessions_table ................... Pending
+2026_01_25_140001_add_checkout_session_id_to_orders_table .......... Pending
+```
+
+### Migration Output
+```
+2026_01_24_130000_create_order_shipping_lines_table .......... 207.46ms DONE
+2026_01_25_140000_create_checkout_sessions_table .............. 56.85ms DONE
+2026_01_25_140001_add_checkout_session_id_to_orders_table ..... 50.67ms DONE
+```
+
+### After Migration
+```
+2026_01_24_130000_create_order_shipping_lines_table ................ [7] Ran
+2026_01_25_140000_create_checkout_sessions_table ................... [7] Ran
+2026_01_25_140001_add_checkout_session_id_to_orders_table .......... [7] Ran
+```
+
+### Endpoint Verification
+```
+curl -i https://dixis.gr/api/v1/public/orders
+HTTP/1.1 200 OK
+Content-Type: application/json
+{"data":[{"id":103,"order_number":"ORD-000103","checkout_session_id":null,...}],...}
+```
+
+---
+
+_Pass-ORDERS-500-HYDRATION-01 | 2026-01-25_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,38 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-25 (PROD-DEPLOY-VERIFY-01)
+**Last Updated**: 2026-01-25 (ORDERS-500-HYDRATION-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~370 lines (target ≤250). ⚠️
+> **Current size**: ~400 lines (target ≤250). ⚠️
+
+---
+
+## 2026-01-25 — Pass ORDERS-500-HYDRATION-01: Fix Orders Endpoint 500 Error
+
+**Status**: ✅ FIXED
+
+**Incident**: `GET /api/v1/public/orders` returned HTTP 500 with HTML error page instead of JSON.
+
+**Root Cause**: `vps-migrate.yml` workflow used wrong path `/var/www/dixis/backend` instead of `/var/www/dixis/current/backend`. Migrations from multi-producer checkout (PR #2456, #2476, #2477) never ran on production.
+
+**Missing Tables/Columns**:
+- `order_shipping_lines` table
+- `checkout_sessions` table
+- `orders.checkout_session_id` column
+- `orders.is_child_order` column
+
+**Fix**:
+- PR #2482: Corrected path in `vps-migrate.yml`
+- Ran `vps-migrate` workflow with `migrate` action
+
+**Evidence**:
+- Before: 3 migrations PENDING
+- After: All migrations RAN (batch 7)
+- `curl https://dixis.gr/api/v1/public/orders` → HTTP 200 + valid JSON
+
+**Docs**:
+- Tasks: `docs/AGENT/TASKS/Pass-ORDERS-500-HYDRATION-01.md`
+- Summary: `docs/AGENT/SUMMARY/Pass-ORDERS-500-HYDRATION-01.md`
 
 ---
 


### PR DESCRIPTION
## Summary
Documentation for Pass ORDERS-500-HYDRATION-01 which fixed the 500 error on `/api/v1/public/orders`.

## Files
- `docs/OPS/STATE.md` - Added pass entry
- `docs/AGENT/TASKS/Pass-ORDERS-500-HYDRATION-01.md` - Task checklist
- `docs/AGENT/SUMMARY/Pass-ORDERS-500-HYDRATION-01.md` - Root cause & fix

## Related
- PR #2482 (workflow fix)

---
Pass: ORDERS-500-HYDRATION-01