### PR TITLE
fix(e2e): stabilize smoke.spec.ts strict-mode flake (products grid)

### DIFF
--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,11 +1,27 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-04 (Pass-PROD-E2E-PG-FLAKE-01)
+**Last Updated**: 2026-02-04 (Pass-PROD-E2E-PG-FLAKE-02)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~360 lines (target ≤350). ⚠️ Near limit.
+> **Current size**: ~370 lines (target ≤350). ⚠️ Near limit — archive soon.
 >
 > **Key Docs**: [DEPLOY SOP](DEPLOY.md) | [STATE Archive](STATE-ARCHIVE/)
+
+---
+
+## 2026-02-04 — Pass-PROD-E2E-PG-FLAKE-02: Stabilize smoke.spec.ts strict-mode flake
+
+**Status**: PR OPEN
+
+**Root cause**: `smoke.spec.ts:51` — `locator('main .grid').or(emptyState).toBeVisible()` fails with strict-mode violation. The products page has **two** elements matching `main .grid` (product grid + layout grid). Playwright strict mode rejects ambiguous locators that resolve to >1 element.
+
+**Fix** (test-only, `smoke.spec.ts`):
+- Replaced `page.locator('main .grid')` with `page.locator('[data-testid="product-card"]').first()` (unique per card, strict-mode safe)
+- Replaced `.or()` pattern with two independent `isVisible()` checks
+- Empty state now uses `page.getByTestId('no-results')` (matches app's actual testid)
+- Final assertion: `expect(hasProducts || hasEmptyState).toBe(true)`
+
+**Why stable now**: No ambiguous locators. Each check targets a unique element (data-testid).
 
 ---
 


### PR DESCRIPTION
## What
Fixes Playwright strict-mode violation in `smoke.spec.ts:51` that was causing intermittent `E2E (PostgreSQL)` failures.

## Failing Signature (from merge-commit run 21653152747)
```
Error: expect.toBeVisible: Error: strict mode violation:
  locator('main .grid').or(getByText('Δεν υπάρχουν διαθέσιμα προϊόντα').first())
  resolved to 2 elements:
    1) <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">…</div>
    2) <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">…</div>
  at smoke.spec.ts:51:44
```

## Root Cause
`page.locator('main .grid')` matches **two** grid elements inside `<main>` (product grid + layout grid). The `.or()` pattern preserves strict mode, so when the first operand resolves to 2 elements, Playwright rejects it.

## Fix (test-only, +23 net lines)
- Replaced `page.locator('main .grid')` with `page.locator('[data-testid="product-card"]').first()` — unique per card, strict-mode safe
- Replaced `.or()` chain with two independent `isVisible()` checks
- Empty state now uses `page.getByTestId('no-results')` (matches app's actual data-testid)
- Final assertion: `expect(hasProducts || hasEmptyState).toBe(true)`

## Why Safe
- **Test-only change** — no app/runtime code modified
- `smoke.spec.ts` (products grid assertion) + `docs/OPS/STATE.md` (pass entry)
- The locator change is strictly narrower (data-testid instead of CSS class)

---
*Generated-by: Claude Code | Pass: PROD-E2E-PG-FLAKE-02*