### PR TITLE
feat(admin): sidebar navigation + layout shell (ADMIN-LAYOUT-01)

### DIFF
--- a/frontend/src/app/admin/components/AdminShell.tsx
+++ b/frontend/src/app/admin/components/AdminShell.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import { AdminSidebar } from './AdminSidebar';
+
+/**
+ * Pass ADMIN-LAYOUT-01: Fixed-overlay admin shell.
+ *
+ * Renders a full-screen fixed overlay (z-50) that covers the public site's
+ * Header (z-40) and Footer. The sidebar is collapsible on mobile.
+ */
+export function AdminShell({ children }: { children: React.ReactNode }) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  return (
+    <div className="fixed inset-0 z-50 flex bg-neutral-50" data-testid="admin-shell">
+      {/* Mobile overlay backdrop */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/30 lg:hidden"
+          onClick={() => setSidebarOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Sidebar */}
+      <aside
+        className={`
+          fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-neutral-200
+          transform transition-transform duration-200 ease-in-out
+          lg:static lg:translate-x-0
+          ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
+        `}
+      >
+        <AdminSidebar onClose={() => setSidebarOpen(false)} />
+      </aside>
+
+      {/* Main content area */}
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {/* Top bar */}
+        <header className="h-14 border-b border-neutral-200 bg-white flex items-center px-4 lg:px-6 shrink-0">
+          {/* Hamburger button (mobile only) */}
+          <button
+            type="button"
+            className="lg:hidden mr-3 p-2 rounded-md text-neutral-600 hover:bg-neutral-100 hover:text-neutral-900"
+            onClick={() => setSidebarOpen(true)}
+            aria-label="Open sidebar"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+            </svg>
+          </button>
+
+          <span className="text-sm font-medium text-neutral-500">
+            Dixis Admin
+          </span>
+        </header>
+
+        {/* Scrollable content */}
+        <main className="flex-1 overflow-y-auto p-4 lg:p-6">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/components/AdminSidebar.tsx
+++ b/frontend/src/app/admin/components/AdminSidebar.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/cn';
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: string;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { href: '/admin', label: 'Dashboard', icon: '📊' },
+  { href: '/admin/orders', label: 'Παραγγελίες', icon: '📦' },
+  { href: '/admin/products', label: 'Προϊόντα', icon: '🏷️' },
+  { href: '/admin/products/moderation', label: 'Moderation', icon: '🛡️' },
+  { href: '/admin/producers', label: 'Παραγωγοί', icon: '🧑‍🌾' },
+  { href: '/admin/producers/images', label: 'Εικόνες', icon: '🖼️' },
+  { href: '/admin/categories', label: 'Κατηγορίες', icon: '📂' },
+  { href: '/admin/analytics', label: 'Analytics', icon: '📈' },
+  { href: '/admin/users', label: 'Διαχειριστές', icon: '👥' },
+  { href: '/admin/settings', label: 'Ρυθμίσεις', icon: '⚙️' },
+];
+
+/**
+ * Pass ADMIN-LAYOUT-01: Sidebar navigation for admin panel.
+ *
+ * - Shows all admin pages with emoji icons
+ * - Active page highlighting via usePathname()
+ * - Close button visible on mobile only
+ */
+export function AdminSidebar({ onClose }: { onClose: () => void }) {
+  const pathname = usePathname();
+
+  function isActive(href: string): boolean {
+    if (href === '/admin') return pathname === '/admin';
+    return pathname.startsWith(href);
+  }
+
+  return (
+    <div className="flex flex-col h-full" data-testid="admin-sidebar">
+      {/* Header */}
+      <div className="h-14 flex items-center justify-between px-4 border-b border-neutral-200 shrink-0">
+        <Link href="/admin" className="text-base font-bold text-neutral-900 tracking-tight">
+          Dixis Admin
+        </Link>
+        <button
+          type="button"
+          className="lg:hidden p-1.5 rounded-md text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100"
+          onClick={onClose}
+          aria-label="Close sidebar"
+        >
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex-1 overflow-y-auto py-3 px-2" aria-label="Admin navigation">
+        <ul className="space-y-0.5">
+          {NAV_ITEMS.map((item) => (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                onClick={onClose}
+                className={cn(
+                  'flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors',
+                  isActive(item.href)
+                    ? 'bg-emerald-50 text-emerald-800'
+                    : 'text-neutral-600 hover:bg-neutral-100 hover:text-neutral-900'
+                )}
+                aria-current={isActive(item.href) ? 'page' : undefined}
+              >
+                <span className="text-base leading-none" aria-hidden="true">{item.icon}</span>
+                {item.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {/* Footer */}
+      <div className="border-t border-neutral-200 px-4 py-3 shrink-0">
+        <Link
+          href="/"
+          className="flex items-center gap-2 text-xs text-neutral-400 hover:text-neutral-600 transition-colors"
+        >
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+          </svg>
+          Επιστροφή στο site
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,0 +1,28 @@
+import { redirect } from 'next/navigation';
+import { requireAdmin, AdminError } from '@/lib/auth/admin';
+import { AdminShell } from './components/AdminShell';
+
+/**
+ * Pass ADMIN-LAYOUT-01: Admin layout with sidebar navigation.
+ *
+ * - Server Component handles auth (requireAdmin)
+ * - AdminShell (client) renders fixed overlay with sidebar + content area
+ * - Covers root layout's Header/Footer with z-50 fixed overlay
+ * - Zero changes to root layout = zero risk to public site
+ */
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  try {
+    await requireAdmin();
+  } catch (e) {
+    if (e instanceof AdminError) {
+      redirect('/auth/admin-login?from=/admin');
+    }
+    throw e;
+  }
+
+  return <AdminShell>{children}</AdminShell>;
+}


### PR DESCRIPTION
## Summary
- Adds fixed-overlay admin shell (`z-50`) with collapsible sidebar linking to all 10 admin pages
- Layout-level `requireAdmin()` auth — every `/admin/*` route is now protected at the layout level
- Mobile hamburger toggle with backdrop overlay
- Active page highlighting via `usePathname()`

## Pass: `ADMIN-LAYOUT-01`

### New files (192 LOC total)
| File | LOC | Role |
|------|-----|------|
| `app/admin/layout.tsx` | 28 | Server Component — auth gate |
| `app/admin/components/AdminShell.tsx` | 66 | Client Component — fixed overlay shell |
| `app/admin/components/AdminSidebar.tsx` | 98 | Client Component — nav links + active state |

### Sidebar links
Dashboard, Παραγγελίες, Προϊόντα, Moderation, Παραγωγοί, Εικόνες, Κατηγορίες, Analytics, Διαχειριστές, Ρυθμίσεις

### Technical approach
- **Fixed overlay** (`fixed inset-0 z-50`) covers root layout Header/Footer — zero changes to public site
- Individual admin pages still have their own `requireAdmin()` (redundant but safe — layout runs first)
- Uses `@/lib/cn` utility for className composition

## Test plan
- [ ] `npm run type-check` — zero errors ✅
- [ ] `npm run build` — success ✅  
- [ ] Login as admin → sidebar visible with all 10 links
- [ ] Click each link → navigates correctly, active state highlights
- [ ] Mobile: hamburger opens sidebar, backdrop closes it
- [ ] Unauthenticated → redirects to `/auth/admin-login`

---
*Generated by Claude | Pass ADMIN-LAYOUT-01*