### PR TITLE
fix(meta): eliminate OG/Twitter 404 console errors (P0-PROD-SMOKE-404-01)

### DIFF
--- a/docs/AGENT/SUMMARY/Pass-P0-PROD-SMOKE-404-01.md
+++ b/docs/AGENT/SUMMARY/Pass-P0-PROD-SMOKE-404-01.md
@@ -1,0 +1,74 @@
+# Pass P0-PROD-SMOKE-404-01 Summary
+
+**Status**: IN_PROGRESS
+**Date**: 2026-02-02
+**PR**: TBD
+
+## Problem
+
+Production smoke test `reload-and-css.smoke.spec.ts` failed with:
+```
+Error: Console errors on /: Failed to load resource: the server responded with a status of 404 (Not Found)
+```
+
+## Root Cause Analysis
+
+The homepage metadata in `frontend/src/app/page.tsx` referenced non-existent OG images:
+
+| Meta Tag | Referenced URL | Status |
+|----------|----------------|--------|
+| `og:image` | `https://dixis.gr/og-products.jpg` | 404 |
+| `twitter:image` | `https://dixis.gr/twitter-products.jpg` | 404 |
+
+The smoke test captures console errors (excluding `net::` and `ERR_` prefixes) and fails
+when any are present. The 404 resource load generates a console error message that gets captured.
+
+## Investigation Steps
+
+1. Examined CI logs showing "Failed to load resource: 404"
+2. Inspected production HTML with `curl https://dixis.gr/`
+3. Found `og:image` and `twitter:image` meta tags pointing to missing files
+4. Verified 404 status: `curl -sI https://dixis.gr/og-products.jpg`
+5. Confirmed `/logo.png` exists as alternative
+
+## Fix
+
+Updated `frontend/src/app/page.tsx` to use existing `/logo.png` for social media images:
+
+```diff
+-        url: `${siteUrl}/og-products.jpg`,
+-        width: 1200,
+-        height: 630,
++        url: `${siteUrl}/logo.png`,
++        width: 400,
++        height: 400,
+...
+-    images: [`${siteUrl}/twitter-products.jpg`],
++    images: [`${siteUrl}/logo.png`],
+```
+
+This is a minimal fix that:
+- Eliminates 404 console errors
+- Uses an existing asset (logo.png)
+- Maintains valid OG/Twitter metadata
+- Can be improved later with dedicated social images
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/src/app/page.tsx` | Updated OG/Twitter image URLs to use logo.png |
+| `docs/OPS/STATE.md` | Added pass entry |
+| `docs/AGENT/TASKS/Pass-P0-PROD-SMOKE-404-01.md` | Task specification |
+| `docs/AGENT/SUMMARY/Pass-P0-PROD-SMOKE-404-01.md` | This summary |
+
+## Future Improvement
+
+Create dedicated OG images (1200x630) for better social media sharing appearance:
+- `public/og-products.jpg` - Main homepage share image
+- `public/twitter-products.jpg` - Twitter-specific card image
+
+## Related
+
+- `reload-and-css.smoke.spec.ts` - The affected smoke test
+- Production URL: https://dixis.gr

--- a/docs/AGENT/TASKS/Pass-P0-PROD-SMOKE-404-01.md
+++ b/docs/AGENT/TASKS/Pass-P0-PROD-SMOKE-404-01.md
@@ -1,0 +1,23 @@
+# Pass P0-PROD-SMOKE-404-01: Fix prod smoke 404 console error
+
+**Created**: 2026-02-02
+**Status**: IN_PROGRESS
+**Priority**: P0
+
+## Problem
+Production smoke test `reload-and-css.smoke.spec.ts` fails due to a console 404 resource error on homepage.
+
+## Root Cause
+Homepage metadata referenced non-existent OG images:
+- `og-products.jpg` → 404
+- `twitter-products.jpg` → 404
+
+## Solution
+Updated `page.tsx` to use existing `/logo.png` for OG/Twitter images.
+
+## DoD
+- [x] Identify exact 404 URL (og-products.jpg, twitter-products.jpg)
+- [x] Fix root cause (updated metadata to use logo.png)
+- [x] Smoke remains strict for real errors
+- [ ] CI green (required checks) + PR merged
+- [x] STATE + SUMMARY updated

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,34 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-02 (Pass-P0-PROD-AUTH-CATALOGUE-01)
+**Last Updated**: 2026-02-02 (Pass-P0-PROD-SMOKE-404-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~350 lines (target ≤350). ✅
+
+---
+
+## 2026-02-02 — Pass-P0-PROD-SMOKE-404-01: Fix prod smoke 404 console error
+
+**Status**: 🔄 IN_PROGRESS — Branch `feat/pass-P0-PROD-SMOKE-404-01`
+
+**Objective**: Eliminate missing OG images (404) that cause console errors in prod smoke test.
+
+**Root Cause**:
+Homepage metadata referenced non-existent OG images:
+- `og-products.jpg` → 404
+- `twitter-products.jpg` → 404
+
+The smoke test `reload-and-css.smoke.spec.ts` captures console errors and fails on these 404s.
+
+**Fix**:
+Updated `frontend/src/app/page.tsx` to use existing `/logo.png` for OG/Twitter images
+until dedicated social images are created.
+
+**DoD**:
+- [x] Identified 404 URLs via curl against production
+- [x] Updated metadata to use existing asset
+- [ ] CI green (required checks)
+- [ ] PR merged
 
 ---
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -53,10 +53,11 @@ export const metadata: Metadata = {
     url: siteUrl,
     images: [
       {
-        url: `${siteUrl}/og-products.jpg`,
-        width: 1200,
-        height: 630,
-        alt: 'Fresh local products from Greek producers',
+        // Use logo.png as OG image until dedicated og-products.jpg is created
+        url: `${siteUrl}/logo.png`,
+        width: 400,
+        height: 400,
+        alt: 'Dixis - Fresh local products from Greek producers',
       },
     ],
   },
@@ -67,7 +68,8 @@ export const metadata: Metadata = {
     description: LANDING_MODE
       ? "Η νέα πλατφόρμα που συνδέει παραγωγούς με καταναλωτές."
       : "Discover premium organic vegetables, fresh fruits, and artisanal products directly from local Greek producers.",
-    images: [`${siteUrl}/twitter-products.jpg`],
+    // Use logo.png as Twitter card image until dedicated twitter-products.jpg is created
+    images: [`${siteUrl}/logo.png`],
   },
 };
 


### PR DESCRIPTION
## Summary
Fixes the 404 console errors that cause production smoke test (`reload-and-css.smoke.spec.ts`) to fail.

## Root Cause
Homepage metadata referenced non-existent OG images:
- `og-products.jpg` → 404
- `twitter-products.jpg` → 404

## Fix
Updated `frontend/src/app/page.tsx` to use existing `/logo.png` for social media images until dedicated OG images are created.

```diff
-        url: `${siteUrl}/og-products.jpg`,
+        url: `${siteUrl}/logo.png`,
...
-    images: [`${siteUrl}/twitter-products.jpg`],
+    images: [`${siteUrl}/logo.png`],
```

## Test plan
- [x] Verified `/logo.png` returns 200 OK on production
- [x] Verified `/og-products.jpg` and `/twitter-products.jpg` return 404
- [ ] CI required checks pass (build-and-test, quality-gates, CodeQL)
- [ ] Production smoke test passes after deploy

## Future work
Create dedicated 1200x630 OG images for better social sharing appearance.