### PR TITLE
docs: Complete Pass-PROD-CHECKOUT-SAFETY-01 + create Pass-STRIPE-CARD-E2E-01

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-PROD-CHECKOUT-SAFETY-01.md
+++ b/docs/AGENT/SUMMARY/Pass-PROD-CHECKOUT-SAFETY-01.md
@@ -1,0 +1,44 @@
+# Pass-PROD-CHECKOUT-SAFETY-01 Summary
+
+**Status**: ✅ COMPLETE | **PR**: #2488 | **Commit**: `7b0eca26` | **Date**: 2026-01-26
+
+## What
+
+Fixed multi-producer checkout API response to include aggregated `shipping_lines` at the top level. Previously, `CheckoutSessionResource` returned `shipping_lines: []` while child orders had the data nested.
+
+## Why
+
+- Frontend/tests accessed `response.data.shipping_lines` expecting aggregated data
+- GP2 E2E test was logging: `shipping_lines count: 0` despite `shipping_total: 7.00` being correct
+- Without top-level aggregation, UI couldn't display per-producer shipping breakdown
+
+## How
+
+1. **CheckoutSessionResource.php**: Added `shipping_lines` field that flattens all shipping lines from child orders using `flatMap()`
+2. **CheckoutService.php**: Changed to nested eager loading (`orders.shippingLines`) to ensure relation is available
+
+## Evidence
+
+**Production canary** (2026-01-26T09:40 UTC):
+```json
+{
+  "type": "checkout_session",
+  "is_multi_producer": true,
+  "order_count": 2,
+  "shipping_lines_count": 2,
+  "shipping_lines": [
+    {"producer_id": 1, "producer_name": "Green Farm Co.", "shipping_cost": "3.50"},
+    {"producer_id": 4, "producer_name": "Test Producer B", "shipping_cost": "3.50"}
+  ],
+  "shipping_total": "7.00"
+}
+```
+
+**CI**: All required checks PASS (`build-and-test`, `Analyze (javascript)`, `quality-gates`)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/app/Http/Resources/CheckoutSessionResource.php` | +17 LOC: aggregate shipping_lines |
+| `backend/app/Services/CheckoutService.php` | +7/-4 LOC: nested eager loading |

--- a/docs/AGENT/TASKS/Pass-PROD-CHECKOUT-SAFETY-01.md
+++ b/docs/AGENT/TASKS/Pass-PROD-CHECKOUT-SAFETY-01.md
@@ -1,0 +1,128 @@
+# Pass-PROD-CHECKOUT-SAFETY-01: Multi-Producer shipping_lines Aggregation
+
+**Status**: ✅ COMPLETE
+**PR**: #2488
+**Commit**: `7b0eca26`
+**Date**: 2026-01-26
+
+---
+
+## Problem Statement
+
+Multi-producer checkout responses returned `shipping_lines: []` at the top level, even though:
+- `shipping_total` was correctly calculated (e.g., "7.00")
+- Child orders had their own `shipping_lines` populated correctly
+
+Frontend/tests expected `data.shipping_lines` at the top level of `CheckoutSessionResource`.
+
+## Root Cause Analysis
+
+1. `CheckoutService.processCheckout()` correctly creates child orders with `OrderShippingLine` records
+2. Each child order's `shippingLines` relation was loaded correctly
+3. `CheckoutSessionResource` returned `orders: [OrderResource, ...]` with nested shipping_lines
+4. **Bug**: `CheckoutSessionResource` did NOT aggregate shipping_lines at the top level
+5. Frontend accessed `response.data.shipping_lines` → got `[]` or `undefined`
+
+## Solution
+
+### Files Changed (2 files, +24/-4 LOC)
+
+1. **`backend/app/Http/Resources/CheckoutSessionResource.php`**
+   - Added `shipping_lines` field that aggregates all shipping lines from child orders
+   - Uses `flatMap()` to flatten N orders × M lines into single array
+
+2. **`backend/app/Services/CheckoutService.php`**
+   - Changed from `$checkoutSession->load('orders')` to `$checkoutSession->load(['orders.orderItems.producer', 'orders.shippingLines'])`
+   - Nested eager loading ensures `shippingLines` relation is available on checkout session's orders
+
+### Code Changes
+
+```php
+// CheckoutSessionResource.php - NEW
+'shipping_lines' => $this->when($this->relationLoaded('orders'), function () {
+    return $this->orders
+        ->filter(fn ($order) => $order->relationLoaded('shippingLines'))
+        ->flatMap(fn ($order) => $order->shippingLines->map(fn ($line) => [
+            'producer_id' => $line->producer_id,
+            'producer_name' => $line->producer_name,
+            'subtotal' => number_format((float) $line->subtotal, 2),
+            'shipping_cost' => number_format((float) $line->shipping_cost, 2),
+            'shipping_method' => $line->shipping_method,
+            'free_shipping_applied' => (bool) $line->free_shipping_applied,
+        ]))
+        ->values()
+        ->all();
+}, []),
+```
+
+```php
+// CheckoutService.php - CHANGED
+// Before:
+$checkoutSession->load('orders');
+
+// After:
+$checkoutSession->load(['orders.orderItems.producer', 'orders.shippingLines']);
+```
+
+## Verification
+
+### CI Checks (Required)
+| Check | Status |
+|-------|--------|
+| `build-and-test` | ✅ PASS |
+| `Analyze (javascript)` | ✅ PASS |
+| `quality-gates` | ✅ PASS |
+| `E2E (PostgreSQL)` | ✅ PASS (retry) |
+
+### Production API Canary (2026-01-26T09:40 UTC)
+
+```bash
+curl -X POST 'https://dixis.gr/api/v1/public/orders' \
+  -H 'Content-Type: application/json' \
+  -d '{"items": [{"product_id": 11, "quantity": 1}, {"product_id": 6, "quantity": 1}], ...}'
+```
+
+**Response**:
+```json
+{
+  "type": "checkout_session",
+  "is_multi_producer": true,
+  "order_count": 2,
+  "shipping_lines_count": 2,
+  "shipping_lines": [
+    {
+      "producer_id": 1,
+      "producer_name": "Green Farm Co.",
+      "subtotal": "15.99",
+      "shipping_cost": "3.50",
+      "shipping_method": "HOME",
+      "free_shipping_applied": false
+    },
+    {
+      "producer_id": 4,
+      "producer_name": "Test Producer B",
+      "subtotal": "5.00",
+      "shipping_cost": "3.50",
+      "shipping_method": "HOME",
+      "free_shipping_applied": false
+    }
+  ],
+  "shipping_total": "7.00"
+}
+```
+
+### Assertions Verified
+- ✅ `shipping_lines.length == 2` (one per producer)
+- ✅ `shipping_total == "7.00"` (= sum of shipping_cost: 3.50 + 3.50)
+- ✅ Each line has: producer_id, producer_name, subtotal, shipping_cost, shipping_method, free_shipping_applied
+
+## Related Passes
+
+- Pass-GUARDRAILS-CRITICAL-FLOWS-01 (added GP2 test that exposed this bug)
+- Pass-MP-ORDERS-SPLIT-01 (original CheckoutService implementation)
+- Pass-CI-SMOKE-STABILIZE-001 (CI test stabilization)
+
+## Follow-up
+
+- [ ] Pass-STRIPE-CARD-E2E-01: Verify CARD payment email timing
+- [ ] UI verification: Confirm checkout page displays shipping breakdown

--- a/docs/AGENT/TASKS/Pass-STRIPE-CARD-E2E-01.md
+++ b/docs/AGENT/TASKS/Pass-STRIPE-CARD-E2E-01.md
@@ -1,0 +1,105 @@
+# Pass-STRIPE-CARD-E2E-01: Stripe/Card Payment End-to-End Verification
+
+**Status**: 🔲 TODO
+**Priority**: HIGH
+**Blocked by**: None
+
+---
+
+## Scope
+
+Verify the complete CARD payment flow with timeline evidence. Ensure email "Order Confirmation" is sent **ONLY after payment confirmation/webhook success**.
+
+## Objectives
+
+1. **Reproduce CARD flow** in staging or prod test mode (whichever exists)
+2. **Collect timeline evidence**:
+   - Order created (timestamp)
+   - Payment intent created (timestamp)
+   - `confirmPayment` called (timestamp)
+   - Webhook received (timestamp)
+   - Email sent (timestamp)
+3. **Verify requirement**: Email must be sent ONLY after payment confirmation
+
+## Test Scenarios
+
+### Scenario 1: Single-producer CARD payment
+- Add 1 product to cart
+- Complete checkout with card (Stripe test card: 4242...)
+- Verify:
+  - Order created with `payment_status: pending`
+  - PaymentIntent created
+  - After `confirmPayment` → `payment_status: paid`
+  - Email sent AFTER confirmation
+
+### Scenario 2: Multi-producer CARD payment
+- Add 2 products from different producers
+- Complete checkout with card
+- Verify:
+  - CheckoutSession created with 2 child orders
+  - Single PaymentIntent for total
+  - After `confirmPayment` → ALL child orders marked paid
+  - Email sent for ALL child orders AFTER confirmation
+
+### Scenario 3: Payment failure handling
+- Use Stripe test card that declines (4000 0000 0000 0002)
+- Verify:
+  - No email sent
+  - UI shows error message (not success)
+  - Order remains `payment_status: pending`
+
+## Evidence Collection
+
+### Required Artifacts
+1. **Backend logs**: Filter for order creation, payment confirmation, email sending
+2. **Database timestamps**:
+   - `orders.created_at`
+   - `orders.updated_at` (when payment confirmed)
+3. **Email service logs**: Resend API response timestamps
+4. **Stripe dashboard**: PaymentIntent timeline
+
+### Expected Timeline (correct behavior)
+```
+T+0s:   Order created (status: pending, payment_status: pending)
+T+1s:   PaymentIntent created
+T+5s:   User completes Stripe form
+T+6s:   confirmPayment called
+T+7s:   Webhook received (payment_intent.succeeded)
+T+8s:   Order updated (payment_status: paid)
+T+8s:   Email sent (AFTER payment confirmation) ✅
+```
+
+### Incorrect Behavior (bug)
+```
+T+0s:   Order created
+T+0s:   Email sent (BEFORE payment) ❌ BUG
+T+6s:   Payment confirmed
+```
+
+## Environment Requirements
+
+- [ ] Staging environment with Stripe test mode OR
+- [ ] Production with Stripe test cards (if supported) OR
+- [ ] Local environment with Stripe webhook forwarding
+
+## Code Locations to Verify
+
+| File | Purpose |
+|------|---------|
+| `backend/app/Http/Controllers/Api/V1/OrderController.php:165-180` | COD email at creation |
+| `backend/app/Http/Controllers/Api/PaymentController.php:130-160` | CARD email after confirmation |
+| `backend/app/Http/Controllers/StripeWebhookController.php` | Webhook handling |
+| `backend/app/Services/OrderEmailService.php` | Email sending with idempotency |
+
+## Success Criteria
+
+1. ✅ CARD payment emails sent ONLY after `PaymentController::confirmPayment` or webhook success
+2. ✅ COD payment emails sent at order creation (different flow)
+3. ✅ Multi-producer: ALL sibling orders get emails after parent PaymentIntent confirms
+4. ✅ Payment failure: NO email sent, UI shows error
+
+## Notes
+
+- DO NOT implement changes in this pass
+- ONLY collect evidence and document findings
+- If issues found, create follow-up fix pass


### PR DESCRIPTION
## Summary
Documentation for completed Pass-PROD-CHECKOUT-SAFETY-01 and next pass setup.

## Changes
- Updated `docs/OPS/STATE.md` with pass completion details
- Created `docs/AGENT/TASKS/Pass-PROD-CHECKOUT-SAFETY-01.md`
- Created `docs/AGENT/SUMMARY/Pass-PROD-CHECKOUT-SAFETY-01.md`
- Created `docs/AGENT/TASKS/Pass-STRIPE-CARD-E2E-01.md` (next pass scope)

## Evidence
- PR #2488 merged, deployed (7b0eca26)
- Production canary: `shipping_lines_count=2`, `shipping_total="7.00"`
- UI verification: No React #418, no auth loops

## Test plan
- [x] Docs only - no code changes