### PR TITLE
fix(env): migrate lib/ to @/env SSOT + fix auth double-v1 bug

### DIFF
--- a/frontend/src/app/auth/forgot-password/page.tsx
+++ b/frontend/src/app/auth/forgot-password/page.tsx
@@ -3,8 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from '@/contexts/LocaleContext';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
+import { API_BASE_URL } from '@/env';
 
 export default function ForgotPassword() {
   const [email, setEmail] = useState('');
@@ -25,7 +24,8 @@ export default function ForgotPassword() {
       setLoading(true);
       setError(null);
 
-      const response = await fetch(`${API_BASE}/v1/auth/password/forgot`, {
+      // SSOT: Use centralized API_BASE_URL (already includes /api/v1)
+      const response = await fetch(`${API_BASE_URL}/auth/password/forgot`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/app/auth/reset-password/page.tsx
+++ b/frontend/src/app/auth/reset-password/page.tsx
@@ -4,8 +4,7 @@ import { useState, useEffect, Suspense } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from '@/contexts/LocaleContext';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
+import { API_BASE_URL } from '@/env';
 
 function ResetPasswordForm() {
   const [password, setPassword] = useState('');
@@ -48,7 +47,8 @@ function ResetPasswordForm() {
       setLoading(true);
       setError(null);
 
-      const response = await fetch(`${API_BASE}/v1/auth/password/reset`, {
+      // SSOT: Use centralized API_BASE_URL (already includes /api/v1)
+      const response = await fetch(`${API_BASE_URL}/auth/password/reset`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/app/auth/verify-email/page.tsx
+++ b/frontend/src/app/auth/verify-email/page.tsx
@@ -4,8 +4,7 @@ import { useEffect, useState, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from '@/contexts/LocaleContext';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
+import { API_BASE_URL } from '@/env';
 
 type VerificationState = 'loading' | 'success' | 'error' | 'expired' | 'missing';
 
@@ -41,7 +40,8 @@ function VerifyEmailForm() {
     try {
       setState('loading');
 
-      const response = await fetch(`${API_BASE}/v1/auth/email/verify`, {
+      // SSOT: Use centralized API_BASE_URL (already includes /api/v1)
+      const response = await fetch(`${API_BASE_URL}/auth/email/verify`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -74,7 +74,7 @@ function VerifyEmailForm() {
     try {
       setResendLoading(true);
 
-      const response = await fetch(`${API_BASE}/v1/auth/email/resend`, {
+      const response = await fetch(`${API_BASE_URL}/auth/email/resend`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/lib/api/analytics.ts
+++ b/frontend/src/lib/api/analytics.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+import { API_BASE_URL } from '@/env';
 
 export interface SalesData {
   date: string;

--- a/frontend/src/lib/api/notifications.ts
+++ b/frontend/src/lib/api/notifications.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+import { API_BASE_URL } from '@/env';
 
 export interface Notification {
   id: number;

--- a/frontend/src/lib/api/payment.ts
+++ b/frontend/src/lib/api/payment.ts
@@ -60,7 +60,7 @@ export interface PaymentStatusResponse {
   };
 }
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+import { API_BASE_URL } from '@/env';
 
 class PaymentApiClient {
   private async request<T>(

--- a/frontend/src/lib/api/producer-analytics.ts
+++ b/frontend/src/lib/api/producer-analytics.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+import { API_BASE_URL } from '@/env';
 
 // Import shared types and utilities from admin analytics
 import type {

--- a/frontend/src/lib/api/refunds.ts
+++ b/frontend/src/lib/api/refunds.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+import { API_BASE_URL } from '@/env';
 
 interface RefundRequest {
   amount_cents?: number;

--- a/frontend/src/lib/gdpr-dsr.ts
+++ b/frontend/src/lib/gdpr-dsr.ts
@@ -129,8 +129,9 @@ export class GDPRDataSubjectService {
   private apiBaseUrl: string;
 
   private constructor() {
-    // Use relative URL for browser (same-origin), env var if set
-    this.apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+    // SSOT: Import from @/env — but currently only used with mockApiCall
+    // When real API integration added, use API_BASE_URL from '@/env'
+    this.apiBaseUrl = '/api/v1';
   }
 
   static getInstance(): GDPRDataSubjectService {

--- a/frontend/src/lib/products.ts
+++ b/frontend/src/lib/products.ts
@@ -40,8 +40,9 @@ const centsFrom = (item: any): number | null => {
 
 export const getProducts = cache(async (): Promise<Product[]> => {
   // 1) Προσπάθησε REAL API (εάν υπάρχει NEXT_PUBLIC_API_BASE_URL)
+  // SSOT: Use centralized env resolution (see src/env.ts)
   try {
-    const base = process.env.NEXT_PUBLIC_API_BASE_URL;
+    const { API_BASE_URL: base } = await import('@/env');
     if (base) {
       const res = await fetch(`${base}/products`, { headers: { 'Accept': 'application/json' }, next: { revalidate: 30 } });
       if (res.ok) {


### PR DESCRIPTION
## Summary

Migrates 10 files from inline `process.env.NEXT_PUBLIC_API_BASE_URL` reads to centralized `@/env` imports, and **fixes a latent auth URL bug**.

### Auth Double-v1 Bug Fix (CRITICAL)
Three auth pages (`forgot-password`, `reset-password`, `verify-email`) had:
```typescript
const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
fetch(`${API_BASE}/v1/auth/password/forgot`, ...)
```
If `NEXT_PUBLIC_API_BASE_URL=https://dixis.gr/api/v1` (production build), this produces:
`https://dixis.gr/api/v1/v1/auth/password/forgot` — **double v1, broken URL**.

Now uses `API_BASE_URL` from `@/env` (already includes `/api/v1`) + endpoint without `/v1/` prefix.

### Env SSOT Migrations
- `lib/api/payment.ts`, `refunds.ts`, `analytics.ts`, `producer-analytics.ts`, `notifications.ts` — import `API_BASE_URL` from `@/env`
- `lib/gdpr-dsr.ts` — remove inline process.env read (mock-only module)
- `lib/products.ts` — dynamic import from `@/env`

### Impact
- 10 files, 38 LOC total (20+/18-)
- Zero breaking changes
- Reduces inline `process.env` reads by 10

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [ ] CI: All checks pass (build, typecheck, E2E)
- [ ] Auth pages produce correct URLs (no double v1)

---
Part of SSOT guardrails series (PR 2620). Follows PR #2619 (merged).
Generated-by: Claude Code