### PR TITLE
chore(ops): deploy guardrails + DEPLOY doc

### DIFF
--- a/docs/OPS/DEPLOY-FRONTEND.md
+++ b/docs/OPS/DEPLOY-FRONTEND.md
@@ -1,4 +1,7 @@
-# Frontend Deployment Guide
+# Frontend Deployment Guide (Legacy)
+
+> **Superseded by**: [`docs/OPS/DEPLOY.md`](DEPLOY.md) and `scripts/prod-deploy-clean.sh`
+> This file is kept for historical reference only.
 
 **Last Updated**: 2025-01-03
 

--- a/docs/OPS/DEPLOY.md
+++ b/docs/OPS/DEPLOY.md
@@ -1,0 +1,148 @@
+# Production Deploy SOP
+
+**Last Updated**: 2026-02-03 (Pass-PROD-OPS-GUARDRAILS-01)
+
+> **Canonical script**: `scripts/prod-deploy-clean.sh`
+> **Supersedes**: `docs/OPS/DEPLOY-FRONTEND.md` (legacy, kept for history)
+
+---
+
+## Golden Path
+
+### From local machine (SSH mode)
+
+```bash
+bash scripts/prod-deploy-clean.sh
+```
+
+The script SSHs into the VPS (host alias `dixis-prod`) and runs the full sequence.
+
+### Directly on VPS
+
+```bash
+SSH_ONLY=1 bash scripts/prod-deploy-clean.sh
+```
+
+### What the script does (in order)
+
+| Step | Action | Failure behavior |
+|------|--------|------------------|
+| Preflight | Verify prod is live (`/api/healthz`, `/`) | STOP if unhealthy |
+| A | `git reset --hard origin/main` | STOP on error |
+| B | Guardrails: drift, deleted files, ghost deps, config drift | STOP with fix instructions |
+| C | Wipe `node_modules` + `.next` | Always clean slate |
+| D | `pnpm install --frozen-lockfile` | STOP on error |
+| E | `pnpm rebuild` (native modules) | STOP on error |
+| F | Post-install sanity (no ghost `@types/sharp`) | STOP if found |
+| G | `prisma generate` + `pnpm build` | STOP on error, prints log tail |
+| H | Copy standalone assets | Continues |
+| I | `pm2 restart` (only after successful build) | STOP on error |
+| J | Localhost verification (4 endpoints) | WARN only |
+| Postflight | Public HTTPS verification (4 endpoints) | STOP if unhealthy |
+
+---
+
+## Environment Variables
+
+Override defaults via env vars:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `DEPLOY_REMOTE` | `dixis-prod` | SSH host alias |
+| `DEPLOY_ROOT` | `/var/www/dixis/current` | Repo root on VPS |
+| `DEPLOY_PM2_APP` | `dixis-frontend` | PM2 app name |
+| `DEPLOY_NODE_HEAP` | `2048` | Node.js max heap (MB) |
+| `DEPLOY_PROD_URL` | `https://dixis.gr` | Public URL for health checks |
+
+---
+
+## Common Failure Modes
+
+### 1. Tracked files missing from disk
+
+**Symptom**: `git ls-files --deleted` shows files after reset.
+
+**Root cause**: `git checkout -f HEAD` does NOT restore all deleted tracked files.
+
+**Fix**: Always use `git reset --hard origin/main` (the script does this).
+
+### 2. Ghost `@types/sharp` in node_modules
+
+**Symptom**: TS build error `Cannot find type definition file for 'sharp'`.
+
+**Root cause**: `@types/sharp@0.32.0` was manually installed during debugging but not in `package.json`. Stale `node_modules` kept it alive.
+
+**Fix**: The script wipes `node_modules` entirely before install. It also checks for this ghost package before and after install.
+
+### 3. pnpm build scripts not running (sharp/prisma/esbuild)
+
+**Symptom**: Native modules fail at runtime (`sharp`, `prisma`, `esbuild`).
+
+**Root cause**: pnpm's `onlyBuiltDependencies` can block native module compilation.
+
+**Fix**: Script runs `pnpm config set onlyBuiltDependencies "[]"` before install, then `pnpm rebuild` after.
+
+### 4. OOM during Next.js build
+
+**Symptom**: `FATAL ERROR: Reached heap limit Allocation failed`.
+
+**Root cause**: Default Node.js heap (320MB) too small for TS type-checking.
+
+**Fix**: Script sets `NODE_OPTIONS='--max-old-space-size=2048'`.
+
+### 5. VPS config drift (`ignoreBuildErrors`)
+
+**Symptom**: Build succeeds but masks real TS errors. Breaks on next clean deploy.
+
+**Root cause**: Manual edit to `next.config.ts` on VPS during emergency.
+
+**Fix**: Script checks for `ignoreBuildErrors` in `next.config.ts` and STOPs if found. The proper fix is the `sharp.d.ts` shim (PR #2605).
+
+---
+
+## Rules
+
+1. **No manual edits on VPS**. All code changes go through PRs.
+2. **Never use `ignoreBuildErrors`**. Fix TS errors properly (shims, type fixes).
+3. **Always `git reset --hard`**, never `git checkout -f`.
+4. **Always wipe `node_modules`** for deterministic installs.
+5. **PM2 restart only after successful build**. Never restart on a failed build.
+
+---
+
+## Verification Endpoints
+
+### Localhost (on VPS)
+
+```bash
+curl -s http://127.0.0.1:3000/api/healthz
+curl -s http://127.0.0.1:3000/
+curl -s http://127.0.0.1:3000/og-products.jpg
+curl -s http://127.0.0.1:3000/twitter-products.jpg
+```
+
+### Public HTTPS
+
+```bash
+curl -s https://dixis.gr/api/healthz
+curl -s https://dixis.gr/
+curl -s https://dixis.gr/og-products.jpg
+curl -s https://dixis.gr/twitter-products.jpg
+```
+
+---
+
+## Build Log
+
+On failure, the script captures build output to `/tmp/dixis-deploy.log` and prints the last 80 lines. Check this file for detailed error context.
+
+---
+
+## Incident History
+
+| Date | Issue | Root Cause | Fix |
+|------|-------|------------|-----|
+| 2026-02-02 | OG images 404 | Missing assets in `public/` | PR #2594 |
+| 2026-02-02 | Build fails on VPS | Ghost `@types/sharp`, stale node_modules | PR #2605 (sharp shim) |
+| 2026-02-02 | 143 tracked files missing | `git checkout -f` vs `git reset --hard` | SOP mandates `reset --hard` |
+| 2026-02-03 | SOP codified | Manual deploy steps error-prone | PR #2606 (this script) |

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,9 +1,24 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-03 (Pass-PROD-STATE-ARCHIVE-01)
+**Last Updated**: 2026-02-03 (Pass-PROD-OPS-GUARDRAILS-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~325 lines (target ≤350). ✅
+> **Current size**: ~340 lines (target ≤350). ✅
+>
+> **Key Docs**: [DEPLOY SOP](DEPLOY.md) | [STATE Archive](STATE-ARCHIVE/)
+
+---
+
+## 2026-02-03 — Pass-PROD-OPS-GUARDRAILS-01: Deploy guardrails + DEPLOY doc
+
+**Status**: OPEN PR
+
+**What**:
+- Hardened `scripts/prod-deploy-clean.sh` with preflight guardrails (drift/deleted-files/ghost-deps/config-drift checks, build log capture with trap, clear STOP messages)
+- Created `docs/OPS/DEPLOY.md` documenting the canonical deploy SOP, failure modes, and rules
+- Marked `docs/OPS/DEPLOY-FRONTEND.md` as legacy (superseded)
+
+**Why**: Codifies incident learnings from P0-PROD-OG-ASSETS-01 so the safe deploy path is explicit and repeatable.
 
 ---
 

--- a/scripts/prod-deploy-clean.sh
+++ b/scripts/prod-deploy-clean.sh
@@ -9,20 +9,22 @@
 # What it does:
 #   1. Preflight: verifies prod is up before touching anything
 #   2. Hard-syncs repo to origin/main (no partial checkouts)
-#   3. Wipes node_modules + .next for a clean slate
-#   4. Installs deps, rebuilds natives, generates Prisma, builds Next.js
-#   5. Copies standalone assets, restarts PM2 ONLY after successful build
-#   6. Verifies localhost + public https endpoints
+#   3. Preflight guardrails: drift check, deleted files, ghost deps
+#   4. Wipes node_modules + .next for a clean slate
+#   5. Installs deps, rebuilds natives, generates Prisma, builds Next.js
+#   6. Copies standalone assets, restarts PM2 ONLY after successful build
+#   7. Verifies localhost + public https endpoints
 #
 # Safety:
 #   - Exits on ANY error (set -euo pipefail)
 #   - PM2 restart happens ONLY after a successful build
 #   - NO manual config edits (nginx/next.config/etc)
 #   - Idempotent: safe to re-run at any time
+#   - Build output captured to /tmp/dixis-deploy.log for failure diagnosis
 #
 # Requirements (on VPS): git, node 20+, pnpm, pm2, curl
 #
-# Context: Created after #2605 incident hardening. See docs/OPS/STATE.md.
+# Context: Created after #2605 incident hardening. See docs/OPS/DEPLOY.md.
 #
 
 set -euo pipefail
@@ -36,7 +38,7 @@ NODE_HEAP="${DEPLOY_NODE_HEAP:-2048}"
 PROD_URL="${DEPLOY_PROD_URL:-https://dixis.gr}"
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
-fail() { echo "FATAL: $*" >&2; exit 1; }
+fail() { echo ""; echo "STOP: $*" >&2; exit 1; }
 
 check_http() {
   local label="$1" url="$2"
@@ -59,69 +61,141 @@ set -euo pipefail
 ROOT="'"$ROOT"'"
 FE="'"$FE"'"
 APP="'"$APP"'"
+LOGFILE="/tmp/dixis-deploy.log"
 export NODE_OPTIONS="--max-old-space-size='"$NODE_HEAP"'"
+
+# ── Failure trap: print last 80 lines of build log + SHA ──
+on_fail() {
+  echo ""
+  echo "=========================================="
+  echo "STOP: Deploy failed. Diagnostics below."
+  echo "=========================================="
+  echo "Current SHA: $(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+  echo "PM2 status:"
+  pm2 ls 2>/dev/null || true
+  if [ -f "$LOGFILE" ]; then
+    echo ""
+    echo "--- Last 80 lines of $LOGFILE ---"
+    tail -80 "$LOGFILE"
+  fi
+  echo ""
+  echo "STOP: Fix the issue above, then re-run this script."
+}
+trap on_fail ERR
+
+# Start logging
+echo "Deploy started at $(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$LOGFILE"
 
 cd "$ROOT"
 
 echo "--- A) Hard sync to origin/main ---"
-git fetch --all --prune
-git checkout -f main
-git reset --hard origin/main
+git fetch --all --prune 2>&1 | tee -a "$LOGFILE"
+git checkout -f main 2>&1 | tee -a "$LOGFILE"
+git reset --hard origin/main 2>&1 | tee -a "$LOGFILE"
 SHA=$(git rev-parse HEAD)
-echo "DEPLOY SHA: $SHA"
-git log -1 --oneline
+echo "DEPLOY SHA: $SHA" | tee -a "$LOGFILE"
+git log -1 --oneline | tee -a "$LOGFILE"
 
 echo ""
-echo "--- B) Check for tracked drift ---"
+echo "--- B) Preflight guardrails ---"
+
+# B1: Tracked drift check
 TRACKED_DIRTY=$(git status --porcelain | grep -v "^??" || true)
 if [ -n "$TRACKED_DIRTY" ]; then
-  echo "ERROR: tracked drift detected:"
-  echo "$TRACKED_DIRTY"
+  echo "STOP: Tracked file drift detected after git reset --hard." | tee -a "$LOGFILE"
+  echo "Dirty files:" | tee -a "$LOGFILE"
+  echo "$TRACKED_DIRTY" | tee -a "$LOGFILE"
+  echo "" | tee -a "$LOGFILE"
+  echo "Fix: run  git reset --hard origin/main  and retry." | tee -a "$LOGFILE"
   exit 1
 fi
-echo "Working tree clean (tracked files)"
+echo "  tracked drift: clean"
+
+# B2: Deleted tracked files (catches partial checkout bugs)
+DELETED=$(git ls-files --deleted)
+if [ -n "$DELETED" ]; then
+  DELETED_COUNT=$(echo "$DELETED" | wc -l | tr -d " ")
+  echo "STOP: $DELETED_COUNT tracked files missing from disk." | tee -a "$LOGFILE"
+  echo "First 20:" | tee -a "$LOGFILE"
+  echo "$DELETED" | head -20 | tee -a "$LOGFILE"
+  echo "" | tee -a "$LOGFILE"
+  echo "Fix: run  git reset --hard origin/main  (not git checkout -f)." | tee -a "$LOGFILE"
+  exit 1
+fi
+echo "  deleted tracked files: none"
+
+# B3: Ghost @types/sharp (caused #2605 build failure)
+cd "$FE"
+if [ -d "node_modules/.pnpm/@types+sharp@0.32.0" ] || [ -d "node_modules/@types/sharp" ]; then
+  echo "WARN: Ghost @types/sharp detected in node_modules." | tee -a "$LOGFILE"
+  echo "      This was NOT in package.json and caused TS build errors." | tee -a "$LOGFILE"
+  echo "      Will be cleaned by node_modules wipe below." | tee -a "$LOGFILE"
+fi
+
+# B4: VPS config drift check (next.config must not have ignoreBuildErrors)
+if grep -q "ignoreBuildErrors" "$FE/next.config.ts" 2>/dev/null; then
+  echo "STOP: next.config.ts contains ignoreBuildErrors." | tee -a "$LOGFILE"
+  echo "      This is a VPS-only hack that should not exist." | tee -a "$LOGFILE"
+  echo "      The git reset --hard above should have fixed it." | tee -a "$LOGFILE"
+  echo "Fix: run  git reset --hard origin/main  and retry." | tee -a "$LOGFILE"
+  exit 1
+fi
+echo "  next.config.ts drift: clean"
+
+echo "Preflight guardrails: ALL PASS"
 
 echo ""
 echo "--- C) Wipe node_modules + .next ---"
-cd "$FE"
 rm -rf node_modules .next
 echo "Wiped node_modules and .next"
 
 echo ""
 echo "--- D) Install dependencies ---"
+# Ensure pnpm allows build scripts for native modules
+pnpm config set onlyBuiltDependencies "[]" >/dev/null 2>&1 || true
+
 if [ -f pnpm-lock.yaml ]; then
   echo "Installing from lockfile..."
-  pnpm install --frozen-lockfile 2>&1 | tail -10
+  pnpm install --frozen-lockfile 2>&1 | tee -a "$LOGFILE" | tail -10
 else
   echo "No lockfile found, installing fresh..."
-  pnpm install --no-frozen-lockfile 2>&1 | tail -10
+  pnpm install --no-frozen-lockfile 2>&1 | tee -a "$LOGFILE" | tail -10
 fi
 
 echo ""
 echo "--- E) Rebuild native modules ---"
-pnpm config set onlyBuiltDependencies "[]" >/dev/null 2>&1 || true
-pnpm rebuild 2>&1 | tail -10
+pnpm rebuild 2>&1 | tee -a "$LOGFILE" | tail -10
 
 echo ""
-echo "--- F) Prisma generate + Next.js build ---"
-npx prisma generate 2>&1 | tail -3
+echo "--- F) Post-install sanity ---"
+# Verify no ghost @types/sharp crept back in
+if [ -d "node_modules/@types/sharp" ]; then
+  echo "STOP: @types/sharp appeared after fresh install." | tee -a "$LOGFILE"
+  echo "      Check package.json for accidental dependency." | tee -a "$LOGFILE"
+  exit 1
+fi
+echo "  post-install sanity: clean"
+
+echo ""
+echo "--- G) Prisma generate + Next.js build ---"
+npx prisma generate 2>&1 | tee -a "$LOGFILE" | tail -3
 echo "Building Next.js..."
-pnpm build 2>&1 | tail -15
+pnpm build 2>&1 | tee -a "$LOGFILE" | tail -15
 
 echo ""
-echo "--- G) Prepare standalone bundle ---"
+echo "--- H) Prepare standalone bundle ---"
 cp -r .next/static .next/standalone/.next/ 2>/dev/null || true
 cp -r public .next/standalone/ 2>/dev/null || true
 echo "Standalone prepared"
 
 echo ""
-echo "--- H) Restart PM2 (post-build only) ---"
+echo "--- I) Restart PM2 (post-build only) ---"
 pm2 restart "$APP"
 sleep 5
 pm2 ls
 
 echo ""
-echo "--- I) Localhost verification ---"
+echo "--- J) Localhost verification ---"
 for ep in "/api/healthz" "/" "/og-products.jpg" "/twitter-products.jpg"; do
   CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "http://127.0.0.1:3000${ep}" || echo "000")
   echo "  localhost${ep}: $CODE"
@@ -132,6 +206,7 @@ done
 
 echo ""
 echo "DEPLOY OK SHA=$(git -C "$ROOT" rev-parse HEAD)"
+echo "Build log: $LOGFILE"
 '
 
 # ── Execute ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What
- Hardens `scripts/prod-deploy-clean.sh` with preflight guardrails:
  - Tracked drift detection (`git status --porcelain`)
  - Deleted tracked files check (`git ls-files --deleted`)
  - Ghost `@types/sharp` detection (pre- and post-install)
  - VPS config drift check (`ignoreBuildErrors` in next.config.ts)
  - Build log capture to `/tmp/dixis-deploy.log` with ERR trap (last 80 lines on failure)
  - Clear STOP messages with fix instructions
- Adds `docs/OPS/DEPLOY.md` documenting canonical deploy SOP:
  - Golden path (SSH + local modes)
  - Step-by-step with failure behavior table
  - 5 common failure modes with root cause + fix
  - Deploy rules (no VPS edits, no ignoreBuildErrors, always reset --hard)
  - Verification endpoints
- Marks `docs/OPS/DEPLOY-FRONTEND.md` as legacy (superseded)
- STATE.md entry + key docs links in header

## Why
We hit real prod risk from:
- partial git state (tracked files missing until `git reset --hard`)
- stale/ghost node_modules (e.g. @types/sharp)
- pnpm build scripts not running consistently
- VPS config drift (ignoreBuildErrors hack)
This pass makes the safe path explicit and repeatable.

## Scope
Docs + ops scripts only. No runtime changes.

## Stats
4 files changed, 270 insertions (+), 29 deletions (-) — within ≤300 LOC budget

---
Generated by Claude Code (Pass-PROD-OPS-GUARDRAILS-01)