### PR TITLE
chore: gitignore pass verification reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,9 @@ frontend/prisma/ci.db
 # Local ops outputs (untracked - use for dev/CI artifacts)
 docs/OPS/.local/
 docs/OPS/PROD-FACTS-LAST.md
+
+# Pass verification reports (local-only, not committed)
+docs/PROD-*.md
+docs/PR*-REPORT.md
+docs/PR*-VERIFICATION-REPORT.md
+docs/AGENT/SUMMARY/Pass-*.md


### PR DESCRIPTION
## Summary
Add patterns to exclude local-only Pass verification reports that are generated during development/verification cycles.

**Changes:**
- `docs/PROD-*.md` - Production verification reports
- `docs/PR*-REPORT.md` - PR verification reports  
- `docs/AGENT/SUMMARY/Pass-*.md` - Pass summary documents

These docs exist locally for reference but shouldn't clutter `git status`.

## Test plan
- [x] Verify patterns match intended files
- [x] No production code affected

---
Generated-by: Claude Code | Pass: FIX-ADMIN-DASHBOARD-418-02