### PR TITLE
fix(admin): add missing AdminUser migration + graceful DB error handling

### DIFF
--- a/frontend/prisma/migrations/20260204000000_add_admin_rbac/migration.sql
+++ b/frontend/prisma/migrations/20260204000000_add_admin_rbac/migration.sql
@@ -1,0 +1,52 @@
+-- CreateTable: AdminUser (RBAC whitelist for admin dashboard access)
+-- Pass PROD-BUGFIX-ADMIN-DB-01: Table existed in schema.prisma but had no migration.
+-- This caused requireAdmin() to crash on prisma.adminUser.findUnique() in production.
+CREATE TABLE "AdminUser" (
+    "id" TEXT NOT NULL,
+    "phone" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'admin',
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AdminUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: AdminAuditLog (audit trail for admin actions)
+CREATE TABLE "AdminAuditLog" (
+    "id" TEXT NOT NULL,
+    "adminPhone" TEXT NOT NULL,
+    "adminUserId" TEXT,
+    "action" TEXT NOT NULL,
+    "entityType" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "oldValue" JSONB,
+    "newValue" JSONB,
+    "details" TEXT,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdminAuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdminUser_phone_key" ON "AdminUser"("phone");
+
+-- CreateIndex
+CREATE INDEX "AdminUser_phone_idx" ON "AdminUser"("phone");
+
+-- CreateIndex
+CREATE INDEX "AdminAuditLog_adminPhone_idx" ON "AdminAuditLog"("adminPhone");
+
+-- CreateIndex
+CREATE INDEX "AdminAuditLog_action_idx" ON "AdminAuditLog"("action");
+
+-- CreateIndex
+CREATE INDEX "AdminAuditLog_entityType_entityId_idx" ON "AdminAuditLog"("entityType", "entityId");
+
+-- CreateIndex
+CREATE INDEX "AdminAuditLog_createdAt_idx" ON "AdminAuditLog"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "AdminAuditLog" ADD CONSTRAINT "AdminAuditLog_adminUserId_fkey" FOREIGN KEY ("adminUserId") REFERENCES "AdminUser"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/frontend/src/app/api/auth/verify-otp/route.ts
+++ b/frontend/src/app/api/auth/verify-otp/route.ts
@@ -83,8 +83,10 @@ export async function POST(req: NextRequest) {
         });
         console.log(`[Auth] AdminUser synced for ${phoneNorm}`);
       } catch (dbError) {
-        // Log but don't fail login - admin can still use JWT type check
-        console.error('[Auth] Failed to sync AdminUser:', dbError);
+        // Pass PROD-BUGFIX-ADMIN-DB-01: Log clearly so ops can see migration is needed.
+        // Login still succeeds (JWT has type:'admin'), but requireAdmin() will fail
+        // on the DB check until the AdminUser table exists and this upsert succeeds.
+        console.error('[Auth] Failed to sync AdminUser (run prisma migrate deploy):', dbError);
       }
     }
 


### PR DESCRIPTION
## Summary

**Pass**: PROD-BUGFIX-ADMIN-DB-01

**Root cause**: `AdminUser` and `AdminAuditLog` models existed in `schema.prisma` (Sprint 11 RBAC) but **had no migration**. Tables never created in production PostgreSQL.

**Impact chain**:
1. Admin login (`verify-otp`) issues JWT with `type: 'admin'` — succeeds
2. `prisma.adminUser.upsert()` silently fails (table doesn't exist) — error caught, login still works
3. `/admin` page calls `requireAdmin()` → JWT checks pass → `prisma.adminUser.findUnique()` **crashes** (table missing)
4. Prisma error is NOT `AdminError`, so `admin/page.tsx` line 48 `throw e` → raw 500 error

## Changes (4 files, +95/-8)

1. **New migration** `20260204000000_add_admin_rbac/migration.sql`
   - Creates `AdminUser` table (id, phone, role, isActive, timestamps)
   - Creates `AdminAuditLog` table (id, adminPhone, action, entity, old/new values, context)
   - All indexes matching schema.prisma: unique phone, composite (entityType, entityId), etc.
   - FK: AdminAuditLog.adminUserId → AdminUser.id (SET NULL)

2. **`frontend/src/lib/auth/admin.ts`** — Wrapped `prisma.adminUser.findUnique()` in try/catch
   - On DB error → throws `AdminError('NOT_ADMIN')` → clean redirect to login
   - Prevents raw 500 crash when table doesn't exist yet

3. **`frontend/src/app/api/auth/verify-otp/route.ts`** — Improved error log
   - Surfaces "run prisma migrate deploy" hint in console.error

4. **`docs/OPS/STATE.md`** — Added pass entry

## Deploy Note

After merge, run on VPS:
```bash
cd frontend && npx prisma migrate deploy
```
First admin login after migration will auto-upsert the AdminUser row.

## Test Plan

- [ ] TypeScript typecheck passes (verified locally: exit 0)
- [ ] CI checks pass (no runtime behavior change — migration is additive)
- [ ] Post-deploy: `prisma migrate deploy` creates tables
- [ ] Post-deploy: admin login → `/admin` dashboard loads without 500

---
Generated-by: Claude Code (Pass PROD-BUGFIX-ADMIN-DB-01)