### PR TITLE
docs: Pass-PAY-CARD-CONFIRM-GUARD-01 completion docs

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-PAY-CARD-CONFIRM-GUARD-01.md
+++ b/docs/AGENT/SUMMARY/Pass-PAY-CARD-CONFIRM-GUARD-01.md
@@ -1,0 +1,91 @@
+# Summary: Pass-PAY-CARD-CONFIRM-GUARD-01
+
+**Date**: 2026-01-27
+**Status**: COMPLETE
+**PR**: https://github.com/lomendor/Project-Dixis/pull/2504
+
+---
+
+## TL;DR
+
+Added strict guards to card payment flow to prevent null reference errors and ensure backend confirm is only called with valid Stripe results.
+
+---
+
+## Problem
+
+Users reported runtime error "Cannot read properties of null (reading 'o')" during card payment, plus backend returning 400 on confirm endpoint. The cryptic error occurred when:
+
+1. `paymentIntent` was null/undefined after `stripe.confirmPayment()`
+2. `paymentIntent.status` was not 'succeeded' (e.g., 'requires_action')
+3. Invalid/missing paymentIntentId passed to backend confirm
+
+---
+
+## Root Cause
+
+StripePaymentForm had weak guards:
+
+```typescript
+// Before: Combined check, all-or-nothing
+if (!stripe || !elements) { ... }
+
+// After confirmPayment:
+else if (paymentIntent && paymentIntent.status === 'succeeded') {
+  onPaymentSuccess(paymentIntent.id);
+} else {
+  onPaymentError('Generic error');  // Catches too many cases
+}
+```
+
+---
+
+## Solution
+
+Frontend-only fix with defense-in-depth:
+
+1. **StripePaymentForm** (57 lines added):
+   - Separate null checks for `stripe` and `elements`
+   - Log confirmPayment result for debugging
+   - Handle each paymentIntent status explicitly:
+     - `succeeded` → onPaymentSuccess
+     - `requires_action` → 3D Secure message
+     - `null` → error message
+     - Other → status-specific message
+
+2. **Checkout page** (15 lines added):
+   - Validate `paymentIntentId` starts with `pi_`
+   - Don't call backend confirm with invalid data
+
+---
+
+## Evidence
+
+| Check | Result |
+|-------|--------|
+| TypeScript compile | PASS |
+| quality-gates | PASS |
+| build-and-test | PASS |
+| E2E (PostgreSQL) | PASS |
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/payment/StripePaymentForm.tsx` | +57/-11 lines |
+| `frontend/src/app/(storefront)/checkout/page.tsx` | +15/-3 lines |
+| `frontend/tests/e2e/card-payment-confirm-guards.spec.ts` | NEW (325 lines) |
+
+---
+
+## NOT Changed
+
+- Backend payment routes unchanged
+- Stripe configuration unchanged
+- No i18n changes
+
+---
+
+_Pass-PAY-CARD-CONFIRM-GUARD-01 | 2026-01-27 | COMPLETE_

--- a/docs/AGENT/TASKS/Pass-PAY-CARD-CONFIRM-GUARD-01.md
+++ b/docs/AGENT/TASKS/Pass-PAY-CARD-CONFIRM-GUARD-01.md
@@ -1,0 +1,133 @@
+# Pass-PAY-CARD-CONFIRM-GUARD-01: Card Payment Confirmation Guards
+
+**Date**: 2026-01-27
+**Status**: COMPLETE
+**PR**: https://github.com/lomendor/Project-Dixis/pull/2504
+
+---
+
+## Task Overview
+
+Add strict guards to prevent null reference errors and ensure backend payment confirmation is only called with valid Stripe results.
+
+---
+
+## Tasks
+
+### 1. Analyze Root Cause
+- [x] Map the payment flow: checkout -> order -> payment init -> Stripe Elements -> confirmPayment -> backend confirm
+- [x] Identify where null values can cause issues
+- [x] Understand the "Cannot read properties of null (reading 'o')" error
+
+### 2. Fix StripePaymentForm Guards
+- [x] Separate null checks for `stripe` and `elements`
+- [x] Add logging before Stripe call for debugging
+- [x] Handle all `paymentIntent.status` cases explicitly:
+  - `succeeded` -> call onPaymentSuccess
+  - `requires_action` -> show 3D Secure message
+  - `null/undefined` -> show error
+  - Other statuses -> show status message
+
+### 3. Fix Checkout Page Guards
+- [x] Validate `pendingOrderId` exists before backend call
+- [x] Validate `paymentIntentId` format (must start with `pi_`)
+- [x] Add logging for debugging production issues
+
+### 4. Add E2E Tests
+- [x] Create `card-payment-confirm-guards.spec.ts`
+- [x] GUARD1: Stripe Elements must be loaded before submit
+- [x] GUARD2: Backend confirm only called with valid paymentIntentId
+- [x] GUARD3: User-friendly errors instead of null reference errors
+
+### 5. Verify & Deploy
+- [x] TypeScript compiles cleanly
+- [x] CI passes (quality-gates, build-and-test, E2E PostgreSQL)
+- [x] Create and merge PR #2504
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/payment/StripePaymentForm.tsx` | +57/-11 lines |
+| `frontend/src/app/(storefront)/checkout/page.tsx` | +15/-3 lines |
+| `frontend/tests/e2e/card-payment-confirm-guards.spec.ts` | NEW (325 lines) |
+
+---
+
+## Technical Details
+
+### StripePaymentForm Guards
+
+```typescript
+// Before: Combined check, no logging
+if (!stripe || !elements) {
+  onPaymentError('Stripe δεν έχει φορτώσει ακόμα');
+  return;
+}
+
+// After: Separate checks with logging
+if (!stripe) {
+  console.error('[StripePaymentForm] stripe is null - not loaded');
+  onPaymentError('Stripe δεν έχει φορτώσει ακόμα. Παρακαλώ περιμένετε.');
+  return;
+}
+
+if (!elements) {
+  console.error('[StripePaymentForm] elements is null - not initialized');
+  onPaymentError('Η φόρμα πληρωμής δεν έχει φορτώσει. Παρακαλώ ανανεώστε τη σελίδα.');
+  return;
+}
+```
+
+### PaymentIntent Status Handling
+
+```typescript
+// Case 1: Error from Stripe
+if (error) { ... }
+
+// Case 2: No error but paymentIntent is null
+if (!paymentIntent) { ... }
+
+// Case 3: PaymentIntent has no ID
+if (!paymentIntent.id) { ... }
+
+// Case 4: Succeeded - call backend
+if (paymentIntent.status === 'succeeded') { onPaymentSuccess(paymentIntent.id); return; }
+
+// Case 5: Requires action (3D Secure)
+if (paymentIntent.status === 'requires_action') { ... }
+
+// Case 6: Other statuses
+console.warn('Unexpected status:', paymentIntent.status);
+```
+
+### Checkout Page Guard
+
+```typescript
+// Validate paymentIntentId format
+if (!paymentIntentId || typeof paymentIntentId !== 'string' || !paymentIntentId.startsWith('pi_')) {
+  console.error('[Checkout] Invalid paymentIntentId:', paymentIntentId);
+  setError('Σφάλμα: Μη έγκυρο αναγνωριστικό πληρωμής. Παρακαλώ δοκιμάστε ξανά.');
+  return;
+}
+```
+
+---
+
+## Evidence
+
+**TypeScript Compilation**:
+```
+npx tsc --noEmit --skipLibCheck  # No errors
+```
+
+**CI Results**:
+- quality-gates: PASS
+- build-and-test: PASS
+- E2E (PostgreSQL): PASS
+
+---
+
+_Pass-PAY-CARD-CONFIRM-GUARD-01 | 2026-01-27 | COMPLETE_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,47 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-27 (Pass-PAY-GUEST-CARD-GATE-01)
+**Last Updated**: 2026-01-27 (Pass-PAY-CARD-CONFIRM-GUARD-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~700 lines (target ≤250). ⚠️
+
+---
+
+## 2026-01-27 — Pass-PAY-CARD-CONFIRM-GUARD-01: Card Payment Confirmation Guards
+
+**Status**: ✅ FIXED — MERGED (PR #2504) — FRONTEND ONLY
+
+**Symptom**: Users reported runtime error "Cannot read properties of null (reading 'o')" during card payment, plus backend returning 400 on confirm endpoint.
+
+**Root Cause**:
+StripePaymentForm had weak guards:
+- Combined null check for `stripe || elements`
+- Generic catch-all for non-succeeded status
+- No validation of paymentIntentId before backend call
+
+**Fix** (PR #2504, commit `8f368c08`) — Frontend Only:
+
+1. **StripePaymentForm**: Separate null checks, handle all paymentIntent statuses explicitly
+2. **Checkout page**: Validate paymentIntentId format (must start with `pi_`)
+3. **Logging**: Added console logs for debugging production issues
+
+**Evidence**:
+
+| Check | Result |
+|-------|--------|
+| TypeScript compile | PASS |
+| quality-gates | PASS |
+| build-and-test | PASS |
+| E2E (PostgreSQL) | PASS |
+
+**Files Changed**:
+- `frontend/src/components/payment/StripePaymentForm.tsx` (+57/-11 lines)
+- `frontend/src/app/(storefront)/checkout/page.tsx` (+15/-3 lines)
+- `frontend/tests/e2e/card-payment-confirm-guards.spec.ts` (NEW: 325 lines)
+
+**Docs**:
+- Tasks: `docs/AGENT/TASKS/Pass-PAY-CARD-CONFIRM-GUARD-01.md`
+- Summary: `docs/AGENT/SUMMARY/Pass-PAY-CARD-CONFIRM-GUARD-01.md`
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation for Pass-PAY-CARD-CONFIRM-GUARD-01 (card payment confirmation guards).

## Files

- `docs/AGENT/TASKS/Pass-PAY-CARD-CONFIRM-GUARD-01.md` - Task breakdown
- `docs/AGENT/SUMMARY/Pass-PAY-CARD-CONFIRM-GUARD-01.md` - TL;DR summary
- `docs/OPS/STATE.md` - Updated with pass entry

Related PR: #2504

---

_Pass-PAY-CARD-CONFIRM-GUARD-01 | 2026-01-27_