### PR TITLE
fix(admin): unblock prod deploy + fix admin sub-page auth redirect

### DIFF
--- a/frontend/src/app/admin/analytics/page.tsx
+++ b/frontend/src/app/admin/analytics/page.tsx
@@ -1,8 +1,16 @@
-import { requireAdmin } from '@/lib/auth/admin';
+import { redirect } from 'next/navigation';
+import { requireAdmin, AdminError } from '@/lib/auth/admin';
 import AnalyticsContent from './AnalyticsContent';
 
 export default async function AnalyticsPage() {
-  await requireAdmin?.();
+  try {
+    await requireAdmin();
+  } catch (e) {
+    if (e instanceof AdminError) {
+      redirect('/auth/login?from=/admin/analytics');
+    }
+    throw e;
+  }
 
   return <AnalyticsContent />;
 }

--- a/frontend/src/app/admin/settings/page.tsx
+++ b/frontend/src/app/admin/settings/page.tsx
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic';
-import { requireAdmin } from '@/lib/auth/admin';
+import { redirect } from 'next/navigation';
+import { requireAdmin, AdminError } from '@/lib/auth/admin';
 import Link from 'next/link';
 
 // Environment config (read-only display)
@@ -10,7 +11,14 @@ const envConfig = {
 };
 
 export default async function AdminSettingsPage() {
-  await requireAdmin?.();
+  try {
+    await requireAdmin();
+  } catch (e) {
+    if (e instanceof AdminError) {
+      redirect('/auth/login?from=/admin/settings');
+    }
+    throw e;
+  }
 
   return (
     <main style={{ padding: 16, maxWidth: 960, margin: '0 auto' }}>

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,6 +1,7 @@
 export const dynamic = 'force-dynamic';
+import { redirect } from 'next/navigation';
 import { prisma } from '@/lib/db/client';
-import { requireAdmin } from '@/lib/auth/admin';
+import { requireAdmin, AdminError } from '@/lib/auth/admin';
 import Link from 'next/link';
 
 /**
@@ -22,7 +23,14 @@ interface AdminUser {
 }
 
 export default async function AdminUsersPage() {
-  await requireAdmin?.();
+  try {
+    await requireAdmin();
+  } catch (e) {
+    if (e instanceof AdminError) {
+      redirect('/auth/login?from=/admin/users');
+    }
+    throw e;
+  }
 
   const adminUsers = await prisma.adminUser.findMany({
     orderBy: { createdAt: 'desc' },

--- a/scripts/prod-deploy-clean.sh
+++ b/scripts/prod-deploy-clean.sh
@@ -177,8 +177,10 @@ fi
 echo "  post-install sanity: clean"
 
 echo ""
-echo "--- G) Prisma generate + Next.js build ---"
+echo "--- G) Prisma generate + migrate + Next.js build ---"
 npx prisma generate 2>&1 | tee -a "$LOGFILE" | tail -3
+echo "Running migrations (idempotent)..."
+npx prisma migrate deploy 2>&1 | tee -a "$LOGFILE" | tail -5
 echo "Building Next.js..."
 pnpm build 2>&1 | tee -a "$LOGFILE" | tail -15
 


### PR DESCRIPTION
## Summary

**Pass**: PROD-UNBLOCK-DEPLOY-01

### Problem 1 (P0): VPS deploy broken since Feb 3
Auto-deploy via `deploy-frontend.yml` (rsync) has failed 7 consecutive times. PM2 runtime files owned by `www-data` cause rsync `--delete` permission errors (code 23). CI/CD guardrail blocks workflow changes.

**Fix**: Added `npx prisma migrate deploy` to `scripts/prod-deploy-clean.sh` (manual SOP script). Deploy via `bash scripts/prod-deploy-clean.sh` until rsync issue is resolved separately.

### Problem 2 (P2): Admin sub-pages broken auth pattern
Three admin sub-pages used `requireAdmin?.()` (optional chaining, no try-catch):
- `/admin/analytics` 
- `/admin/settings`
- `/admin/users`

If `requireAdmin()` throws `AdminError`, these pages showed generic error page instead of redirecting to login. Now matches `admin/page.tsx` pattern with proper try-catch + `redirect('/auth/login?from=...')`.

## Changes (5 files, +53/-9)

| File | Change |
|------|--------|
| `scripts/prod-deploy-clean.sh` | Add `prisma migrate deploy` between generate and build |
| `frontend/src/app/admin/analytics/page.tsx` | `requireAdmin?.()` → try-catch + AdminError redirect |
| `frontend/src/app/admin/settings/page.tsx` | Same |
| `frontend/src/app/admin/users/page.tsx` | Same |
| `docs/OPS/STATE.md` | Pass documentation |

## Test Plan

- [x] TypeScript typecheck passes (exit 0)
- [ ] CI checks pass
- [ ] Post-deploy: `bash scripts/prod-deploy-clean.sh` succeeds
- [ ] Post-deploy: `prisma migrate status` shows admin_rbac migration applied
- [ ] Admin login → `/admin` dashboard loads
- [ ] `/admin/users`, `/admin/settings`, `/admin/analytics` load (or redirect to login)

## Deploy Note

After merge:
```bash
bash scripts/prod-deploy-clean.sh
```
Admin must log out + log in after deploy to trigger AdminUser upsert.

---
Generated-by: Claude Code (Pass PROD-UNBLOCK-DEPLOY-01)