### PR TITLE
fix(checkout): use correct order ID for payment init (multi-producer)

### DIFF
--- a/backend/app/Http/Resources/CheckoutSessionResource.php
+++ b/backend/app/Http/Resources/CheckoutSessionResource.php
@@ -35,6 +35,12 @@ class CheckoutSessionResource extends JsonResource
             // Stripe payment (will be set in Phase 3)
             'stripe_payment_intent_id' => $this->stripe_payment_intent_id,
 
+            // Pass PAYMENT-INIT-ORDER-ID-01: Canonical order ID for payment initialization
+            // For multi-producer, use first child order ID (all share same PaymentIntent)
+            'payment_order_id' => $this->when($this->relationLoaded('orders') && $this->orders->isNotEmpty(), function () {
+                return $this->orders->first()->id;
+            }),
+
             // Timestamps
             'created_at' => $this->created_at?->toISOString(),
             'updated_at' => $this->updated_at?->toISOString(),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -112,6 +112,10 @@ export interface Order {
   shipping_total?: string; // Sum of shipping_lines when order has multiple producers
   shipping_lines?: ShippingLine[]; // Per-producer shipping breakdown
   is_multi_producer?: boolean; // True when order spans 2+ producers
+  // Pass PAYMENT-INIT-ORDER-ID-01: Multi-producer checkout session support
+  type?: 'checkout_session'; // Present for multi-producer orders
+  payment_order_id?: number; // Canonical order ID for payment init (first child order)
+  orders?: Order[]; // Child orders for multi-producer checkout
 }
 
 export interface OrderItem {


### PR DESCRIPTION
## Summary
- **Pass PAYMENT-INIT-ORDER-ID-01**: Fix 404 error when initializing card payment for multi-producer checkout
- Add `payment_order_id` to CheckoutSessionResource for canonical payment order ID
- Handle 409 stock conflict errors with clear user feedback

## Root Cause
For multi-producer checkout:
1. API returns `CheckoutSession` with `id=5` and child `Orders` (id=113, 114)
2. Frontend called `initPayment(5)` - treating CheckoutSession ID as Order ID
3. Backend `Order::findOrFail(5)` failed with 404 (order 5 doesn't exist)

## Fix
1. **Backend**: `CheckoutSessionResource` now includes `payment_order_id` (first child order ID)
2. **Frontend**: Uses `payment_order_id` for `initPayment`, CheckoutSession ID for thank-you redirect
3. **Frontend**: Handles 409 (stock conflict) with Greek error message
4. **Frontend**: Clears stale payment state on order creation failure

## Changes
| File | Change |
|------|--------|
| `backend/app/Http/Resources/CheckoutSessionResource.php` | +6 LOC: add payment_order_id |
| `frontend/src/lib/api.ts` | +4 LOC: add type, payment_order_id, orders to Order interface |
| `frontend/src/app/(storefront)/checkout/page.tsx` | +30/-7 LOC: use correct IDs, handle errors |

## Test plan
- [ ] Multi-producer card payment: initPayment called with correct order ID
- [ ] Single-producer card payment: still works (payment_order_id is undefined, uses order.id)
- [ ] 409 stock conflict: shows Greek error, no initPayment called
- [ ] CI checks pass