### PR TITLE
fix(ui): complete producer status copy cleanup - inactive state

### DIFF
--- a/frontend/src/app/my/products/page.tsx
+++ b/frontend/src/app/my/products/page.tsx
@@ -252,16 +252,16 @@ function ProducerProductsContent() {
                   </div>
                 </div>
               ) : (
-                // Profile rejected
+                // Profile inactive/suspended
                 <div>
                   <div className="w-16 h-16 mx-auto mb-4 bg-red-100 rounded-full flex items-center justify-center">
                     <span className="text-2xl">❌</span>
                   </div>
                   <h2 className="text-xl font-semibold text-gray-900 mb-2" data-testid="rejected-title">
-                    Αίτηση Απορρίφθηκε
+                    Λογαριασμός Ανενεργός
                   </h2>
                   <p className="text-gray-600 mb-6" data-testid="rejected-message">
-                    Δυστυχώς η αίτησή σας δεν μπορεί να εγκριθεί αυτή τη στιγμή. Επικοινωνήστε μαζί μας για περισσότερες πληροφορίες.
+                    Ο λογαριασμός σας είναι προσωρινά ανενεργός. Επικοινωνήστε μαζί μας για περισσότερες πληροφορίες.
                   </p>
                   <div className="space-y-3">
                     <button


### PR DESCRIPTION
## Summary
Follow-up to #2561: fix remaining misleading copy for inactive producer state that was missed.

## Change
- "Αίτηση Απορρίφθηκε" → "Λογαριασμός Ανενεργός" (Application Rejected → Account Inactive)

## Files Changed
- `frontend/src/app/my/products/page.tsx` (1 string, 3 lines)

---
*Generated-by: Claude Code (Pass-PRODUCER-STATUS-COPY-CLARITY-02)*