### PR TITLE
fix(security): secure producer order-status email API (Pass P0-SEC-01)

### DIFF
--- a/frontend/src/app/api/producer/orders/[id]/status/route.ts
+++ b/frontend/src/app/api/producer/orders/[id]/status/route.ts
@@ -1,55 +1,113 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sendOrderStatusUpdate } from '@/lib/email'
+import { requireProducer } from '@/lib/auth/requireProducer'
+import { prisma } from '@/lib/db/client'
 
 /**
  * POST /api/producer/orders/[id]/status
  *
  * Sends email notification for order status change.
- * The actual status update is done by the client calling the backend directly.
- * This route only handles the email notification (which needs server-side env vars).
+ *
+ * SECURITY:
+ * - Requires authenticated producer session (cookie-based JWT)
+ * - Verifies producer owns at least one item in the order
+ * - Customer email is fetched from trusted order data, not request body
  */
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  let producer;
   try {
-    const { id } = await params
-    const orderId = parseInt(id, 10)
+    producer = await requireProducer();
+  } catch (response) {
+    // requireProducer throws Response on auth failure
+    if (response instanceof Response) {
+      return response;
+    }
+    return NextResponse.json(
+      { success: false, message: 'Απαιτείται είσοδος' },
+      { status: 401 }
+    );
+  }
 
-    if (isNaN(orderId)) {
+  try {
+    const { id: orderId } = await params;
+
+    // Validate order ID format
+    if (!orderId || typeof orderId !== 'string' || orderId.length < 1) {
       return NextResponse.json(
         { success: false, message: 'Invalid order ID' },
         { status: 400 }
-      )
+      );
     }
 
-    const body = await request.json()
-    const { status, customerName, customerEmail, total } = body
+    // Parse request body - only accept status, nothing else
+    const body = await request.json();
+    const { status } = body;
 
     if (!status || !['processing', 'shipped', 'delivered'].includes(status)) {
       return NextResponse.json(
         { success: false, message: 'Invalid status' },
         { status: 400 }
-      )
+      );
     }
 
+    // Fetch order with ownership verification
+    // Producer must have at least one item in this order
+    const order = await prisma.order.findUnique({
+      where: { id: orderId },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        buyerName: true,
+        total: true,
+        items: {
+          where: { producerId: producer.id },
+          select: { id: true }
+        }
+      }
+    });
+
+    if (!order) {
+      return NextResponse.json(
+        { success: false, message: 'Η παραγγελία δεν βρέθηκε' },
+        { status: 404 }
+      );
+    }
+
+    // Ownership check: producer must have items in this order
+    if (!order.items || order.items.length === 0) {
+      console.warn(`[API] Producer ${producer.id} attempted to access order ${orderId} without ownership`);
+      return NextResponse.json(
+        { success: false, message: 'Δεν έχετε πρόσβαση σε αυτή την παραγγελία' },
+        { status: 403 }
+      );
+    }
+
+    // Get customer email from trusted order data, NOT from request body
+    const customerEmail = order.email;
     if (!customerEmail) {
       return NextResponse.json(
-        { success: false, message: 'Customer email required' },
+        { success: false, message: 'Δεν βρέθηκε email πελάτη στην παραγγελία' },
         { status: 400 }
-      )
+      );
     }
+
+    // Get customer name from trusted order data
+    const customerName = order.name || order.buyerName || 'Πελάτη';
 
     // Send email notification
     const emailResult = await sendOrderStatusUpdate({
       data: {
-        orderId,
-        customerName: customerName || 'Πελάτη',
+        orderId: parseInt(orderId, 10) || 0,
+        customerName,
         newStatus: status,
-        total: parseFloat(total || '0'),
+        total: order.total,
       },
       toEmail: customerEmail,
-    })
+    });
 
     return NextResponse.json({
       success: emailResult.ok,
@@ -58,13 +116,13 @@ export async function POST(
       message: emailResult.ok
         ? (emailResult.dryRun ? 'Email skipped (dry-run mode)' : 'Email sent successfully')
         : 'Email failed to send',
-    })
+    });
 
   } catch (error) {
-    console.error('[API] Email notification error:', error)
+    console.error('[API] Email notification error:', error);
     return NextResponse.json(
       { success: false, message: 'Failed to send email notification' },
       { status: 500 }
-    )
+    );
   }
 }

--- a/frontend/tests/e2e/api-producer-order-status-auth.spec.ts
+++ b/frontend/tests/e2e/api-producer-order-status-auth.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Pass P0-SEC-01: Ensure producer order status email API is not callable without auth.
+ * This catches the critical vulnerability where anyone could trigger emails.
+ *
+ * Tests verify:
+ * 1. Unauthenticated requests are rejected (401/403)
+ * 2. Invalid order IDs are rejected (400)
+ * 3. Invalid status values are rejected (400)
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('API security - producer order status @security', () => {
+  test('POST /api/producer/orders/:id/status rejects unauthenticated requests', async ({ request }) => {
+    const res = await request.post('/api/producer/orders/test-order-id/status', {
+      data: { status: 'shipped' }
+    });
+    // Accept either 401 (no session) or 403 (unauthorized)
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/producer/orders/:id/status rejects invalid status values', async ({ request }) => {
+    const res = await request.post('/api/producer/orders/test-order-id/status', {
+      data: { status: 'invalid-status' }
+    });
+    // Should reject - either auth failure first (401/403) or bad request (400)
+    expect([400, 401, 403]).toContain(res.status());
+  });
+
+  test('POST /api/producer/orders/:id/status ignores spoofed customerEmail in body', async ({ request }) => {
+    // Even if someone tries to pass customerEmail in body, it should be rejected
+    // because auth is required first
+    const res = await request.post('/api/producer/orders/fake-order/status', {
+      data: {
+        status: 'shipped',
+        customerEmail: 'spoofed@example.com',
+        customerName: 'Spoofed Name',
+        total: 999999
+      }
+    });
+    // Must reject - auth required
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test('POST without body returns 400 or auth error', async ({ request }) => {
+    const res = await request.post('/api/producer/orders/test-order/status');
+    // Either auth failure (401/403) or bad request (400) for missing body
+    expect([400, 401, 403, 500]).toContain(res.status());
+  });
+});


### PR DESCRIPTION
## 🔒 Critical Security Fix

Close a **critical security vulnerability** in the producer order-status email endpoint.

### Problem
The `/api/producer/orders/[id]/status` endpoint had **NO authentication**:
- Anyone could call this API without being logged in
- The endpoint accepted `customerEmail`, `customerName`, and `total` from the request body
- This allowed attackers to:
  - Send spam emails to arbitrary addresses
  - Spoof order notifications with fake data
  - Impersonate legitimate order updates

### Solution

1. **Authentication Required**: Added `requireProducer()` check
   - Uses existing cookie-based JWT session
   - Returns 401 if not authenticated

2. **Ownership Verification**: Producer must own items in the order
   - Queries `OrderItem` table for `producerId` match
   - Returns 403 if producer doesn't own any items

3. **Anti-Spoofing**: Customer data from trusted source only
   - `customerEmail` fetched from `Order.email`, not request body
   - `customerName` fetched from `Order.name` or `Order.buyerName`
   - `total` fetched from `Order.total`
   - Request body only accepts `{ status }` now

4. **Proper HTTP Status Codes**:
   - 401: Not authenticated
   - 403: Authenticated but doesn't own order
   - 404: Order not found
   - 400: Invalid status or missing email

### Files Changed
- `frontend/src/app/api/producer/orders/[id]/status/route.ts` - Security hardening
- `frontend/tests/e2e/api-producer-order-status-auth.spec.ts` - New security test

### Test Plan
- [ ] Unauthenticated POST returns 401/403
- [ ] Authenticated producer cannot access orders they don't own (403)
- [ ] Authenticated producer CAN send email for their own orders
- [ ] Request body `customerEmail` field is ignored (uses DB value)
- [ ] Invalid status values return 400

### Security Audit Reference
This fix addresses P0 item #1 from the Producer Dashboard Audit (2026-02-01).