### PR TITLE
refactor(env): SSOT for API URL env vars (guard/ssot-env-vars)

### DIFF
--- a/frontend/.env.ci
+++ b/frontend/.env.ci
@@ -8,8 +8,9 @@ BASE_URL=http://127.0.0.1:3001
 
 # API: Mocked via Playwright route stubs (no real backend in CI)
 # Pass E2E-SEED-01: SSR needs internal URL pointing to Next.js mock API (not Laravel)
+# SSOT: Canonical var names — see src/env.ts for resolution logic
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:3001/api/v1
-API_INTERNAL_URL=http://127.0.0.1:3001/api/v1
+INTERNAL_API_URL=http://127.0.0.1:3001/api/v1
 
 # Auth (dev)
 OTP_BYPASS=000000

--- a/frontend/src/app/(storefront)/products/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from 'next-intl/server';
 import type { Metadata } from 'next';
 import Add from './ui/Add';
 import { getBaseUrl } from '@/lib/site';
+import { getServerApiUrl } from '@/env';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -24,7 +25,8 @@ async function getProductById(id: string) {
     // In CI SSR, we need absolute URL to Next.js server
     base = 'http://127.0.0.1:3001/api/v1';
   } else if (isServer) {
-    base = process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+    // SSOT: Use centralized env resolution (see src/env.ts)
+    base = getServerApiUrl();
   } else {
     base = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
   }

--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -3,6 +3,7 @@ import { ProductCard } from '@/components/ProductCard';
 import { CategoryStrip } from '@/components/CategoryStrip';
 import { ProductSearchInput } from '@/components/ProductSearchInput';
 import { DEMO_PRODUCTS } from '@/data/demoProducts';
+import { getServerApiUrl } from '@/env';
 
 /**
  * Pass FIX-STOCK-GUARD-01: Added stock field for OOS awareness
@@ -31,9 +32,10 @@ type ApiItem = {
 async function getData(search?: string): Promise<{ items: ApiItem[]; total: number; isDemo: boolean }> {
   // Use internal URL for SSR to avoid external round-trip timeout (Pass 26 fix)
   // CRITICAL: No localhost fallback - use relative URL if not configured
+  // SSOT: Use centralized env resolution (see src/env.ts)
   const isServer = typeof window === 'undefined';
   const base = isServer
-    ? (process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1')
+    ? getServerApiUrl()
     : (process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1');
 
   try {

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,9 +1,10 @@
 import { MetadataRoute } from 'next';
+import { getServerApiUrl, SITE_URL } from '@/env';
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://dixis.gr';
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || SITE_URL;
 
-// Use internal API during build (SSR), external for runtime
-const API_BASE = process.env.INTERNAL_API_URL || 'https://dixis.gr/api/v1';
+// SSOT: Use centralized env resolution for SSR API calls (see src/env.ts)
+const API_BASE = getServerApiUrl();
 
 interface ProductForSitemap {
   id: number;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 // API client utility with Bearer token support
+// NOTE: URL resolution delegates to @/env (SSOT). Do NOT add new process.env reads here.
 
 export interface ApiResponse<T = unknown> {
   data?: T;
@@ -282,29 +283,12 @@ export interface TopProduct {
 // Helper functions for safe URL joining
 // CRITICAL: Browser must use relative URLs (same-origin) to avoid localhost in production
 // Server-side can use INTERNAL_API_URL for SSR server-to-server calls
-// Export for use in other files
+//
+// SSOT: Delegates to @/env for URL resolution. Do NOT duplicate logic here.
+import { API_BASE_URL as _envApiBase } from '@/env';
+
 export function getApiBaseUrl(): string {
-  // 1. If explicitly configured via NEXT_PUBLIC_API_BASE_URL, use it
-  const explicitUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
-  if (explicitUrl) {
-    return explicitUrl;
-  }
-
-  // 2. In browser: ALWAYS use relative URL (same-origin requests)
-  // This ensures production browser calls go to https://dixis.gr/api/v1
-  if (typeof window !== 'undefined') {
-    return '/api/v1';
-  }
-
-  // 3. Server-side (SSR): Use internal URL if configured, else relative
-  // INTERNAL_API_URL is for server-to-server calls only (never exposed to browser)
-  const internalUrl = process.env.INTERNAL_API_URL;
-  if (internalUrl) {
-    return internalUrl;
-  }
-
-  // 4. Fallback for SSR without internal URL: relative path
-  return '/api/v1';
+  return _envApiBase;
 }
 
 const RAW_BASE = getApiBaseUrl();

--- a/frontend/src/lib/http/apiBase.ts
+++ b/frontend/src/lib/http/apiBase.ts
@@ -1,8 +1,14 @@
+/**
+ * @deprecated Use imports from '@/env' instead:
+ *   import { API_BASE_URL, apiUrl } from '@/env';
+ * This module is a legacy duplicate. SSOT is src/env.ts.
+ */
 export function apiBase() {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL?.trim();
   return base ? base.replace(/\/+$/, '') : '';
 }
 
+/** @deprecated Use `import { apiUrl } from '@/env'` instead. */
 export function apiUrl(path: string) {
   if (!path.startsWith('/')) {
     path = '/' + path;

--- a/frontend/src/lib/runtime/urls.ts
+++ b/frontend/src/lib/runtime/urls.ts
@@ -1,4 +1,8 @@
 /**
+ * @deprecated Use imports from '@/env' instead:
+ *   import { apiUrl, getServerApiUrl } from '@/env';
+ * This module is a legacy duplicate. SSOT is src/env.ts.
+ *
  * apiPath: SSR-safe URL builder for fetch
  *
  * SSR context (Node.js):

--- a/frontend/src/lib/url.ts
+++ b/frontend/src/lib/url.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated Use `import { SITE_URL, getServerApiUrl } from '@/env'` instead.
+ * This module is a legacy duplicate. SSOT is src/env.ts.
+ */
 export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://dixis.gr';
 
 // Internal URL for server-side API calls (avoids self-deadlock through nginx)


### PR DESCRIPTION
## Summary

Establishes `src/env.ts` as the **Single Source of Truth** for all environment variable reads, eliminating duplicated URL resolution logic across the codebase.

### Problem
- **5 different modules** computed API base URLs independently (`env.ts`, `lib/api.ts`, `lib/http/apiBase.ts`, `lib/runtime/urls.ts`, `lib/url.ts`)
- `.env.ci` used legacy `API_INTERNAL_URL` instead of canonical `INTERNAL_API_URL`
- SSR pages read `process.env.INTERNAL_API_URL` inline instead of centralizing

### Changes
- **`src/env.ts`**: Enhanced with `getServerApiUrl()` for SSR calls + comprehensive SSOT docs
- **`lib/api.ts`**: `getApiBaseUrl()` now delegates to `env.ts` (removes 20 LOC of duplicate logic)
- **`products/page.tsx`** + **`products/[id]/page.tsx`** + **`sitemap.ts`**: Use `getServerApiUrl()` instead of inline `process.env` reads
- **3 unused modules** (`lib/http/apiBase.ts`, `lib/runtime/urls.ts`, `lib/url.ts`): Marked `@deprecated` pointing to `env.ts`
- **`.env.ci`**: Fixed `API_INTERNAL_URL` → `INTERNAL_API_URL` (canonical name)

### Impact
- 9 files changed, ~100 LOC (well under 300 LOC limit)
- Zero breaking changes — existing consumers work unchanged
- Future env var reads should import from `@/env` instead of `process.env` directly

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [ ] CI: All 23 checks pass (build, typecheck, E2E smoke, E2E PostgreSQL)
- [ ] Verify `.env.ci` rename doesn't break CI (INTERNAL_API_URL is now set correctly)

---
Part of SSOT guardrails series (PR 3/6). See `docs/AGENT-STATE.md`.
Generated-by: Claude Code