### PR TITLE
docs: Complete Pass-PAYMENT-INIT-ORDER-ID-01 documentation

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-PAYMENT-INIT-ORDER-ID-01.md
+++ b/docs/AGENT/SUMMARY/Pass-PAYMENT-INIT-ORDER-ID-01.md
@@ -1,0 +1,44 @@
+# Pass-PAYMENT-INIT-ORDER-ID-01 Summary
+
+**Status**: ✅ COMPLETE | **PR**: #2490 | **Date**: 2026-01-26
+
+## What
+
+Fixed 404 error when initializing card payment for multi-producer checkout. Backend `initPayment` endpoint was receiving CheckoutSession ID instead of Order ID.
+
+## Why
+
+- Multi-producer checkout returns `CheckoutSession` (id=6) with child `Orders` (id=115, 116)
+- Frontend called `initPayment(6)` - treating CheckoutSession ID as Order ID
+- Backend `Order::findOrFail(6)` failed with 404 (no Order with that ID exists)
+
+## How
+
+1. **Backend**: Added `payment_order_id` to `CheckoutSessionResource` (first child order ID)
+2. **Frontend**: Uses `payment_order_id` for `initPayment`, CheckoutSession ID for thank-you redirect
+3. **Frontend**: Handles 409 (stock conflict) with Greek error message
+4. **Frontend**: Clears stale payment state on order creation failure
+
+## Evidence
+
+**Production API** (2026-01-26):
+```json
+{
+  "id": 6,
+  "type": "checkout_session",
+  "is_multi_producer": true,
+  "payment_order_id": 115,
+  "first_child_order_id": 115
+}
+```
+
+**CI**: All required checks PASS
+**Deploy**: "Deploy Backend (VPS)" - success
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/app/Http/Resources/CheckoutSessionResource.php` | +6 LOC: add payment_order_id |
+| `frontend/src/lib/api.ts` | +4 LOC: Order interface types |
+| `frontend/src/app/(storefront)/checkout/page.tsx` | +30/-7 LOC: use correct IDs |

--- a/docs/AGENT/TASKS/Pass-PAYMENT-INIT-ORDER-ID-01.md
+++ b/docs/AGENT/TASKS/Pass-PAYMENT-INIT-ORDER-ID-01.md
@@ -1,0 +1,134 @@
+# Pass-PAYMENT-INIT-ORDER-ID-01: Fix 404 on Payment Init (Multi-Producer)
+
+**Status**: ✅ COMPLETE
+**PR**: #2490
+**Date**: 2026-01-26
+
+---
+
+## Problem Statement
+
+Users reported 404 errors when attempting card payment for multi-producer checkout:
+```
+POST /api/v1/payments/orders/5/init -> 404 Not Found ("Order not found")
+```
+
+## Reproduction Steps
+
+1. Add products from 2 different producers to cart
+2. Proceed to checkout
+3. Select CARD payment method
+4. Submit order
+5. **Expected**: Payment form appears
+6. **Actual**: 404 error, payment fails
+
+## Root Cause Analysis
+
+### API Response Structure
+
+Multi-producer checkout returns `CheckoutSession`, not `Order`:
+
+```json
+{
+  "data": {
+    "id": 6,                    // <-- CheckoutSession ID
+    "type": "checkout_session",
+    "is_multi_producer": true,
+    "orders": [
+      { "id": 115, ... },       // <-- Child Order 1
+      { "id": 116, ... }        // <-- Child Order 2
+    ]
+  }
+}
+```
+
+### Bug Location
+
+**Frontend** (`checkout/page.tsx:153`):
+```typescript
+const paymentInit = await paymentApi.initPayment(order.id, {...})
+//                                               ^^^^^^^
+// order.id = 6 (CheckoutSession ID, NOT Order ID!)
+```
+
+**Backend** (`PaymentController.php:18`):
+```php
+public function initPayment(Request $request, Order $order): JsonResponse
+//                                            ^^^^^^^^^^^^
+// Order::findOrFail(6) fails - no Order with ID 6 exists
+```
+
+### Root Cause
+
+1. `apiClient.createOrder()` returns `{ data: CheckoutSession }` for multi-producer
+2. Frontend uses `order.id` (CheckoutSession ID) for `initPayment`
+3. Backend expects Order ID, not CheckoutSession ID
+4. `Order::findOrFail(6)` throws 404
+
+## Solution
+
+### Files Changed (3 files, +40/-7 LOC)
+
+1. **`backend/app/Http/Resources/CheckoutSessionResource.php`** (+6 LOC)
+   - Add `payment_order_id` field (first child order ID)
+
+2. **`frontend/src/lib/api.ts`** (+4 LOC)
+   - Add `type`, `payment_order_id`, `orders` to Order interface
+
+3. **`frontend/src/app/(storefront)/checkout/page.tsx`** (+30/-7 LOC)
+   - Use `payment_order_id` for initPayment
+   - Use CheckoutSession ID for thank-you redirect
+   - Handle 409 (stock conflict) with Greek message
+   - Clear stale payment state on failure
+
+### Code Changes
+
+**Backend** (CheckoutSessionResource.php):
+```php
+// Pass PAYMENT-INIT-ORDER-ID-01: Canonical order ID for payment initialization
+'payment_order_id' => $this->when($this->relationLoaded('orders') && $this->orders->isNotEmpty(), function () {
+    return $this->orders->first()->id;
+}),
+```
+
+**Frontend** (checkout/page.tsx):
+```typescript
+// Pass PAYMENT-INIT-ORDER-ID-01: Get correct order ID for payment init
+const paymentOrderId = order.payment_order_id ?? order.id;
+const thankYouId = order.id;
+
+// Initialize payment with correct order ID
+const paymentInit = await paymentApi.initPayment(paymentOrderId, {...})
+```
+
+## Acceptance Criteria
+
+- [x] Multi-producer CARD payment: `initPayment` called with child Order ID
+- [x] Single-producer CARD payment: Still uses `order.id` (unchanged)
+- [x] 409 stock conflict: Shows Greek error, no initPayment called
+- [x] CI required checks pass
+- [x] Production deployment successful
+
+## Production Evidence
+
+**API Response** (2026-01-26):
+```json
+{
+  "id": 6,
+  "type": "checkout_session",
+  "is_multi_producer": true,
+  "payment_order_id": 115,
+  "first_child_order_id": 115
+}
+```
+
+**Deployment**:
+- PR: https://github.com/lomendor/Project-Dixis/pull/2490
+- Workflow: "Deploy Backend (VPS)" - success
+- Commit: `ef3fb29fc78051aadaf6130a4d35a5d0c6b714b9`
+
+## Related Issues
+
+- Pass-PROD-CHECKOUT-SAFETY-01: Fixed shipping_lines aggregation
+- React #418: Addressed by proper hydration handling (existing fix)
+- 409 stock conflict: Now shows clear Greek error message


### PR DESCRIPTION
## Summary
Documentation for completed Pass-PAYMENT-INIT-ORDER-ID-01.

## Changes
- Updated `docs/OPS/STATE.md` with pass completion details
- Created `docs/AGENT/TASKS/Pass-PAYMENT-INIT-ORDER-ID-01.md`
- Created `docs/AGENT/SUMMARY/Pass-PAYMENT-INIT-ORDER-ID-01.md`

## Evidence
- PR #2490 merged, deployed
- Production API: `payment_order_id: 115` returned correctly
- UI Sanity: No React #418, no 404 on payment endpoints

## Test plan
- [x] Docs only - no code changes