### PR TITLE
feat(admin): product creation API + UI (PR-CRUD-02)

### DIFF
--- a/frontend/src/app/api/admin/products/route.ts
+++ b/frontend/src/app/api/admin/products/route.ts
@@ -1,6 +1,18 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db/client'
 import { requireAdmin, AdminError } from '@/lib/auth/admin'
+import { z } from 'zod'
+
+const CreateProductSchema = z.object({
+  title: z.string().min(3, 'Τίτλος τουλάχιστον 3 χαρακτήρες'),
+  category: z.string().min(1, 'Απαιτείται κατηγορία'),
+  price: z.number().min(0, 'Η τιμή πρέπει να είναι ≥ 0'),
+  unit: z.string().min(1, 'Απαιτείται μονάδα μέτρησης'),
+  stock: z.number().int().min(0).optional().default(0),
+  description: z.string().optional(),
+  producerId: z.string().min(1, 'Απαιτείται παραγωγός'),
+  imageUrl: z.string().url().optional().or(z.literal('')),
+})
 
 export async function GET(req: Request) {
   try {
@@ -51,5 +63,76 @@ export async function GET(req: Request) {
     }
 
     return NextResponse.json({ error: 'Σφάλμα διακομιστή' }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    await requireAdmin()
+
+    const body = await req.json().catch(() => ({}))
+    const parsed = CreateProductSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Λάθος δεδομένα', issues: parsed.error.format() },
+        { status: 400 }
+      )
+    }
+
+    const { title, category, price, unit, stock, description, producerId, imageUrl } = parsed.data
+
+    // Verify producer exists
+    const producer = await prisma.producer.findUnique({ where: { id: producerId } })
+    if (!producer) {
+      return NextResponse.json({ error: 'Ο παραγωγός δεν βρέθηκε' }, { status: 400 })
+    }
+
+    // Generate slug from title
+    const baseSlug = title
+      .toLowerCase()
+      .replace(/[αά]/g, 'a').replace(/[εέ]/g, 'e').replace(/[ηή]/g, 'i')
+      .replace(/[ιί]/g, 'i').replace(/[οό]/g, 'o').replace(/[υύ]/g, 'y')
+      .replace(/[ωώ]/g, 'o').replace(/[σς]/g, 's')
+      .replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+    const slug = `${baseSlug}-${Date.now().toString(36)}`
+
+    const item = await prisma.product.create({
+      data: {
+        title,
+        slug,
+        category,
+        price,
+        unit,
+        stock: stock ?? 0,
+        description: description || null,
+        producerId,
+        imageUrl: imageUrl || null,
+        isActive: true,
+        approvalStatus: 'approved', // Admin-created products auto-approved
+      },
+      select: {
+        id: true,
+        title: true,
+        slug: true,
+        category: true,
+        price: true,
+        producer: { select: { id: true, name: true } },
+      },
+    })
+
+    return NextResponse.json({ item }, { status: 201 })
+
+  } catch (error: unknown) {
+    console.error('Admin product create error:', error)
+
+    if (error instanceof AdminError) {
+      if (error.code === 'NOT_AUTHENTICATED') {
+        return NextResponse.json({ error: 'Απαιτείται σύνδεση' }, { status: 401 })
+      }
+      return NextResponse.json({ error: 'Απαιτείται σύνδεση διαχειριστή' }, { status: 403 })
+    }
+
+    return NextResponse.json({ error: 'Σφάλμα δημιουργίας προϊόντος' }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
- Add POST `/api/admin/products` with Zod validation (title, category, price, unit, stock, producerId)
- Auto-generates Greek-safe slug from title, admin-created products auto-approved
- Verifies producer exists before creating product
- Add "Νέο Προϊόν" button + modal form with producer dropdown in products page
- 201 LOC (under 300 LOC guardrail)

## Test plan
- [x] Local `tsc --noEmit` passes
- [x] Local `next build` passes
- [ ] CI build-and-test passes
- [ ] Manual: create product via modal, verify in list