### PR TITLE
docs: Complete Pass-MP-SHIPPING-BREAKDOWN-TRUTH-01 documentation

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-MP-SHIPPING-BREAKDOWN-TRUTH-01.md
+++ b/docs/AGENT/SUMMARY/Pass-MP-SHIPPING-BREAKDOWN-TRUTH-01.md
@@ -1,111 +1,168 @@
 # Summary: Pass-MP-SHIPPING-BREAKDOWN-TRUTH-01
 
-**Date**: 2026-01-25
-**Status**: COMPLETE
-**PR**: Pending
+**Date**: 2026-01-26 (Updated)
+**Status**: ✅ COMPLETE - PROD DEPLOYED & VERIFIED
+**PR**: https://github.com/lomendor/Project-Dixis/pull/2496
 
 ---
 
 ## TL;DR
 
-Enabled multi-producer checkout by removing frontend HOTFIX blocks. Backend CheckoutService (from PR #2476/#2477) handles order splitting with per-producer shipping. Thank-you page now shows shipping breakdown per producer.
+Backend is now the SINGLE SOURCE OF TRUTH for shipping calculation. Removed frontend hardcoded values, deleted dead code with conflicting threshold, added comprehensive backend tests, and verified production behavior.
 
 ---
 
 ## Problem Statement
 
-Multi-producer checkout was blocked by HOTFIX (PR #2448/#2449/#2465) which was necessary before backend order splitting was implemented. The backend is now ready:
-
-- CheckoutService creates CheckoutSession + N child Orders
-- Per-producer shipping calculated correctly
-- Email timing follows truth rules (COD at creation, CARD after confirmation)
-
-But the frontend still blocks multi-producer carts at checkout.
+1. **Frontend hardcoded shipping**: `checkout/page.tsx` sent `shipping_cost: 3.50` in order payload
+2. **Dead code with wrong threshold**: `lib/checkout/totals.ts` had €25 free threshold (backend uses €35)
+3. **Misleading VAT display**: Thank-you page showed "ΦΠΑ (24%): €0.00" when VAT is not implemented
 
 ---
 
 ## Solution
 
-### 1. Remove HOTFIX Blocks
+### 1. Remove Hardcoded Shipping from Frontend
 
-**checkout/page.tsx** - Removed two blocks:
-
+**checkout/page.tsx**:
 ```typescript
-// REMOVED: Submit-time block (lines 82-88)
-if (isMultiProducerCart(cartItems)) {
-  setError('Δεν υποστηρίζεται ακόμη...')
-  return
-}
+// REMOVED:
+const shippingCost = 3.50;
+const orderData = {
+  ...
+  shipping_cost: shippingCost,  // DELETED
+};
 
-// REMOVED: Render-time block (lines 219-254)
-const multiProducer = isMultiProducerCart(cartItems)
-if (multiProducer && !stripeClientSecret) {
-  return (...blocking UI...)
-}
+// NOW: Backend CheckoutService calculates shipping
+const orderData = {
+  ...
+  // shipping_cost removed - backend is source of truth
+};
 ```
 
-### 2. Add Shipping Breakdown Display
+### 2. Delete Dead Code with Conflicting Threshold
 
-**thank-you/page.tsx** - Shows per-producer shipping:
-
+**lib/checkout/totals.ts** - DELETED:
 ```typescript
-{order.isMultiProducer && order.shippingLines && order.shippingLines.length > 1 ? (
-  <>
-    <div>Μεταφορικά ανά παραγωγό:</div>
-    {order.shippingLines.map((line) => (
-      <div>
-        <span>{line.producer_name}:</span>
-        <span>{line.free_shipping_applied ? 'Δωρεάν' : fmt.format(line.shipping_cost)}</span>
-      </div>
-    ))}
-    <div>Σύνολο μεταφορικών: {order.shipping}</div>
-  </>
-) : (
-  // Single producer: show single shipping line
+// Had €25 threshold vs backend's €35 - was never imported anyway
+const SHIP_FREE = envNum('SHIPPING_FREE_FROM_EUR', 25);  // WRONG
+```
+
+### 3. Fix Thank-You Page VAT Display
+
+**thank-you/page.tsx**:
+```typescript
+// BEFORE: Always showed VAT (even when 0)
+<div>ΦΠΑ (24%): {fmt.format(order.vat || 0)}</div>
+
+// AFTER: Only show when VAT is implemented
+{order.vat && order.vat > 0 && (
+  <div>ΦΠΑ (24%): {fmt.format(order.vat)}</div>
 )}
 ```
 
-### 3. Update E2E Tests
+### 4. Add Backend Unit Tests
 
-Replaced `multi-producer-checkout-blocked.spec.ts` with `multi-producer-checkout.spec.ts`:
-- MPC1: Verify checkout form accessible (not blocked)
-- MPC2: Verify single-producer still works
-- MPC3: Verify multi-producer COD checkout completes
+**CheckoutServiceShippingTest.php** - 6 tests:
+- `single_producer_below_threshold_charges_shipping`: €20 → €3.50 ✅
+- `single_producer_at_threshold_gets_free_shipping`: €35 → €0.00 ✅
+- `single_producer_above_threshold_gets_free_shipping`: €50 → €0.00 ✅
+- `multi_producer_each_below_threshold_both_charge_shipping`: €20+€15 → €7.00 ✅
+- `multi_producer_one_above_threshold_one_below`: €40+€20 → €3.50 ✅
+- `pickup_always_has_free_shipping`: any → €0.00 ✅
 
 ---
 
-## Truth Rules Verified
+## Shipping Rules (Backend Canonical)
 
-| Rule | Status |
+Source: `backend/app/Services/CheckoutService.php`
+
+```php
+private const FREE_SHIPPING_THRESHOLD = 35.00;
+private const FLAT_SHIPPING_RATE = 3.50;
+
+private function calculateProducerShipping(float $subtotal, bool $isPickup): float
+{
+    if ($isPickup) return 0.0;
+    if ($subtotal >= self::FREE_SHIPPING_THRESHOLD) return 0.0;
+    return self::FLAT_SHIPPING_RATE;
+}
+```
+
+| Condition | Shipping Cost |
+|-----------|---------------|
+| Subtotal < €35 | €3.50 |
+| Subtotal ≥ €35 | €0.00 (Free) |
+| Pickup | €0.00 (Always) |
+
+---
+
+## Production Evidence
+
+### Test 1: Two producers, both below €35
+
+```bash
+POST /api/v1/public/orders
+Items: Product B (€5.00) + Tomatoes (€3.50)
+```
+
+Response:
+```json
+{
+  "is_multi_producer": true,
+  "subtotal": "8.50",
+  "shipping_total": "7.00",
+  "shipping_lines": [
+    {"producer_name": "Test Producer B", "shipping_cost": "3.50", "free_shipping_applied": false},
+    {"producer_name": "Green Farm Co.", "shipping_cost": "3.50", "free_shipping_applied": false}
+  ]
+}
+```
+
+### Test 2: Two producers, one above €35
+
+```bash
+POST /api/v1/public/orders
+Items: Product B (€5.00) + Olive Oil x3 (€36.00)
+```
+
+Response:
+```json
+{
+  "is_multi_producer": true,
+  "subtotal": "41.00",
+  "shipping_total": "3.50",
+  "shipping_lines": [
+    {"producer_name": "Test Producer B", "shipping_cost": "3.50", "free_shipping_applied": false},
+    {"producer_name": "Green Farm Co.", "shipping_cost": "0.00", "free_shipping_applied": true}
+  ]
+}
+```
+
+---
+
+## Files Changed
+
+| File | Change |
 |------|--------|
-| COD orders: Email at creation | Backend (MultiProducerPaymentEmailTest) |
-| CARD orders: Email after payment confirmation | Backend (MultiProducerPaymentEmailTest) |
-| Per-producer shipping: €3.50 flat, free >= €35 | Backend (MultiProducerShippingTotalTest) |
-| Multi-producer: Creates CheckoutSession + N Orders | Backend (MultiProducerOrderSplitTest) |
-| Single-producer: Creates single Order (backward compatible) | Backend (MultiProducerOrderSplitTest) |
+| `frontend/src/app/(storefront)/checkout/page.tsx` | Removed hardcoded shipping_cost |
+| `frontend/src/app/(storefront)/thank-you/page.tsx` | VAT only shown when > 0 |
+| `frontend/src/lib/checkout/totals.ts` | DELETED (dead code) |
+| `backend/tests/Unit/CheckoutServiceShippingTest.php` | NEW - 6 shipping tests |
 
 ---
 
-## Files Modified
+## Verification Checklist
 
-- `frontend/src/app/(storefront)/checkout/page.tsx` (-45 LOC)
-- `frontend/src/app/(storefront)/thank-you/page.tsx` (+25 LOC)
-- `frontend/tests/e2e/multi-producer-checkout.spec.ts` (NEW)
-- `frontend/tests/e2e/multi-producer-checkout-blocked.spec.ts` (REMOVED)
-
----
-
-## Evidence
-
-Backend tests (34 passed, 157 assertions):
-```
-PASS Tests\Unit\CheckoutSessionTest (11 tests)
-PASS Tests\Feature\MultiProducerOrderSplitTest (7 tests)
-PASS Tests\Feature\MultiProducerOrderTest (5 tests)
-PASS Tests\Feature\MultiProducerPaymentEmailTest (8 tests)
-PASS Tests\Feature\MultiProducerShippingTotalTest (3 tests)
-```
+- [x] Backend tests: 6/6 pass
+- [x] Frontend build: success
+- [x] PR merged: #2496
+- [x] Deploy backend: success (2026-01-26 20:32)
+- [x] Deploy frontend: success (2026-01-26 20:33)
+- [x] Production API: shipping calculated by backend
+- [x] Free shipping threshold: works at €35
+- [x] Multi-producer: per-producer breakdown correct
 
 ---
 
-_Pass-MP-SHIPPING-BREAKDOWN-TRUTH-01 | 2026-01-25 | COMPLETE_
+_Pass-MP-SHIPPING-BREAKDOWN-TRUTH-01 | 2026-01-26 | ✅ COMPLETE_


### PR DESCRIPTION
## Summary
Documentation close-out for Pass-MP-SHIPPING-BREAKDOWN-TRUTH-01.

**Updates:**
- OPS/STATE.md with production evidence
- SUMMARY with verification checklist
- API test responses showing correct shipping calculation

**Evidence from PR #2496:**
- Backend is now single source of truth for shipping
- Production API tests verified shipping_total and per-producer breakdown
- Free shipping threshold (€35) working correctly

## Test Plan
- [x] Documentation only - no code changes