### PR TITLE
feat: rate limit verify-otp + admin session 24h (PR-SEC-01+02)

### DIFF
--- a/frontend/src/lib/auth/cookies.ts
+++ b/frontend/src/lib/auth/cookies.ts
@@ -5,10 +5,14 @@ import type { NextResponse } from 'next/server';
  * - HttpOnly: Προστασία από XSS
  * - SameSite=lax: Προστασία από CSRF
  * - Secure: HTTPS-only σε production
- * - MaxAge: 7 days
+ * - MaxAge: configurable (PR-SEC-02: admin 24h, user 7d)
  * - Path: /
  */
-export function setSessionCookie(res: NextResponse, token: string): void {
+export function setSessionCookie(
+  res: NextResponse,
+  token: string,
+  maxAgeSeconds: number = 60 * 60 * 24 * 7, // default 7 days
+): void {
   const isProd =
     process.env.DIXIS_ENV === 'production' ||
     process.env.NODE_ENV === 'production';
@@ -18,7 +22,7 @@ export function setSessionCookie(res: NextResponse, token: string): void {
     sameSite: 'lax',
     path: '/',
     secure: isProd,
-    maxAge: 60 * 60 * 24 * 7, // 7 days
+    maxAge: maxAgeSeconds,
   });
 }
 


### PR DESCRIPTION
## Summary
- **PR-SEC-01**: Wire existing `authRateLimit` (5 req/15min per IP) into `verify-otp` endpoint — prevents brute-force OTP attacks
- **PR-SEC-02**: Reduce admin session from 7 days to 24 hours; user sessions stay 7 days
- `setSessionCookie` now accepts configurable `maxAgeSeconds` parameter

## Changes
- `frontend/src/app/api/auth/verify-otp/route.ts` — import + call `withRateLimit(authRateLimit)`, admin JWT `expiresIn: '24h'`, cookie `maxAge: 86400`
- `frontend/src/lib/auth/cookies.ts` — add `maxAgeSeconds` parameter to `setSessionCookie`

## Context
- `authRateLimit` and `withRateLimit` already existed in `@/lib/rate-limit` but were never imported — this PR wires them in
- Part of Admin Hardening plan (Phase 0: Security)
- Follows OPS-0: VPS `DIXIS_ENV=production` fix (already deployed)

## Test plan
- [ ] `npm run type-check` passes
- [ ] `npm run build` succeeds
- [ ] Existing E2E tests pass
- [ ] Manual: admin login → session expires after 24h (not 7d)
- [ ] Manual: 6th OTP attempt within 15min returns 429

Generated by Claude Code