### PR TITLE
fix(deploy): precheck shared env source, not symlink target (P0-PROD-SMOKE-404-02)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -98,20 +98,25 @@ jobs:
             ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no \
               ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} 'bash -s' << 'REMOTE_SCRIPT'
             set -euo pipefail
-            echo "=== FRONTEND ENV PRECHECK ==="
+            echo "=== FRONTEND ENV PRECHECK (P0-PROD-SMOKE-404-02) ==="
 
-            ENV_FILE="/var/www/dixis/current/frontend/.env"
+            # P0-PROD-SMOKE-404-02: Check SHARED source, not symlink target
+            # The symlink at /current/frontend/.env is recreated AFTER rsync --delete
+            # So we precheck the shared source that will be linked post-rsync
+            SHARED_ENV="/var/www/dixis/shared/frontend.env"
 
-            if [ ! -f "$ENV_FILE" ]; then
-              echo "❌ FATAL: .env file not found at $ENV_FILE"
+            if [ ! -f "$SHARED_ENV" ]; then
+              echo "❌ FATAL: Shared env source not found at $SHARED_ENV"
+              echo "Please create $SHARED_ENV with required env vars."
+              echo "See: docs/OPS/RUNBOOKS/vps-frontend-deploy.md"
               exit 1
             fi
-            echo "✅ .env file exists"
+            echo "✅ Shared env source exists: $SHARED_ENV"
 
-            # Check for placeholder values
+            # Check for placeholder values in SHARED source
             MISSING_ENVS=""
             for VAR in NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY; do
-              VALUE=$(grep "^${VAR}=" "$ENV_FILE" | cut -d= -f2- || echo "")
+              VALUE=$(grep "^${VAR}=" "$SHARED_ENV" | cut -d= -f2- || echo "")
               if [ -z "$VALUE" ] || [ "$VALUE" = "__FILL_ME__" ]; then
                 MISSING_ENVS="$MISSING_ENVS $VAR"
               fi
@@ -119,10 +124,10 @@ jobs:
 
             if [ -n "$MISSING_ENVS" ]; then
               echo "❌ FATAL: Missing or placeholder values for:$MISSING_ENVS"
-              echo "Please fill these in /var/www/dixis/current/frontend/.env before deploying"
+              echo "Please fill these in $SHARED_ENV before deploying"
               exit 1
             fi
-            echo "✅ Required env vars are set"
+            echo "✅ Required env vars verified in shared source"
             REMOTE_SCRIPT
 
       - name: Prepare VPS directory (with retry)

--- a/docs/AGENT/TASKS/Pass-P0-PROD-SMOKE-404-02.md
+++ b/docs/AGENT/TASKS/Pass-P0-PROD-SMOKE-404-02.md
@@ -1,0 +1,30 @@
+# Pass P0-PROD-SMOKE-404-02: Fix deploy precheck blocking on missing symlink
+
+**Created**: 2026-02-02
+**Status**: IN_PROGRESS
+**Priority**: P0
+
+## Problem
+Frontend deploy workflow fails at "Precheck VPS env files" step with:
+```
+❌ FATAL: .env file not found at /var/www/dixis/current/frontend/.env
+```
+
+This blocks the OG image fix from P0-PROD-SMOKE-404-01 from reaching production.
+
+## Root Cause
+The deploy workflow precheck looks for `/var/www/dixis/current/frontend/.env`, which is a symlink.
+This symlink is deleted by `rsync --delete` during deploy. The symlink restore step runs AFTER rsync,
+creating a chicken-and-egg problem: precheck expects file that will be created later.
+
+## Solution
+Update precheck to verify the SHARED source (`/var/www/dixis/shared/frontend.env`) instead of
+the symlink target. The symlink will be recreated after rsync by the existing restore step.
+
+## DoD
+- [x] Identified root cause (precheck checks wrong path)
+- [x] Fixed workflow to check shared source
+- [ ] CI green (required checks) + PR merged
+- [ ] Deploy succeeds
+- [ ] P0-PROD-SMOKE-404-01 fix reaches production
+- [ ] Prod smoke passes

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,34 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-02 (Pass-P0-PROD-SMOKE-404-01)
+**Last Updated**: 2026-02-02 (Pass-P0-PROD-SMOKE-404-02)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~350 lines (target ≤350). ✅
+
+---
+
+## 2026-02-02 — Pass-P0-PROD-SMOKE-404-02: Fix deploy precheck blocking on missing symlink
+
+**Status**: 🔄 IN_PROGRESS — Branch `feat/pass-P0-PROD-SMOKE-404-02`
+
+**Objective**: Fix deploy workflow precheck that blocks on missing `.env` symlink (caused by rsync --delete).
+
+**Root Cause**:
+The deploy workflow precheck looked for `/var/www/dixis/current/frontend/.env`, but this is a symlink
+that gets deleted by `rsync --delete` during deploy. The symlink restore happens AFTER rsync,
+so the precheck fails on every deploy after the first deletion.
+
+**Fix**:
+Updated precheck to verify the SHARED source (`/var/www/dixis/shared/frontend.env`) instead of
+the symlink target. The symlink will be recreated after rsync by the existing restore step.
+
+**DoD**:
+- [x] Identified root cause (precheck checks wrong path)
+- [x] Fixed workflow to check shared source
+- [ ] CI green (required checks)
+- [ ] PR merged
+- [ ] Deploy succeeds and P0-PROD-SMOKE-404-01 fix reaches production
+- [ ] Prod smoke passes
 
 ---
 


### PR DESCRIPTION
## Summary
Fixes the deploy workflow precheck that blocks on a missing `.env` symlink.

## Problem
Deploy workflow fails at "Precheck VPS env files" step with:
```
❌ FATAL: .env file not found at /var/www/dixis/current/frontend/.env
```

This is blocking the OG image fix (PR #2586) from reaching production, keeping the prod smoke test red.

## Root Cause
The precheck looked for `/var/www/dixis/current/frontend/.env`, which is a symlink that gets deleted by `rsync --delete` during deploy. The symlink restore step runs AFTER rsync, creating a chicken-and-egg problem.

## Fix
Changed precheck to verify `/var/www/dixis/shared/frontend.env` (the shared source) instead of the symlink target. The symlink will be recreated after rsync by the existing "Restore .env symlink" step from OPS-DEPLOY-GUARD-01.

## Test plan
- [ ] CI required checks pass
- [ ] Deploy workflow succeeds
- [ ] Production metadata shows `/logo.png` instead of `/og-products.jpg`
- [ ] Prod smoke test passes