### PR TITLE
fix(payments): allow guest orders to be paid via card (Pass PAY-INIT-404-01)

### DIFF
--- a/backend/app/Http/Controllers/Api/PaymentController.php
+++ b/backend/app/Http/Controllers/Api/PaymentController.php
@@ -14,11 +14,17 @@ class PaymentController extends Controller
 {
     /**
      * Initialize payment for an order.
+     *
+     * Authorization rules (Pass PAY-INIT-404-01):
+     * - Guest orders (user_id = null): Allow if order exists and not paid
+     * - Authenticated orders: Only owner can init payment
      */
     public function initPayment(Request $request, Order $order): JsonResponse
     {
-        // Ensure user can only initialize payment for their own orders
-        if ($order->user_id !== $request->user()->id) {
+        // Pass PAY-INIT-404-01: Allow guest orders OR orders owned by the user
+        // Guest orders (user_id = null) can be paid by anyone with the order ID
+        // Authenticated orders require the owner to init payment
+        if ($order->user_id !== null && $order->user_id !== $request->user()->id) {
             return response()->json(['message' => 'Order not found'], 404);
         }
 
@@ -97,8 +103,8 @@ class PaymentController extends Controller
      */
     public function confirmPayment(Request $request, Order $order): JsonResponse
     {
-        // Ensure user can only confirm payment for their own orders
-        if ($order->user_id !== $request->user()->id) {
+        // Pass PAY-INIT-404-01: Allow guest orders OR orders owned by the user
+        if ($order->user_id !== null && $order->user_id !== $request->user()->id) {
             return response()->json(['message' => 'Order not found'], 404);
         }
 
@@ -194,8 +200,8 @@ class PaymentController extends Controller
      */
     public function cancelPayment(Request $request, Order $order): JsonResponse
     {
-        // Ensure user can only cancel payment for their own orders
-        if ($order->user_id !== $request->user()->id) {
+        // Pass PAY-INIT-404-01: Allow guest orders OR orders owned by the user
+        if ($order->user_id !== null && $order->user_id !== $request->user()->id) {
             return response()->json(['message' => 'Order not found'], 404);
         }
 
@@ -250,8 +256,8 @@ class PaymentController extends Controller
      */
     public function getPaymentStatus(Request $request, Order $order): JsonResponse
     {
-        // Ensure user can only check payment status for their own orders
-        if ($order->user_id !== $request->user()->id) {
+        // Pass PAY-INIT-404-01: Allow guest orders OR orders owned by the user
+        if ($order->user_id !== null && $order->user_id !== $request->user()->id) {
             return response()->json(['message' => 'Order not found'], 404);
         }
 

--- a/backend/tests/Feature/PaymentInitAuthorizationTest.php
+++ b/backend/tests/Feature/PaymentInitAuthorizationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Pass PAY-INIT-404-01: Payment Init Authorization Tests
+ *
+ * Tests that payment init endpoint correctly handles:
+ * - Guest orders (user_id = null)
+ * - Authenticated user's own orders
+ * - Authenticated user trying to access another user's order
+ */
+class PaymentInitAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private User $otherUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->otherUser = User::factory()->create();
+    }
+
+    /** @test */
+    public function authenticated_user_can_init_payment_for_own_order(): void
+    {
+        $order = Order::factory()->create([
+            'user_id' => $this->user->id,
+            'payment_status' => 'pending',
+            'payment_method' => 'CARD',
+            'subtotal' => 30.00,
+            'total' => 33.50,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson("/api/v1/payments/orders/{$order->id}/init");
+
+        // Should not return 404 - may return 400/500 due to Stripe config, but NOT 404
+        $this->assertNotEquals(404, $response->status(), 'Owner should be able to access own order');
+    }
+
+    /** @test */
+    public function authenticated_user_cannot_init_payment_for_other_users_order(): void
+    {
+        $order = Order::factory()->create([
+            'user_id' => $this->otherUser->id,
+            'payment_status' => 'pending',
+            'payment_method' => 'CARD',
+            'subtotal' => 30.00,
+            'total' => 33.50,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson("/api/v1/payments/orders/{$order->id}/init");
+
+        $response->assertStatus(404);
+        $response->assertJson(['message' => 'Order not found']);
+    }
+
+    /** @test */
+    public function authenticated_user_can_init_payment_for_guest_order(): void
+    {
+        // Guest order has user_id = null
+        $order = Order::factory()->create([
+            'user_id' => null,
+            'payment_status' => 'pending',
+            'payment_method' => 'CARD',
+            'subtotal' => 30.00,
+            'total' => 33.50,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson("/api/v1/payments/orders/{$order->id}/init");
+
+        // Should not return 404 - guest orders can be paid by anyone
+        $this->assertNotEquals(404, $response->status(), 'Guest orders should be accessible');
+    }
+
+    /** @test */
+    public function unauthenticated_user_cannot_init_payment(): void
+    {
+        $order = Order::factory()->create([
+            'user_id' => null,
+            'payment_status' => 'pending',
+            'payment_method' => 'CARD',
+        ]);
+
+        $response = $this->postJson("/api/v1/payments/orders/{$order->id}/init");
+
+        $response->assertStatus(401);
+        $response->assertJson(['message' => 'Unauthenticated.']);
+    }
+
+    /** @test */
+    public function cannot_init_payment_for_nonexistent_order(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/v1/payments/orders/99999/init');
+
+        $response->assertStatus(404);
+    }
+
+    /** @test */
+    public function cannot_init_payment_for_already_paid_order(): void
+    {
+        $order = Order::factory()->create([
+            'user_id' => $this->user->id,
+            'payment_status' => 'paid',
+            'payment_method' => 'CARD',
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson("/api/v1/payments/orders/{$order->id}/init");
+
+        $response->assertStatus(400);
+        $response->assertJson(['message' => 'Order has already been paid']);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix 404 "Order not found" when trying to pay for guest orders with card
- Add authorization tests for payment init endpoint

## Root Cause
`PaymentController::initPayment` checked `$order->user_id !== $request->user()->id` which:
- For guest orders (`user_id = null`): Always returned 404 because `null !== <any_user_id>`
- This broke card payments for guest checkout

## Solution
Changed authorization to:
```php
// Allow guest orders (user_id = null) OR orders owned by the user
if ($order->user_id !== null && $order->user_id !== $request->user()->id) {
    return response()->json(['message' => 'Order not found'], 404);
}
```

## Authorization Rules
| Order Type | Can Init Payment? |
|------------|------------------|
| Guest order (user_id = null) | Yes, any authenticated user |
| Own order (user_id = current user) | Yes |
| Other user's order | No (404) |
| Non-existent order | No (404 from route binding) |
| Already paid order | No (400) |

## Files Changed
| File | Change |
|------|--------|
| `backend/app/Http/Controllers/Api/PaymentController.php` | Fixed auth check for 4 endpoints |
| `backend/tests/Feature/PaymentInitAuthorizationTest.php` | NEW - 6 authorization tests |

## Tests Added
- `authenticated_user_can_init_payment_for_own_order`
- `authenticated_user_cannot_init_payment_for_other_users_order`
- `authenticated_user_can_init_payment_for_guest_order`
- `unauthenticated_user_cannot_init_payment`
- `cannot_init_payment_for_nonexistent_order`
- `cannot_init_payment_for_already_paid_order`

## Test Plan
- [x] All 6 new authorization tests pass
- [x] Existing payment tests unaffected
- [ ] Production: Guest can complete card payment

Pass PAY-INIT-404-01