### PR TITLE
fix(build): remove VPS-only hack; add sharp TS shim

### DIFF
--- a/frontend/src/types/sharp.d.ts
+++ b/frontend/src/types/sharp.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Shim for optional 'sharp' dependency used behind runtime flags.
+ * This prevents Next/TS builds from failing on environments where sharp isn't installed.
+ * If/when we require image processing everywhere, replace this shim with a real dependency and types.
+ */
+declare module 'sharp';


### PR DESCRIPTION
## Summary
- Adds a minimal TypeScript shim `src/types/sharp.d.ts` so builds don't fail when `sharp` native types aren't available
- `tsconfig.json` already includes `**/*.ts` which covers the new shim

## Why
Production deploy required a **VPS-only** edit to `next.config.ts` (`typescript.ignoreBuildErrors: true`) to bypass a pre-existing TS error around `sharp`.
That is server drift and will bite us again. This PR makes the build deterministic and removes the need for VPS hacks.

## VPS drift reverted
- `next.config.ts` on VPS has been restored to match HEAD (no `ignoreBuildErrors`)
- Running app is unaffected (uses pre-built `.next/standalone/`)

## Notes
- 1 file added, 6 lines total
- No business logic change
- After merge + deploy, future builds will not require `ignoreBuildErrors` on the server

---
Generated by Claude Code