### PR TITLE
chore(ci): reduce prod smoke/uptime flakes (curl timeout+retry)

### DIFF
--- a/.github/workflows/monitor-uptime-mon1.yml
+++ b/.github/workflows/monitor-uptime-mon1.yml
@@ -16,21 +16,21 @@ jobs:
       - name: Check healthz
         run: |
           set -euo pipefail
-          code="$(curl -sS -o /dev/null -w "%{http_code}" https://dixis.gr/api/healthz)"
+          code="$(curl -sS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code}" https://dixis.gr/api/healthz)"
           echo "healthz=$code"
           test "$code" = "200"
 
       - name: Check products page
         run: |
           set -euo pipefail
-          code="$(curl -sS -o /dev/null -w "%{http_code}" https://dixis.gr/products)"
+          code="$(curl -sS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code}" https://dixis.gr/products)"
           echo "products_page=$code"
           test "$code" = "200"
 
       - name: Check products API has data
         run: |
           set -euo pipefail
-          body="$(curl -fsS https://dixis.gr/api/v1/public/products)"
+          body="$(curl -fsS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors https://dixis.gr/api/v1/public/products)"
           echo "$body" | head -c 220
           echo
           if command -v jq >/dev/null 2>&1; then

--- a/.github/workflows/monitor-uptime-v2.yml
+++ b/.github/workflows/monitor-uptime-v2.yml
@@ -18,7 +18,7 @@ jobs:
         id: healthz
         run: |
           echo "🩺 Testing production health endpoint..."
-          if ! RESPONSE=$(curl -fsS -w "\nHTTP_CODE:%{http_code}" https://dixis.gr/api/healthz 2>&1); then
+          if ! RESPONSE=$(curl -fsS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -w "\nHTTP_CODE:%{http_code}" https://dixis.gr/api/healthz 2>&1); then
             echo "status=failed" >> $GITHUB_OUTPUT
             echo "url=https://dixis.gr/api/healthz" >> $GITHUB_OUTPUT
             echo "error=$RESPONSE" >> $GITHUB_OUTPUT
@@ -42,7 +42,7 @@ jobs:
         id: login
         run: |
           echo "🔐 Testing login page..."
-          HTTP_CODE=$(curl -fsS -o /dev/null -w "%{http_code}" https://dixis.gr/auth/login 2>&1 || echo "failed")
+          HTTP_CODE=$(curl -fsS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code}" https://dixis.gr/auth/login 2>&1 || echo "failed")
 
           if [[ "$HTTP_CODE" =~ ^(5[0-9]{2})$ ]]; then
             echo "status=failed" >> $GITHUB_OUTPUT
@@ -57,7 +57,7 @@ jobs:
         id: products
         run: |
           echo "🛒 Testing products page..."
-          HTTP_CODE=$(curl -fsS -o /dev/null -w "%{http_code}" https://dixis.gr/products 2>&1 || echo "failed")
+          HTTP_CODE=$(curl -fsS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code}" https://dixis.gr/products 2>&1 || echo "failed")
 
           if [[ "$HTTP_CODE" =~ ^(5[0-9]{2})$ ]]; then
             echo "status=failed" >> $GITHUB_OUTPUT

--- a/.github/workflows/monitor-uptime.yml
+++ b/.github/workflows/monitor-uptime.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check API Health Endpoint
         run: |
           echo "Checking https://dixis.gr/api/healthz"
-          HTTP_CODE=$(curl -sS -o /dev/null -w "%{http_code}" https://dixis.gr/api/healthz)
+          HTTP_CODE=$(curl -sS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code}" https://dixis.gr/api/healthz)
           if [ "$HTTP_CODE" != "200" ]; then
             echo "❌ API health check failed with HTTP $HTTP_CODE"
             exit 1
@@ -25,8 +25,8 @@ jobs:
       - name: Check Products Page
         run: |
           echo "Checking https://dixis.gr/products"
-          RESPONSE=$(curl -sS https://dixis.gr/products)
-          HTTP_CODE=$(echo "$RESPONSE" | head -c 1 > /dev/null; curl -sS -o /dev/null -w "%{http_code}" https://dixis.gr/products)
+          RESPONSE=$(curl -sS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors https://dixis.gr/products)
+          HTTP_CODE=$(echo "$RESPONSE" | head -c 1 > /dev/null; curl -sS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code}" https://dixis.gr/products)
 
           if [ "$HTTP_CODE" != "200" ]; then
             echo "❌ Products page failed with HTTP $HTTP_CODE"
@@ -52,7 +52,7 @@ jobs:
       - name: Check Auth Pages
         run: |
           echo "Checking https://dixis.gr/auth/login"
-          LOGIN_CODE=$(curl -sS -o /dev/null -w "%{http_code}" https://dixis.gr/auth/login)
+          LOGIN_CODE=$(curl -sS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code}" https://dixis.gr/auth/login)
           if [ "$LOGIN_CODE" != "200" ]; then
             echo "❌ Auth login page failed with HTTP $LOGIN_CODE"
             exit 1
@@ -60,7 +60,7 @@ jobs:
           echo "✅ Auth login page check passed (HTTP $LOGIN_CODE)"
 
           echo "Checking https://dixis.gr/auth/register"
-          REGISTER_CODE=$(curl -sS -o /dev/null -w "%{http_code}" https://dixis.gr/auth/register)
+          REGISTER_CODE=$(curl -sS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code}" https://dixis.gr/auth/register)
           if [ "$REGISTER_CODE" != "200" ]; then
             echo "❌ Auth register page failed with HTTP $REGISTER_CODE"
             exit 1

--- a/.github/workflows/prod-sanity-orders.yml
+++ b/.github/workflows/prod-sanity-orders.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check healthz
         run: |
           echo "=== Healthz Check ==="
-          HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+          HTTP_CODE=$(curl -sS --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w '%{http_code}' \
             --connect-timeout 10 --max-time 20 \
             https://dixis.gr/api/healthz)
 
@@ -33,10 +33,10 @@ jobs:
       - name: Check orders endpoint returns JSON
         run: |
           echo "=== Orders API Check ==="
-          RESPONSE=$(curl -sS --connect-timeout 10 --max-time 20 \
+          RESPONSE=$(curl -sS --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 10 --max-time 20 \
             https://dixis.gr/api/v1/public/orders)
 
-          HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+          HTTP_CODE=$(curl -sS --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w '%{http_code}' \
             --connect-timeout 10 --max-time 20 \
             https://dixis.gr/api/v1/public/orders)
 
@@ -60,7 +60,7 @@ jobs:
           echo "=== Order Data Integrity Check ==="
 
           # Fetch first order from API
-          ORDER=$(curl -sS --connect-timeout 10 --max-time 20 \
+          ORDER=$(curl -sS --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 10 --max-time 20 \
             https://dixis.gr/api/v1/public/orders | jq -r '.data[0]')
 
           if [ "$ORDER" = "null" ] || [ -z "$ORDER" ]; then

--- a/.github/workflows/prod-smoke-alert.yml
+++ b/.github/workflows/prod-smoke-alert.yml
@@ -18,13 +18,13 @@ jobs:
           echo "" >> fail-report.md
           echo "### Live checks" >> fail-report.md
           echo '#### /api/healthz' >> fail-report.md
-          curl -sS -i https://dixis.gr/api/healthz | sed -n '1,5p' >> fail-report.md || true
+          curl -sS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -i https://dixis.gr/api/healthz | sed -n '1,5p' >> fail-report.md || true
           echo '' >> fail-report.md
           echo '#### /api/products (first 200 chars)' >> fail-report.md
-          curl -sS https://dixis.gr/api/products | head -c 200 >> fail-report.md || true
+          curl -sS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors https://dixis.gr/api/products | head -c 200 >> fail-report.md || true
           echo '' >> fail-report.md
           echo '#### /products 200?' >> fail-report.md
-          curl -sS -o /dev/null -w "HTTP %{http_code}\n" https://dixis.gr/products >> fail-report.md || true
+          curl -sS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "HTTP %{http_code}\n" https://dixis.gr/products >> fail-report.md || true
 
       - name: Open issue
         uses: peter-evans/create-issue-from-file@v4

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -85,7 +85,7 @@ jobs:
           echo "=== Checking auth redirects ==="
 
           # Check /login redirect
-          LOGIN_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+          LOGIN_CODE=$(curl -sS --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w '%{http_code}' \
             --connect-timeout 10 --max-time 20 \
             https://dixis.gr/login)
 
@@ -95,7 +95,7 @@ jobs:
           fi
 
           # Check /register redirect
-          REGISTER_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+          REGISTER_CODE=$(curl -sS --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w '%{http_code}' \
             --connect-timeout 10 --max-time 20 \
             https://dixis.gr/register)
 
@@ -109,7 +109,7 @@ jobs:
       - name: Check PROD orders page
         run: |
           echo "=== Checking orders page ==="
-          ORDERS_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+          ORDERS_CODE=$(curl -sS --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w '%{http_code}' \
             --connect-timeout 10 --max-time 20 \
             https://dixis.gr/orders || true)
 
@@ -130,7 +130,7 @@ jobs:
           # POST to checkout with invalid/empty data
           # Expected: 400, 401, 422 (client errors) - NOT 500 (server error)
           # This guards against database transaction failures
-          HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+          HTTP_CODE=$(curl -sS --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w '%{http_code}' \
             --connect-timeout 10 --max-time 20 \
             -X POST https://dixis.gr/api/v1/public/orders \
             -H "Content-Type: application/json" \

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -14,7 +14,7 @@ jobs:
           set -euo pipefail
           URL="https://dixis.gr/api/healthz"
           echo "GET $URL"
-          CODE="$(curl -sk -o /tmp/hz.json -w '%{http_code}' "$URL")"
+          CODE="$(curl -sk --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /tmp/hz.json -w '%{http_code}' "$URL")"
           echo "HTTP $CODE"
           cat /tmp/hz.json || true
           test "$CODE" = "200"
@@ -26,6 +26,6 @@ jobs:
       - name: Homepage HEAD
         run: |
           set -euo pipefail
-          CODE=$(curl -skI -o /dev/null -w "%{http_code}" https://dixis.gr/)
+          CODE=$(curl -skI --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code}" https://dixis.gr/)
           echo "HTTP $CODE"
           test "$CODE" = "200"

--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -21,7 +21,7 @@ jobs:
           set -euo pipefail
           URL="https://staging.dixis.gr/api/healthz"
           echo "GET $URL"
-          CODE="$(curl -sk -o /tmp/hz.json -w '%{http_code}' "$URL")"
+          CODE="$(curl -sk --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /tmp/hz.json -w '%{http_code}' "$URL")"
           echo "HTTP $CODE"
           cat /tmp/hz.json || true
           test "$CODE" = "200"

--- a/.github/workflows/uptime-healthz.yml
+++ b/.github/workflows/uptime-healthz.yml
@@ -14,7 +14,7 @@ jobs:
         id: curl
         run: |
           set -euo pipefail
-          code=$(curl -sk -o /dev/null -w "%{http_code}" "https://dixis.gr/api/healthz")
+          code=$(curl -sk --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code}" "https://dixis.gr/api/healthz")
           echo "code=$code" >> "$GITHUB_OUTPUT"
           if [ "$code" != "200" ]; then
             echo "::error::healthz returned $code"

--- a/.github/workflows/uptime-smoke.yml
+++ b/.github/workflows/uptime-smoke.yml
@@ -11,7 +11,7 @@ jobs:
           set -e
           URL="https://dixis.gr/api/healthz"
           echo "Probing $URL"
-          RESPONSE=$(curl -fsS "$URL")
+          RESPONSE=$(curl -fsS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors "$URL")
           echo "Response: $RESPONSE"
           if echo "$RESPONSE" | grep -qi '"status".*"ok"'; then
             echo "✅ OK: $URL is healthy"

--- a/.github/workflows/uptime-smokes.yml
+++ b/.github/workflows/uptime-smokes.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Curl ${{ matrix.url }}
         run: |
           URL="${{ matrix.url }}"
-          read -r CODE TIME <<<"$(curl -sS -o /dev/null -w "%{http_code} %{time_total}" "$URL")"
+          read -r CODE TIME <<<"$(curl -sS --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code} %{time_total}" "$URL")"
           echo "GET $URL -> $CODE in ${TIME}s"
 
           # Status must be 200

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Curl ${{ matrix.url }}
         run: |
           for i in 1 2 3; do
-            code=$(curl -s -o /dev/null -w "%{http_code}" "${{ matrix.url }}") || code=0
+            code=$(curl -s --max-time 30 -o /dev/null -w "%{http_code}" "${{ matrix.url }}") || code=0
             echo "Attempt $i → $code"
             [[ "$code" =~ ^2|3 ]] && exit 0
             sleep 5


### PR DESCRIPTION
## What
Hardens prod smoke + uptime monitoring workflows by adding conservative curl resilience:
`--max-time 30 --retry 3 --retry-delay 2 --retry-all-errors -fsS`

## Why
Reduce CI noise from transient network timeouts (curl exit 28) from GitHub runners to https://dixis.gr.

## Scope
12 workflow files under `.github/workflows/`. No app code changes. No required checks changed.