### PR TITLE
fix: remove shipping_address from Orders API responses (PII)

### DIFF
--- a/backend/app/Http/Resources/OrderResource.php
+++ b/backend/app/Http/Resources/OrderResource.php
@@ -68,8 +68,8 @@ class OrderResource extends JsonResource
             'payment_reference' => $this->payment_reference, // Pass 51: external session/transaction ID
             'shipping_method' => $shippingMethodCode,
             'shipping_method_label' => $shippingMethodLabels[$shippingMethodCode] ?? $shippingMethodCode,
-            // Shipping address (structured object, null if not set)
-            'shipping_address' => $this->shipping_address,
+            // PII REMOVED: shipping_address is not exposed in API responses (GDPR/security)
+            // Internal use only via Order model; emails use OrderEmailService which reads model directly
             // Delivery notes
             'notes' => $this->notes,
             // Financial fields - use both new and legacy field names for frontend compatibility


### PR DESCRIPTION
## Summary
- Remove `shipping_address` from OrderResource API responses
- Prevents PII exposure (GDPR/security compliance)
- Internal use continues via Order model (emails use OrderEmailService)

## Proof
```
✓ OrdersApiTest         (7 passed)
✓ OrdersCreateApiTest   (11 passed)
```

## Changes
- `backend/app/Http/Resources/OrderResource.php` (+2/-2 lines)

## Test plan
- [x] php artisan test --filter=OrdersApiTest
- [x] php artisan test --filter=OrdersCreateApiTest
- [x] Verify shipping_address no longer appears in API responses

## Out of scope (next PRs)
- Pennant/features table missing (10 tests)
- FrontendSmokeTest (1)
- Shipping audit / VAT work