### PR TITLE
feat(admin): wire OrderStatusQuickActions into order detail (PR-FIX-01)

### DIFF
--- a/frontend/src/app/admin/orders/[id]/page.tsx
+++ b/frontend/src/app/admin/orders/[id]/page.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { orderNumber } from '../../../../lib/orderNumber';
 import { useToast } from '@/contexts/ToastContext';
+import { OrderStatusQuickActions } from './OrderStatusQuickActions';
 
 type Order = {
   id: string;
@@ -16,6 +17,7 @@ type Order = {
   email?: string | null;
   paymentStatus?: string;
   paymentRef?: string | null;
+  status?: string;
 };
 
 export default function AdminOrderDetail({
@@ -52,6 +54,10 @@ export default function AdminOrderDetail({
         <div className="mt-4 text-sm">Φόρτωση…</div>
       ) : (
         <div className="mt-4 text-sm">
+          {/* PR-FIX-01: Wire orphaned OrderStatusQuickActions */}
+          {data.status && (
+            <OrderStatusQuickActions orderId={data.id} currentStatus={data.status} />
+          )}
           <div className="mb-2">
             Order No:{' '}
             <strong data-testid="detail-order-no">
@@ -111,6 +117,12 @@ export default function AdminOrderDetail({
                 <td className="pr-4">Email</td>
                 <td>{data.email ?? '-'}</td>
               </tr>
+              {data.status && (
+                <tr>
+                  <td className="pr-4">Κατάσταση</td>
+                  <td data-testid="detail-status" className="font-medium">{data.status}</td>
+                </tr>
+              )}
               <tr>
                 <td className="pr-4">Payment</td>
                 <td>


### PR DESCRIPTION
## Summary
- Wire orphaned `OrderStatusQuickActions` component into order detail page
- Component already existed (87 LOC) but was never imported — highest ROI/LOC fix
- Shows "Συσκευασία" / "Απεστάλη" quick action buttons based on order status
- Calls `POST /api/admin/orders/:id/status` (state machine + audit logging + email)

## Changes
- `frontend/src/app/admin/orders/[id]/page.tsx` — import component, add `status` to type, render conditionally, show status in detail table

## Context
- `OrderStatusQuickActions.tsx` existed as an orphan with zero imports
- The status change API (`status/route.ts`, 165 LOC) has full state machine, audit logging, and email notification — all already working
- Part of Admin Hardening plan (Phase 1: Fix What's Broken)

## Test plan
- [ ] `npm run type-check` passes (zero errors)
- [ ] `npm run build` succeeds
- [ ] Manual: open order detail → see quick action buttons for pending/paid orders
- [ ] Manual: click "Συσκευασία" → status changes, page reloads with new status

Generated by Claude Code