### PR TITLE
data: seed user hygiene (block seed logins)

### DIFF
--- a/backend/app/Console/Commands/MarkSeedUsers.php
+++ b/backend/app/Console/Commands/MarkSeedUsers.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+/**
+ * Mark seed/test users to prevent login in production.
+ *
+ * Usage:
+ *   php artisan users:mark-seed                    # Mark all @example.com users
+ *   php artisan users:mark-seed --dry-run          # Preview without changes
+ *   php artisan users:mark-seed --email=test@foo   # Mark specific email
+ *   php artisan users:mark-seed --unmark           # Remove is_seed flag
+ */
+class MarkSeedUsers extends Command
+{
+    protected $signature = 'users:mark-seed
+        {--dry-run : Preview changes without applying}
+        {--email= : Mark specific email address}
+        {--unmark : Remove is_seed flag instead of setting it}';
+
+    protected $description = 'Mark seed/test user accounts (blocks login)';
+
+    /**
+     * Patterns that identify seed/test accounts.
+     */
+    protected array $seedPatterns = [
+        '%@example.com',
+        '%@example.org',
+        '%@test.com',
+        '%@demo.dixis.gr',
+    ];
+
+    public function handle(): int
+    {
+        $dryRun = $this->option('dry-run');
+        $specificEmail = $this->option('email');
+        $unmark = $this->option('unmark');
+
+        $action = $unmark ? 'Unmarking' : 'Marking';
+        $this->info("[{$action} seed users] " . ($dryRun ? '(DRY RUN)' : ''));
+
+        // Build query
+        $query = User::query();
+
+        if ($specificEmail) {
+            $query->where('email', $specificEmail);
+        } else {
+            $query->where(function ($q) {
+                foreach ($this->seedPatterns as $pattern) {
+                    $q->orWhere('email', 'LIKE', $pattern);
+                }
+            });
+        }
+
+        $users = $query->get(['id', 'email', 'name', 'is_seed']);
+
+        if ($users->isEmpty()) {
+            $this->warn('No matching users found.');
+            return Command::SUCCESS;
+        }
+
+        $this->newLine();
+        $this->table(
+            ['ID', 'Email', 'Name', 'Current is_seed'],
+            $users->map(fn ($u) => [$u->id, $u->email, $u->name, $u->is_seed ? 'true' : 'false'])
+        );
+        $this->newLine();
+
+        if ($dryRun) {
+            $this->info("[DRY RUN] Would " . ($unmark ? 'unmark' : 'mark') . " {$users->count()} user(s).");
+            return Command::SUCCESS;
+        }
+
+        // Apply changes
+        $newValue = !$unmark;
+        $updated = User::whereIn('id', $users->pluck('id'))->update(['is_seed' => $newValue]);
+
+        $this->info("[OK] Updated {$updated} user(s): is_seed = " . ($newValue ? 'true' : 'false'));
+
+        return Command::SUCCESS;
+    }
+}

--- a/backend/app/Http/Controllers/Api/AuthController.php
+++ b/backend/app/Http/Controllers/Api/AuthController.php
@@ -107,6 +107,14 @@ class AuthController extends Controller
             ], 401);
         }
 
+        // Block seed/test accounts from login (data hygiene)
+        if ($user->is_seed) {
+            return response()->json([
+                'message' => 'Account disabled',
+                'error' => 'This is a seed/test account and cannot be used for login.',
+            ], 403);
+        }
+
         // Revoke existing tokens (optional - for single device login)
         // $user->tokens()->delete();
 

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -46,6 +46,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_seed' => 'boolean',
         ];
     }
 

--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -30,6 +30,7 @@ class UserFactory extends Factory
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
             'role' => 'consumer',
+            'is_seed' => false,
         ];
     }
 
@@ -70,6 +71,16 @@ class UserFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
+        ]);
+    }
+
+    /**
+     * Mark user as a seed/test account (blocked from login).
+     */
+    public function seed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_seed' => true,
         ]);
     }
 }

--- a/backend/database/migrations/2026_01_30_190000_add_is_seed_to_users_table.php
+++ b/backend/database/migrations/2026_01_30_190000_add_is_seed_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     * Adds is_seed flag to identify seed/test accounts that should be blocked from login.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_seed')->default(false)->index()->after('role');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_seed');
+        });
+    }
+};

--- a/backend/tests/Feature/SeedUserLoginTest.php
+++ b/backend/tests/Feature/SeedUserLoginTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+/**
+ * Tests for seed user login blocking (data hygiene).
+ * Ensures is_seed=true users cannot login while normal users still can.
+ */
+#[Group('auth')]
+#[Group('seed')]
+class SeedUserLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that a seed user (is_seed=true) cannot login.
+     */
+    public function test_seed_user_cannot_login(): void
+    {
+        // Create user marked as seed
+        $user = User::factory()->create([
+            'email' => 'seed@example.com',
+            'password' => Hash::make('password123'),
+            'is_seed' => true,
+        ]);
+
+        $response = $this->postJson('/api/v1/auth/login', [
+            'email' => 'seed@example.com',
+            'password' => 'password123',
+        ]);
+
+        $response->assertStatus(403)
+            ->assertJson([
+                'message' => 'Account disabled',
+            ]);
+
+        // Ensure no token was created
+        $this->assertCount(0, $user->fresh()->tokens);
+    }
+
+    /**
+     * Test that a normal user (is_seed=false) can still login.
+     */
+    public function test_normal_user_can_login(): void
+    {
+        // Create normal user (is_seed defaults to false)
+        $user = User::factory()->create([
+            'email' => 'real@customer.gr',
+            'password' => Hash::make('password123'),
+            'is_seed' => false,
+        ]);
+
+        $response = $this->postJson('/api/v1/auth/login', [
+            'email' => 'real@customer.gr',
+            'password' => 'password123',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'Login successful',
+            ])
+            ->assertJsonStructure(['token']);
+
+        // Ensure token was created
+        $this->assertCount(1, $user->fresh()->tokens);
+    }
+
+    /**
+     * Test that is_seed column exists and defaults to false.
+     */
+    public function test_is_seed_defaults_to_false(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'new@user.gr',
+            'password' => Hash::make('password123'),
+        ]);
+
+        $this->assertFalse($user->is_seed);
+        $this->assertDatabaseHas('users', [
+            'email' => 'new@user.gr',
+            'is_seed' => false,
+        ]);
+    }
+
+    /**
+     * Test that seed user gets 403, not 401 (important for frontend handling).
+     */
+    public function test_seed_user_gets_403_not_401(): void
+    {
+        User::factory()->create([
+            'email' => 'demo@example.com',
+            'password' => Hash::make('demo123'),
+            'is_seed' => true,
+        ]);
+
+        $response = $this->postJson('/api/v1/auth/login', [
+            'email' => 'demo@example.com',
+            'password' => 'demo123',
+        ]);
+
+        // Must be 403 (forbidden), not 401 (unauthorized)
+        // This distinguishes "blocked account" from "wrong password"
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `users.is_seed` boolean column (default false, indexed)
- Blocks login for `is_seed=true` users with 403 response
- Adds `php artisan users:mark-seed` command to mark @example.com accounts
- Includes 4 feature tests for seed user login blocking

## Non-destructive
This does NOT delete any data. Seed accounts can be:
1. Marked with `is_seed=true` to block login
2. Unmarked with `--unmark` flag to restore access

## After merge
Run on VPS:
```bash
cd /var/www/dixis/current/backend
php artisan migrate
php artisan users:mark-seed --dry-run  # Preview
php artisan users:mark-seed            # Apply
```

## Test plan
- [ ] CI passes (migration + tests)
- [ ] Login with seed user → 403
- [ ] Login with normal user → 200 + token