### PR TITLE
docs: update Pass PRODUCER-THRESHOLD-POSTALCODE-01 status to MERGED

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-PRODUCER-THRESHOLD-POSTALCODE-01.md
+++ b/docs/AGENT/SUMMARY/Pass-PRODUCER-THRESHOLD-POSTALCODE-01.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-01-28
 **PR**: #2527
-**Result**: 🟡 OPEN (PR #2527)
+**Result**: ✅ MERGED (commit `82e871d8`)
 
 ## What
 

--- a/docs/AGENT/TASKS/Pass-PRODUCER-THRESHOLD-POSTALCODE-01.md
+++ b/docs/AGENT/TASKS/Pass-PRODUCER-THRESHOLD-POSTALCODE-01.md
@@ -3,7 +3,7 @@
 **Pass ID**: PRODUCER-THRESHOLD-POSTALCODE-01
 **PR**: #2527
 **Branch**: `feat/passPRODUCER-THRESHOLD-POSTALCODE-01`
-**Status**: 🟡 OPEN
+**Status**: ✅ MERGED (commit `82e871d8`)
 
 ## Objective
 

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -9,7 +9,7 @@
 
 ## 2026-01-28 — Pass-PRODUCER-THRESHOLD-POSTALCODE-01: Per-Producer Free Shipping Threshold
 
-**Status**: 🟡 OPEN — PR #2527
+**Status**: ✅ MERGED — PR #2527 (commit `82e871d8`)
 
 **Branch**: `feat/passPRODUCER-THRESHOLD-POSTALCODE-01`
 


### PR DESCRIPTION
## Summary
- Update docs to reflect PR #2527 merged status (commit `82e871d8`)

## Changes
- docs/OPS/STATE.md: OPEN → MERGED
- docs/AGENT/SUMMARY/Pass-*.md: OPEN → MERGED
- docs/AGENT/TASKS/Pass-*.md: OPEN → MERGED

## Test plan
- [x] Docs-only change