### PR TITLE
fix: add Pennant features table migration (unblock tests)

### DIFF
--- a/backend/database/migrations/2026_01_27_113358_create_features_table.php
+++ b/backend/database/migrations/2026_01_27_113358_create_features_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Pennant\Migrations\PennantMigration;
+
+return new class extends PennantMigration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('features', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('scope');
+            $table->text('value');
+            $table->timestamps();
+
+            $table->unique(['name', 'scope']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('features');
+    }
+};


### PR DESCRIPTION
## Scope
- Add Laravel Pennant migration so the `features` table exists
- Fixes: `SQLSTATE[42P01]: Undefined table: relation "features" does not exist`

## Proof (Tests GREEN)
```
PASS  Tests\Feature\Services\CommissionServiceTest
✓ returns zero when flag is off                                        0.36s  
✓ returns structured response                                          0.01s  
✓ handles different order amounts                                      0.01s  
✓ resolve rule returns null when flag off                              0.01s  
Tests: 4 passed (16 assertions)

PASS  Tests\Feature\FeatureFlagHealthTest
✓ commission engine v1 defaults to off                                 0.36s  
✓ commission engine v1 can be toggled                                  0.01s  
✓ commission engine v1 is isolated                                     0.01s  
Tests: 3 passed (4 assertions)
```

## Out of scope
- OrderCommissionPreviewTest failures (unrelated constraint issue)
- PaymentWebhookTest failures (unrelated check constraint)
- FrontendSmokeTest
- Shipping/VAT/audit work