### PR TITLE
feat: order status email notifications via Resend (ORDER-NOTIFY-01)

### DIFF
--- a/frontend/.env.ci
+++ b/frontend/.env.ci
@@ -18,6 +18,7 @@ ADMIN_PHONES=+306900000084
 
 # Mails (dev mailbox)
 DEV_MAIL_TO=dev@localhost
+EMAIL_DRY_RUN=true
 
 # DB: SQLite για CI/E2E
 DATABASE_URL=file:./test.db

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -118,6 +118,8 @@ SMTP_SECURE=false
 SMTP_USER=
 SMTP_PASS=
 MAIL_FROM="Dixis <no-reply@dixis.gr>"
+RESEND_API_KEY=
+EMAIL_DRY_RUN=true
 
 # ── Viva Wallet Payment Gateway (AG128) ─────────────────────────────
 # Environment: demo | live

--- a/frontend/src/app/api/producer/orders/[id]/status/route.ts
+++ b/frontend/src/app/api/producer/orders/[id]/status/route.ts
@@ -101,7 +101,7 @@ export async function POST(
     // Send email notification
     const emailResult = await sendOrderStatusUpdate({
       data: {
-        orderId: parseInt(orderId, 10) || 0,
+        orderId: orderId,
         customerName,
         newStatus: status,
         total: order.total,


### PR DESCRIPTION
## Summary
- Admin status changes (PACKING/SHIPPED/DELIVERED/CANCELLED) now send real emails to customers via Resend API
- Replace broken `sendMailSafe` (NOOP in production) with working `sendOrderStatusUpdate`
- Read customer email from `order.email` field instead of hardcoded `DEV_MAIL_TO`
- Fix producer route `orderId` bug: `parseInt` on CUID string always returned 0

## Changes (5 files, -7 LOC net)
- `frontend/src/lib/email.ts` — Extend StatusUpdateEmailData (packing/cancelled statuses, trackUrl, orderId→string), add `normalizeOrderStatus()`, red header for cancelled
- `frontend/src/app/api/admin/orders/[id]/status/route.ts` — Rewire from sendMailSafe to sendOrderStatusUpdate + order.email
- `frontend/src/app/api/producer/orders/[id]/status/route.ts` — Fix orderId: parseInt→string (1 line)
- `frontend/.env.example` — Document RESEND_API_KEY + EMAIL_DRY_RUN
- `frontend/.env.ci` — Add EMAIL_DRY_RUN=true

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [ ] CI green (smoke + quality gates)
- [ ] VPS deploy: admin changes order status → customer receives email