### PR TITLE
fix(hydration): harden against hydration mismatch (Pass FIX-ADMIN-DASHBOARD-418-02)

### DIFF
--- a/frontend/src/app/dev/notifications/page.tsx
+++ b/frontend/src/app/dev/notifications/page.tsx
@@ -3,6 +3,16 @@ import { renderSMS } from '@/lib/notify/templates';
 
 export const dynamic = 'force-dynamic';
 
+/**
+ * Pass FIX-ADMIN-DASHBOARD-418-02: Deterministic date formatter for Server Components.
+ * Using toISOString() slice avoids hydration mismatch from locale-dependent formatting.
+ */
+function formatDateStable(date: Date | string | null): string {
+  if (!date) return '—';
+  const d = new Date(date);
+  return d.toISOString().slice(0, 16).replace('T', ' ');
+}
+
 function maskPhone(v:string){
   if(!v) return '';
   const digits = v.replace(/\D/g,'');
@@ -35,7 +45,7 @@ export default async function Page(){
         <tbody>
           {rows.map((n: any)=>(
             <tr key={n.id} style={{borderTop:'1px solid #eee'}}>
-              <td style={{padding:'0.5rem'}}>{new Date(n.createdAt as any).toLocaleString()}</td>
+              <td style={{padding:'0.5rem'}}>{formatDateStable(n.createdAt)}</td>
               <td style={{padding:'0.5rem'}}>{n.channel}</td>
               <td style={{padding:'0.5rem'}}>{maskPhone(n.to as any)}</td>
               <td style={{padding:'0.5rem'}}>{n.template}</td>

--- a/frontend/src/app/track/[token]/page.tsx
+++ b/frontend/src/app/track/[token]/page.tsx
@@ -1,5 +1,16 @@
 import StatusBadge from '@/components/admin/StatusBadge'
 
+/**
+ * Pass FIX-ADMIN-DASHBOARD-418-02: Deterministic date formatter for Server Components.
+ * Using toISOString() slice avoids hydration mismatch from locale-dependent formatting.
+ */
+function formatDateStable(date: string | Date | null): string {
+  if (!date) return '—';
+  const d = new Date(date);
+  // Format: YYYY-MM-DD HH:MM (stable across server/client)
+  return d.toISOString().slice(0, 16).replace('T', ' ');
+}
+
 async function fetchData(token:string){
   const base = process.env.NEXT_PUBLIC_SITE_URL || ''
   const res = await fetch(`${base}/api/track/${token}`, { cache:'no-store' })
@@ -19,7 +30,7 @@ export default async function TrackPage({ params }:{ params:{ token:string } }){
         <span style={{opacity:0.7}}>Κατάσταση:</span><StatusBadge status={data.status}/>
       </div>
       <div style={{opacity:0.8, marginTop:6}}>
-        <div>Ημ/νία: {data.createdAt ? new Date(data.createdAt).toLocaleString('el-GR') : '—'}</div>
+        <div>Ημ/νία: {formatDateStable(data.createdAt)}</div>
         <div>Πελάτης: {data.buyerName || '—'}</div>
         <div>Σύνολο: {typeof data.total === 'number' ? fmt(data.total) : '—'}</div>
       </div>


### PR DESCRIPTION
## Summary
Remove remaining locale/timezone-dependent date formatting from Server Components to prevent hydration mismatch (#418).

## Files Fixed
1. `src/app/track/[token]/page.tsx` - **User-facing order tracking page**
2. `src/app/dev/notifications/page.tsx` - Dev notifications outbox

## Root cause
Server Components using `toLocaleString()` produce different output on server (UTC) vs client (local timezone), causing React hydration error #418.

## Fix
Added `formatDateStable()` function using ISO-based format (YYYY-MM-DD HH:MM) that is stable across server/client.

## Test plan
- [x] CI (build/typecheck)
- [ ] Manual: Navigate to /track/[token] - no console #418