### PR TITLE
docs: summaries for producer orders fixes (#2548, #2549)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-HYDRATION-PRODUCER-ORDERS-01.md
+++ b/docs/AGENT/SUMMARY/Pass-HYDRATION-PRODUCER-ORDERS-01.md
@@ -1,0 +1,46 @@
+# Summary: Pass-HYDRATION-PRODUCER-ORDERS-01
+
+**Date**: 2026-01-30
+**Status**: COMPLETE
+**PR**: #2548
+
+---
+
+## TL;DR
+
+Fixed React hydration error #418 on `/producer/orders` by deferring date rendering until client-side mount with `mounted` state guard and semantic `<time>` element.
+
+---
+
+## Problem
+
+`/producer/orders` displayed "Σφάλμα στην Περιοχή Παραγωγού" error with React #418 (hydration mismatch). Producer dashboard worked; only orders page with dates failed.
+
+---
+
+## Root Cause
+
+`toLocaleString('el-GR', ...)` on `order.created_at` produced different output between server (UTC) and client (local timezone), causing hydration mismatch.
+
+---
+
+## Solution
+
+1. Added `mounted` state guard with `useEffect`
+2. Changed `<p>` to semantic `<time>` element with `dateTime` attribute
+3. Added `suppressHydrationWarning` for extra safety
+4. Added regression test capturing console errors for #418
+
+---
+
+## Evidence
+
+| Metric | Before | After |
+|--------|--------|-------|
+| `/producer/orders` | Error #418 | Works |
+| VPS commit | — | f6324107 |
+| CI checks | — | All GREEN |
+
+---
+
+_Pass-HYDRATION-PRODUCER-ORDERS-01 | 2026-01-30 | COMPLETE_

--- a/docs/AGENT/SUMMARY/Pass-PRODUCER-ORDERS-ITEMS-SHAPE-01.md
+++ b/docs/AGENT/SUMMARY/Pass-PRODUCER-ORDERS-ITEMS-SHAPE-01.md
@@ -1,0 +1,46 @@
+# Summary: Pass-PRODUCER-ORDERS-ITEMS-SHAPE-01
+
+**Date**: 2026-01-30
+**Status**: COMPLETE
+**PR**: #2549
+
+---
+
+## TL;DR
+
+Fixed crash on `/producer/orders` by normalizing API response from snake_case (`order_items`) to camelCase (`orderItems`) in the frontend API layer.
+
+---
+
+## Problem
+
+`/producer/orders` crashed with `TypeError: Cannot read properties of undefined (reading 'length')` at `order.orderItems.length`. The error boundary displayed "Σφάλμα στην Περιοχή Παραγωγού".
+
+---
+
+## Root Cause
+
+Backend returns `order_items` (Laravel snake_case). Frontend expected `orderItems` (camelCase).
+
+---
+
+## Solution
+
+1. Added `ProducerOrderRaw` interface accepting both field names
+2. Normalized in API layer: `orderItems: order.orderItems ?? order.order_items ?? []`
+3. Added defensive `?? []` in UI
+4. Added regression test with snake_case mock
+
+---
+
+## Evidence
+
+| Metric | Before | After |
+|--------|--------|-------|
+| `/producer/orders` | Crash | Works |
+| "Προϊόντα (3)" | Undefined error | Renders |
+| VPS bundle | page-3de9... | page-31850... |
+
+---
+
+_Pass-PRODUCER-ORDERS-ITEMS-SHAPE-01 | 2026-01-30 | COMPLETE_

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,99 @@
 # OPS STATE
 
-**Last Updated**: 2026-01-28 (Pass-PRODUCER-THRESHOLD-POSTALCODE-01)
+**Last Updated**: 2026-01-30 (Pass-PRODUCER-ORDERS-ITEMS-SHAPE-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~750 lines (target ≤250). ⚠️
+> **Current size**: ~800 lines (target ≤250). ⚠️
+
+---
+
+## 2026-01-30 — Pass-PRODUCER-ORDERS-ITEMS-SHAPE-01: Fix order_items snake_case crash
+
+**Status**: ✅ MERGED & DEPLOYED — PR #2549 (commit `6c1b2a97`)
+
+**Branch**: `fix/producer-orders-order-items-shape`
+
+**Objective**: Fix crash on `/producer/orders` due to API returning `order_items` (snake_case) while frontend expected `orderItems` (camelCase).
+
+**Root Cause**:
+Backend `ProducerOrderController` returns orders with Laravel's default snake_case JSON serialization (`order_items`), but frontend TypeScript types and UI code expected camelCase (`orderItems`). This caused:
+```
+TypeError: Cannot read properties of undefined (reading 'length')
+```
+...which triggered the error boundary.
+
+**Fix**:
+- Added `ProducerOrderRaw` interface accepting both snake/camelCase
+- Normalized in API layer: `getProducerOrders`, `getProducerOrder`, `updateProducerOrderStatus`
+- Added defensive fallback in UI: `(order.orderItems ?? [])`
+- Added regression test with snake_case mock data
+
+**Changes** (3 files, +123/-5):
+
+| File | Change |
+|------|--------|
+| `frontend/src/lib/api.ts` | ProducerOrderRaw + normalization in API methods |
+| `frontend/src/app/producer/orders/page.tsx` | Defensive `?? []` fallback |
+| `frontend/tests/e2e/producer-orders-management.spec.ts` | Snake_case regression test |
+
+**DoD**:
+- [x] Build passes
+- [x] TypeScript type-check passes
+- [x] E2E regression test added (snake_case order_items mock)
+- [x] CI all checks pass
+- [x] Deployed to production
+- [x] Production proof: /producer/orders works as Producer User
+
+**Evidence**:
+- PR: https://github.com/lomendor/Project-Dixis/pull/2549
+- Deploy Frontend: run 21532035372 ✅
+- VPS bundle: `page-31850167b0476c26.js`
+- Production proof: Orders render with "Προϊόντα (3)" count ✅
+
+---
+
+## 2026-01-30 — Pass-HYDRATION-PRODUCER-ORDERS-01: Fix React #418 on Producer Orders
+
+**Status**: ✅ MERGED & DEPLOYED — PR #2548 (commit `f6324107`)
+
+**Branch**: `fix/producer-orders-hydration`
+
+**Objective**: Fix React hydration error #418 on `/producer/orders` page causing error boundary display.
+
+**Root Cause**:
+`toLocaleDateString('el-GR', ...)` in `OrderCard` component produced different output:
+- Server (SSR): UTC timezone
+- Client: User's local timezone (e.g., Europe/Athens)
+- Mismatch triggered React #418, caught by error boundary showing "Σφάλμα στην Περιοχή Παραγωγού"
+
+**Fix**:
+- Added `mounted` state guard to defer date rendering until after hydration
+- Used semantic `<time>` element with `dateTime` attribute
+- Added `suppressHydrationWarning` as safety belt
+- Changed `toLocaleDateString` → `toLocaleString` (more inclusive)
+
+**Changes** (2 files, +75/-20):
+
+| File | Change |
+|------|--------|
+| `frontend/src/app/producer/orders/page.tsx` | Mounted guard + `<time>` element |
+| `frontend/tests/e2e/producer-orders-management.spec.ts` | Hydration regression test |
+
+**DoD**:
+- [x] Build passes
+- [x] TypeScript type-check passes
+- [x] E2E regression test added (checks for error boundary + console #418)
+- [x] CI all checks pass
+- [x] Deployed to production
+- [x] VPS commit matches PR
+
+**Evidence**:
+- PR: https://github.com/lomendor/Project-Dixis/pull/2548
+- Deploy Backend: run 21531117405 ✅
+- Deploy Frontend: run 21531118848 ✅
+- VPS commit: `f6324107 fix(frontend): resolve React hydration error #418 on producer orders page (#2548)`
+
+**Security Cleanup**: Revoked 4 debug tokens for user_id=10 created during investigation.
 
 ---
 


### PR DESCRIPTION
## What
Docs-only PR:
- Update `docs/OPS/STATE.md` with:
  - Pass-HYDRATION-PRODUCER-ORDERS-01 (PR #2548)
  - Pass-PRODUCER-ORDERS-ITEMS-SHAPE-01 (PR #2549)
- Add summaries:
  - `docs/AGENT/SUMMARY/Pass-HYDRATION-PRODUCER-ORDERS-01.md`
  - `docs/AGENT/SUMMARY/Pass-PRODUCER-ORDERS-ITEMS-SHAPE-01.md`

## Why
Keep continuity + traceability across chats/passes (STATE + SUMMARY as source of truth).

## Scope / Safety
Docs only. No code or behavior changes.

## Test plan
N/A (docs only)