### PR TITLE
fix: Pass SMOKE-COMMISSION-QUARANTINE-01 - Quarantine commission smoke on prod

### DIFF
--- a/frontend/tests/e2e/smoke-commission-preview.spec.ts
+++ b/frontend/tests/e2e/smoke-commission-preview.spec.ts
@@ -3,9 +3,26 @@ import { test, expect } from '@playwright/test';
 /**
  * Expect 404 on production because commission_engine_v1 is OFF by default.
  * (When we enable on staging later, we will override BASE_URL in CI to hit staging and expect 200.)
+ *
+ * QUARANTINE (Pass SMOKE-COMMISSION-QUARANTINE-01, 2026-01-27):
+ * Production returns 500 instead of 401/403/404 when flag is OFF.
+ * This is a backend bug - the endpoint throws an unhandled exception.
+ * Skipping on production until backend properly returns 404 when flag is disabled.
+ *
+ * TODO: Remove skip when backend returns proper 404 for disabled commission endpoint
+ * Tracking: Backend should catch the disabled-flag case and return 404 gracefully
  */
 test('commission-preview endpoint guarded when flag OFF', async ({ request }) => {
   const base = process.env.BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'https://dixis.gr';
+
+  // Pass SMOKE-COMMISSION-QUARANTINE-01: Skip on production (dixis.gr) until backend fix
+  // Production returns 500 (unhandled exception) instead of 401/403/404
+  const isProduction = base.includes('dixis.gr');
+  if (isProduction) {
+    test.skip(true, 'QUARANTINE: Production returns 500 instead of 404 when commission flag OFF. Backend fix needed.');
+    return;
+  }
+
   // Use a benign order id; endpoint should be hidden (404) when flag OFF
   const res = await request.get(`${base}/api/orders/123/commission-preview`, { timeout: 45000 });
   expect([401, 403, 404]).toContain(res.status());


### PR DESCRIPTION
## Summary

Quarantine the `smoke-commission-preview.spec.ts` test on production until backend properly handles disabled commission flag.

## Root Cause (from CI logs Run 21391062727)

```
BASE_URL: https://dixis.gr
FLAG_COMMISSION_V1: false
Expected: [401, 403, 404]
Actual: 500
```

The backend endpoint `/api/orders/{id}/commission-preview` returns **500 Internal Server Error** instead of returning 401/403/404 when the `FLAG_COMMISSION_V1` is disabled. This is an unhandled exception in the backend.

## Solution

Skip the test **only on production** (dixis.gr) with clear documentation:
- Test still runs on staging, localhost, and other environments
- Clear TODO comment explaining when to re-enable
- No backend changes (test-only fix)

## Why This Is Safe

1. **Not hiding the bug**: The 500 is documented; we just stop failing CI on a known issue
2. **Reversible**: Remove the skip condition when backend is fixed
3. **Scoped**: Only affects production smoke-matrix job
4. **Test still active**: Runs on non-production environments

## Files Changed

| File | Change |
|------|--------|
| `frontend/tests/e2e/smoke-commission-preview.spec.ts` | +17 lines (skip logic + docs) |

## How to Un-Quarantine

When backend returns 404 (not 500) for disabled commission endpoint:

1. Test on production: `curl -I https://dixis.gr/api/orders/123/commission-preview`
2. If status is 404 (not 500), remove lines 21-25 from the test
3. Run smoke tests to verify: `BASE_URL=https://dixis.gr npx playwright test smoke-commission-preview.spec.ts`

## Evidence

Local test run against production:
```
BASE_URL=https://dixis.gr npx playwright test smoke-healthz.spec.ts smoke-commission-preview.spec.ts

Running 2 tests using 2 workers
  -  1 smoke-commission-preview.spec.ts:15:5 › commission-preview endpoint guarded when flag OFF
  ✓  2 smoke-healthz.spec.ts:3:5 › healthz is healthy
  1 skipped
  1 passed
```

---

_Pass-SMOKE-COMMISSION-QUARANTINE-01 | 2026-01-27_