### PR TITLE
docs: ORDER-NOTIFY-01 SSOT update

### DIFF
--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -1,6 +1,6 @@
 # AGENT-STATE — Dixis Canonical Entry Point
 
-**Updated**: 2026-02-06 (ADMIN-HARDENING ✅ COMPLETE — 11 PRs merged)
+**Updated**: 2026-02-06 (ORDER-NOTIFY-01 ✅ — email notifications)
 
 > **This is THE entry point.** Read this first on every agent session. Single source of truth.
 
@@ -28,9 +28,9 @@ _(empty — pick from NEXT)_
 
 | Priority | Pass ID | Feature |
 |----------|---------|---------|
-| 1 | **ORDER-NOTIFY-01** | Order status email notifications |
-| 2 | **CARD-SMOKE-02** | Card payment E2E smoke on production |
-| 3 | **CART-SYNC-01** | Cart persistence to backend |
+| 1 | **CARD-SMOKE-02** | Card payment E2E smoke on production |
+| 2 | **CART-SYNC-01** | Cart persistence to backend |
+| 3 | **EMAIL-VERIFY-01** | Email verification flow |
 
 See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 
@@ -47,6 +47,7 @@ See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 
 ## Recently Done (last 10)
 
+- **ORDER-NOTIFY-01** — Order status email notifications via Resend (#2651) ✅
 - **PR-CLEAN-02** — Shared admin components: AdminLoading + AdminEmptyState (#2646) ✅
 - **PR-CLEAN-01** — Dead code removal: update-status, validator, resend spec (#2644) ✅
 - **PR-CRUD-02** — Product creation API + UI with Zod validation (#2642) ✅
@@ -56,7 +57,6 @@ See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 - **PR-FIX-02** — Moderation page rewrite: cookies, toast, Tailwind (#2635) ✅
 - **PR-FIX-01** — Wire OrderStatusQuickActions into order detail (#2634) ✅
 - **PR-SEC-01+02** — Rate limit + admin 24h session (#2633) ✅
-- **OPS-0** — VPS DIXIS_ENV=production, bypass closed ✅
 
 ---
 

--- a/docs/AGENT/PASSES/SUMMARY-Pass-ORDER-NOTIFY-01.md
+++ b/docs/AGENT/PASSES/SUMMARY-Pass-ORDER-NOTIFY-01.md
@@ -1,0 +1,39 @@
+# SUMMARY: Pass ORDER-NOTIFY-01 — Order Status Email Notifications
+
+**Date**: 2026-02-06
+**PR**: [#2651](https://github.com/lomendor/Project-Dixis/pull/2651)
+**Status**: ✅ MERGED
+**LOC**: -7 net (70 added, 77 removed)
+
+## What Changed
+
+Admin order status changes now send real emails to customers via Resend API.
+
+### Problem
+- `sendMailSafe` in `@/lib/mail/mailer.ts` was NOOP in production (just `console.log`)
+- Admin route hardcoded `DEV_MAIL_TO` env var as recipient
+- Comment incorrectly claimed "we don't have buyer email in schema" (email field exists)
+
+### Solution
+- Replaced `sendMailSafe` with `sendOrderStatusUpdate` from `@/lib/email.ts` (already working for producer route)
+- Extended `StatusUpdateEmailData`: added `packing`/`cancelled` statuses, `trackUrl`, changed `orderId` from number to string
+- Added `normalizeOrderStatus()` function to map UPPERCASE admin statuses to lowercase email values
+- Cancelled orders get red email header
+- Tracking link button in emails when `publicToken` available
+
+### Bug Fix
+- Producer route `orderId: parseInt(orderId, 10) || 0` always returned 0 for CUID strings. Now passes string directly.
+
+## Files Changed
+
+1. `frontend/src/lib/email.ts` — Core email service extension
+2. `frontend/src/app/api/admin/orders/[id]/status/route.ts` — Rewired email sending
+3. `frontend/src/app/api/producer/orders/[id]/status/route.ts` — orderId bug fix
+4. `frontend/.env.example` — Document RESEND_API_KEY, EMAIL_DRY_RUN
+5. `frontend/.env.ci` — EMAIL_DRY_RUN=true for CI safety
+
+## Verification
+- `npx tsc --noEmit` — clean
+- `npm run build` — clean
+- CI: all checks passed (smoke, typecheck, quality-gates)
+- Production: admin changes status → customer gets email via Resend

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,11 +1,27 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-04 (Pass-PROD-UNBLOCK-DEPLOY-01)
+**Last Updated**: 2026-02-06 (Pass-ORDER-NOTIFY-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~420 lines (target ≤350). ⚠️ Over limit — archive next pass.
+> **Current size**: ~440 lines (target ≤350). ⚠️ Over limit — archive next pass.
 >
 > **Key Docs**: [DEPLOY SOP](DEPLOY.md) | [STATE Archive](STATE-ARCHIVE/)
+
+---
+
+## 2026-02-06 — Pass-ORDER-NOTIFY-01: Wire order status email notifications via Resend
+
+**Status**: ✅ MERGED ([#2651](https://github.com/lomendor/Project-Dixis/pull/2651))
+
+**Changes** (5 files, -7 LOC net):
+1. **`frontend/src/lib/email.ts`** — Extend StatusUpdateEmailData (packing/cancelled statuses, trackUrl, orderId string), add `normalizeOrderStatus()`
+2. **`frontend/src/app/api/admin/orders/[id]/status/route.ts`** — Replace broken `sendMailSafe` (NOOP in prod) with `sendOrderStatusUpdate` + `order.email`
+3. **`frontend/src/app/api/producer/orders/[id]/status/route.ts`** — Fix orderId bug: `parseInt` on CUID string always returned 0
+4. **`frontend/.env.example`** + **`frontend/.env.ci`** — Document `RESEND_API_KEY`, `EMAIL_DRY_RUN`
+
+**Why**: Admin status changes (PACKING/SHIPPED/DELIVERED/CANCELLED) were not sending emails because `sendMailSafe` was NOOP in production. Now uses Resend API via `sendOrderStatusUpdate`. Cancelled orders get red header in email.
+
+**Deploy**: Follow `docs/AGENT/SOPs/SOP-VPS-DEPLOY.md`
 
 ---
 


### PR DESCRIPTION
## Summary
- AGENT-STATE.md: ORDER-NOTIFY-01 → Recently Done, NEXT updated
- OPS/STATE.md: New entry for Pass-ORDER-NOTIFY-01 (#2651)
- PASSES/SUMMARY-Pass-ORDER-NOTIFY-01.md: Pass documentation

## Test plan
- [ ] Docs render correctly on GitHub