### PR TITLE
refactor(admin): shared AdminLoading + AdminEmptyState (PR-CLEAN-02)

### DIFF
--- a/frontend/src/app/admin/components/AdminEmptyState.tsx
+++ b/frontend/src/app/admin/components/AdminEmptyState.tsx
@@ -1,0 +1,31 @@
+/**
+ * Shared empty state for admin tables/lists.
+ * Usage: <AdminEmptyState message="Δεν βρέθηκαν προϊόντα." />
+ * or:    <AdminEmptyState message="Δεν βρέθηκαν αποτελέσματα." colSpan={7} />
+ */
+export default function AdminEmptyState({
+  message = 'Δεν βρέθηκαν αποτελέσματα.',
+  colSpan,
+}: {
+  message?: string
+  colSpan?: number
+}) {
+  const content = (
+    <div
+      style={{ opacity: 0.7, textAlign: 'center', padding: 16 }}
+      data-testid="admin-empty-state"
+    >
+      {message}
+    </div>
+  )
+
+  if (colSpan) {
+    return (
+      <tr>
+        <td colSpan={colSpan}>{content}</td>
+      </tr>
+    )
+  }
+
+  return content
+}

--- a/frontend/src/app/admin/components/AdminLoading.tsx
+++ b/frontend/src/app/admin/components/AdminLoading.tsx
@@ -1,0 +1,14 @@
+/**
+ * Shared loading spinner for admin pages.
+ * Usage: <AdminLoading /> or <AdminLoading text="Αναζήτηση..." />
+ */
+export default function AdminLoading({ text = 'Φόρτωση...' }: { text?: string }) {
+  return (
+    <div
+      style={{ textAlign: 'center', padding: 32, opacity: 0.6 }}
+      data-testid="admin-loading"
+    >
+      {text}
+    </div>
+  )
+}

--- a/frontend/src/app/admin/producers/page.tsx
+++ b/frontend/src/app/admin/producers/page.tsx
@@ -4,6 +4,8 @@ import React, { useState, useEffect, Suspense } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useToast } from '@/contexts/ToastContext'
+import AdminLoading from '@/app/admin/components/AdminLoading'
+import AdminEmptyState from '@/app/admin/components/AdminEmptyState'
 
 interface Producer {
   id: string
@@ -47,7 +49,7 @@ function parseStyle(s: string): React.CSSProperties {
 
 export default function AdminProducersPage() {
   return (
-    <Suspense fallback={<div style={{ padding: 32, textAlign: 'center' }}>Φόρτωση...</div>}>
+    <Suspense fallback={<AdminLoading />}>
       <AdminProducersContent />
     </Suspense>
   )
@@ -220,7 +222,7 @@ function AdminProducersContent() {
       </form>
 
       {loading ? (
-        <div style={{ textAlign: 'center', padding: 32, opacity: 0.6 }}>Φόρτωση...</div>
+        <AdminLoading />
       ) : (
         <table width="100%" cellPadding={8} style={{ borderCollapse: 'collapse' }}>
           <thead>
@@ -269,11 +271,7 @@ function AdminProducersContent() {
               </tr>
             ))}
             {producers.length === 0 && (
-              <tr>
-                <td colSpan={5} style={{ opacity: 0.7, textAlign: 'center', padding: 16 }}>
-                  Δεν βρέθηκαν αποτελέσματα.
-                </td>
-              </tr>
+              <AdminEmptyState message="Δεν βρέθηκαν αποτελέσματα." colSpan={5} />
             )}
           </tbody>
         </table>

--- a/frontend/src/app/admin/products/page.tsx
+++ b/frontend/src/app/admin/products/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, Suspense } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useToast } from '@/contexts/ToastContext'
+import AdminLoading from '@/app/admin/components/AdminLoading'
+import AdminEmptyState from '@/app/admin/components/AdminEmptyState'
 
 interface Product {
   id: string
@@ -361,7 +363,7 @@ function AdminProductsContent() {
       </form>
 
       {loading ? (
-        <div style={{ textAlign: 'center', padding: 32, opacity: 0.6 }}>Φόρτωση...</div>
+        <AdminLoading />
       ) : (
         <table width="100%" cellPadding={8} style={{ borderCollapse: 'collapse' }}>
           <thead>
@@ -446,11 +448,7 @@ function AdminProductsContent() {
               </tr>
             ))}
             {products.length === 0 && (
-              <tr>
-                <td colSpan={7} style={{ opacity: 0.7, textAlign: 'center', padding: 16 }}>
-                  Δεν βρέθηκαν προϊόντα.
-                </td>
-              </tr>
+              <AdminEmptyState message="Δεν βρέθηκαν προϊόντα." colSpan={7} />
             )}
           </tbody>
         </table>
@@ -623,7 +621,7 @@ export default function AdminProductsPage() {
   return (
     <main style={{ padding: 16, maxWidth: 1200, margin: '0 auto' }}>
       <h1>Προϊόντα</h1>
-      <Suspense fallback={<div style={{ textAlign: 'center', padding: 32, opacity: 0.6 }}>Φόρτωση...</div>}>
+      <Suspense fallback={<AdminLoading />}>
         <AdminProductsContent />
       </Suspense>
     </main>


### PR DESCRIPTION
## Summary
- Extract `AdminLoading` (14 LOC) and `AdminEmptyState` (31 LOC) shared components
- Replace 6 inline loading/empty state patterns in products + producers pages
- Components support custom text, table colSpan, and data-testid

## Test plan
- [x] `tsc --noEmit` passes
- [x] `next build` passes
- [ ] CI build-and-test passes