### PR TITLE
fix(hydration): stabilize homepage/admin auth markup (Pass FIX-HOMEPAGE-HYDRATION-01)

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -10,8 +10,12 @@ export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
-  const { user, logout, isAuthenticated, isProducer, isAdmin } = useAuth();
+  const { user, logout, isAuthenticated, isProducer, isAdmin, isHydrated, loading } = useAuth();
   const t = useTranslations();
+
+  // Pass FIX-HOMEPAGE-HYDRATION-01: Don't render auth-dependent UI until hydration is complete.
+  // This prevents hydration mismatch where server renders "guest" but client tries to render "authenticated".
+  const showAuthUI = isHydrated && !loading;
 
   // Close user menu when clicking outside
   useEffect(() => {
@@ -78,8 +82,11 @@ export default function Header() {
           {/* Cart - visible for all roles */}
           <CartIcon data-testid="header-cart" />
 
-          {/* Auth Section */}
-          {isAuthenticated ? (
+          {/* Auth Section - Pass FIX-HOMEPAGE-HYDRATION-01: Gate until hydrated */}
+          {!showAuthUI ? (
+            /* Loading placeholder - same width as auth buttons to prevent layout shift */
+            <div className="w-[140px] h-10 bg-neutral-100 rounded-md animate-pulse" aria-hidden="true" />
+          ) : isAuthenticated ? (
             /* User Dropdown */
             <div className="relative" ref={userMenuRef}>
               <button
@@ -234,9 +241,14 @@ export default function Header() {
               </Link>
             ))}
 
-            {/* Auth Section */}
+            {/* Auth Section - Pass FIX-HOMEPAGE-HYDRATION-01: Gate until hydrated */}
             <div className="border-t border-neutral-200 mt-2 pt-2">
-              {isAuthenticated ? (
+              {!showAuthUI ? (
+                /* Loading placeholder for mobile */
+                <div className="flex items-center justify-center min-h-[48px] py-3">
+                  <div className="w-24 h-6 bg-neutral-100 rounded animate-pulse" aria-hidden="true" />
+                </div>
+              ) : isAuthenticated ? (
                 <>
                   {/* Role-specific links */}
                   {!isProducer && !isAdmin && (

--- a/frontend/tests/e2e/home-hydration.spec.ts
+++ b/frontend/tests/e2e/home-hydration.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Pass FIX-HOMEPAGE-HYDRATION-01: Verify no React hydration errors on homepage.
+ *
+ * This test catches React error #418 (hydration mismatch) that occurs when
+ * server-rendered HTML doesn't match client-side initial render.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('Homepage Hydration', () => {
+  test('should load homepage without React hydration errors', async ({ page }) => {
+    // Collect console errors
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    // Navigate to homepage
+    await page.goto('/');
+
+    // Wait for page to be fully loaded and interactive
+    await page.waitForLoadState('networkidle');
+
+    // Wait a bit for any async hydration to complete
+    await page.waitForTimeout(1000);
+
+    // Check for React hydration error #418
+    const hydrationErrors = consoleErrors.filter(
+      (error) =>
+        error.includes('Minified React error #418') ||
+        error.includes('Hydration failed') ||
+        error.includes('Text content does not match') ||
+        error.includes('did not match')
+    );
+
+    // Log all errors for debugging
+    if (consoleErrors.length > 0) {
+      console.log('Console errors found:', consoleErrors);
+    }
+
+    // Assert no hydration errors
+    expect(hydrationErrors, 'Expected no React hydration errors').toHaveLength(0);
+  });
+
+  test('should load homepage with auth loading state visible briefly', async ({ page }) => {
+    // Navigate to homepage
+    await page.goto('/');
+
+    // The auth loading placeholder should exist briefly or the actual auth UI
+    // This test ensures the page renders something (not blank)
+    const header = page.locator('header');
+    await expect(header).toBeVisible();
+
+    // Page should have main content
+    const main = page.locator('main[data-testid="page-root"]');
+    await expect(main).toBeVisible();
+  });
+
+  test('should not show React error #418 when navigating between pages', async ({ page }) => {
+    // Collect console errors
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    // Start at homepage
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Navigate to products page
+    await page.click('a[href="/products"]');
+    await page.waitForLoadState('networkidle');
+
+    // Navigate back to homepage
+    await page.click('header a[data-testid="header-logo"]');
+    await page.waitForLoadState('networkidle');
+
+    // Check for hydration errors accumulated during navigation
+    const hydrationErrors = consoleErrors.filter(
+      (error) =>
+        error.includes('Minified React error #418') ||
+        error.includes('Hydration failed')
+    );
+
+    expect(hydrationErrors, 'Expected no React hydration errors during navigation').toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Fix React #418 hydration error caused by auth state mismatch between SSR and first client render.

## Root cause
- `getInitialAuthState()` read localStorage during component render
- Server rendered with `hasToken=false` (no localStorage on server)
- Client rendered with `hasToken=true` (localStorage has token when logged in)
- Header rendered different DOM based on `isAuthenticated`
- React detected mismatch and threw error #418

## Fix
1. Remove `getInitialAuthState()` that read localStorage during render
2. Always start with `loading=true`, `user=null` on both server and client
3. Add `isHydrated` flag set after first useEffect completes
4. Header shows loading placeholder until `isHydrated && !loading`
5. Add `isAdmin` to AuthContext type for type safety

## Files changed
- `frontend/src/contexts/AuthContext.tsx` - Remove localStorage read during render, add isHydrated
- `frontend/src/components/layout/Header.tsx` - Gate auth UI until hydrated
- `frontend/tests/e2e/home-hydration.spec.ts` - New test to catch hydration errors

## Test plan
- [x] Playwright: Detect React #418 in console
- [ ] Manual: Homepage loads without console errors
- [ ] Manual: /admin redirect behaves consistently
- [ ] CI: All checks green

---
Generated-by: Claude Code | Pass: FIX-HOMEPAGE-HYDRATION-01