### PR TITLE
fix: add 'unpaid' to orders.payment_status check constraint

### DIFF
--- a/backend/database/migrations/2026_01_27_113858_fix_orders_payment_status_check_add_unpaid.php
+++ b/backend/database/migrations/2026_01_27_113858_fix_orders_payment_status_check_add_unpaid.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Fix orders_payment_status_check constraint to include 'unpaid' status
+     * which is used by PaymentWebhookTest and PaymentCheckoutController.
+     */
+    public function up(): void
+    {
+        // Only run on PostgreSQL
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        // Drop existing constraint and recreate with 'unpaid' included
+        DB::statement('ALTER TABLE orders DROP CONSTRAINT IF EXISTS orders_payment_status_check');
+        DB::statement("ALTER TABLE orders ADD CONSTRAINT orders_payment_status_check CHECK (payment_status IN ('unpaid', 'pending', 'paid', 'completed', 'failed', 'refunded'))");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Only run on PostgreSQL
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        // Revert to previous constraint without 'unpaid'
+        DB::statement('ALTER TABLE orders DROP CONSTRAINT IF EXISTS orders_payment_status_check');
+        DB::statement("ALTER TABLE orders ADD CONSTRAINT orders_payment_status_check CHECK (payment_status IN ('pending', 'paid', 'completed', 'failed', 'refunded'))");
+    }
+};


### PR DESCRIPTION
## Scope
- Fix Postgres CHECK constraint `orders_payment_status_check` to include `'unpaid'` status
- Required by PaymentWebhookTest and PaymentCheckoutController

## Proof (PaymentWebhookTest GREEN)
```
PASS  Tests\Feature\PaymentWebhookTest
✓ webhook without signature returns 400                                0.32s  
✓ webhook with invalid signature returns 400                           0.01s  
✓ webhook without secret configured returns 503                        0.01s  
✓ payment status transitions are valid                                 0.01s  
✓ idempotent webhook does not change paid order                        0.02s  
✓ order has payment provider and reference fields                      0.01s  
✓ cod order has null payment provider                                  0.01s  
Tests: 7 passed (15 assertions)
```

## Out of scope
- OrderCommissionPreviewTest (missing `total_cents` column - separate issue)
- Pennant/features table (handled in PR #2511)
- Shipping/VAT/audit work