### PR TITLE
fix: stabilize card payment E2E for production (CARD-SMOKE-02)

### DIFF
--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -1,6 +1,6 @@
 # AGENT-STATE — Dixis Canonical Entry Point
 
-**Updated**: 2026-02-06 (ORDER-NOTIFY-01 ✅ — email notifications)
+**Updated**: 2026-02-06 (CARD-SMOKE-02 ✅ — card payment E2E on production)
 
 > **This is THE entry point.** Read this first on every agent session. Single source of truth.
 
@@ -28,9 +28,9 @@ _(empty — pick from NEXT)_
 
 | Priority | Pass ID | Feature |
 |----------|---------|---------|
-| 1 | **CARD-SMOKE-02** | Card payment E2E smoke on production |
-| 2 | **CART-SYNC-01** | Cart persistence to backend |
-| 3 | **EMAIL-VERIFY-01** | Email verification flow |
+| 1 | **CART-SYNC-01** | Cart persistence to backend |
+| 2 | **EMAIL-VERIFY-01** | Email verification flow |
+| 3 | **PRODUCER-DASH-01** | Producer dashboard improvements |
 
 See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 
@@ -47,6 +47,7 @@ See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 
 ## Recently Done (last 10)
 
+- **CARD-SMOKE-02** — Card payment E2E smoke verified on production ✅
 - **ORDER-NOTIFY-01** — Order status email notifications via Resend (#2651) ✅
 - **PR-CLEAN-02** — Shared admin components: AdminLoading + AdminEmptyState (#2646) ✅
 - **PR-CLEAN-01** — Dead code removal: update-status, validator, resend spec (#2644) ✅

--- a/docs/AGENT/PASSES/SUMMARY-Pass-CARD-SMOKE-02.md
+++ b/docs/AGENT/PASSES/SUMMARY-Pass-CARD-SMOKE-02.md
@@ -1,0 +1,83 @@
+# Pass CARD-SMOKE-02: Card Payment E2E Smoke on Production
+
+**Date**: 2026-02-06
+**Status**: DONE
+**Branch**: `pass/card-smoke-02`
+
+---
+
+## Goal
+
+Unblock and verify the full Stripe card payment E2E flow on production (TEST mode, no real charges).
+
+Previous pass (PAYMENTS-CARD-REAL-01) got 3/4 tests passing; the Stripe Elements test was SKIPPED because `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` was not baked into the production build.
+
+---
+
+## What Was Done
+
+### Production Environment Fixes (VPS)
+
+1. **Created `frontend/.env`** on VPS with all required vars:
+   - `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_*`
+   - `NEXT_PUBLIC_PAYMENTS_CARD_FLAG=true`
+   - `INTERNAL_API_URL=https://dixis.gr/api/v1` (SSR server-to-server)
+   - Plus DATABASE_URL, RESEND_API_KEY, etc.
+
+2. **Rebuilt frontend** (`npm run build`) to bake `NEXT_PUBLIC_*` vars into client bundle
+
+3. **Fixed PM2 crash loop** — old Next.js process held port 3000, causing EADDRINUSE. Fix: `fuser -k 3000/tcp` before restart.
+
+4. **Fixed SSR demo fallback** — Products page was showing demo data (`demo-1`, `demo-2`) because SSR couldn't reach the backend API. Root cause: missing `INTERNAL_API_URL`. Node.js fetch with relative `/api/v1` URL fails server-side.
+
+### E2E Test Fixes (102 LOC)
+
+1. **URL regex**: Changed `/\/products\/\d+/` to `/\/products\/[^/]+/` (production uses slugs, not just numeric IDs)
+
+2. **In-stock product selection**: Added `beforeAll` API call to find a product with `stock > 0` via `/api/v1/public/products`. Tests navigate directly to `/products/{id}` instead of clicking first card (which could be OOS).
+
+3. **UI fallback**: If API unavailable, falls back to clicking product cards that don't show "Εξαντλήθηκε" (Out of Stock).
+
+---
+
+## Test Results
+
+```
+Running 4 tests using 1 worker
+
+  4 passed (1.3m)
+
+  1. UI login with real credentials          PASSED
+  2. Add product to cart and reach checkout   PASSED
+  3. Card payment option visible              PASSED (COD: true, Card: true)
+  4. Stripe Elements card payment flow        PASSED
+     - Order creation: 201
+     - Payment init: 200 (client_secret present)
+     - Stripe Elements iframe: loaded
+     - Card 4242...4242 entered via PaymentElement
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/tests/e2e/card-payment-real-auth.spec.ts` | +62 -40 (102 LOC) |
+
+---
+
+## Production Config Added (VPS only, not in repo)
+
+| File | What |
+|------|------|
+| `/var/www/dixis/current/frontend/.env` | Created with all NEXT_PUBLIC vars + INTERNAL_API_URL |
+
+---
+
+## Key Lessons
+
+1. `NEXT_PUBLIC_*` vars must exist at **build time** for Next.js to inline them
+2. `INTERNAL_API_URL` must be set for SSR to reach the backend (relative URLs fail in Node.js)
+3. PM2 restart after rebuild: always `fuser -k PORT/tcp` first to avoid EADDRINUSE crash loops
+4. Products page falls back to demo data silently when API fetch fails — monitor for this

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,11 +1,28 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-06 (Pass-ORDER-NOTIFY-01)
+**Last Updated**: 2026-02-06 (Pass-CARD-SMOKE-02)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~440 lines (target ≤350). ⚠️ Over limit — archive next pass.
+> **Current size**: ~460 lines (target ≤350). ⚠️ Over limit — archive next pass.
 >
 > **Key Docs**: [DEPLOY SOP](DEPLOY.md) | [STATE Archive](STATE-ARCHIVE/)
+
+---
+
+## 2026-02-06 — Pass-CARD-SMOKE-02: Card Payment E2E Smoke on Production
+
+**Status**: ✅ DONE (branch: `pass/card-smoke-02`)
+
+**Changes** (1 file, 102 LOC):
+1. **`frontend/tests/e2e/card-payment-real-auth.spec.ts`** — Fix product selection: API-resolved in-stock product + URL regex for slug-based routes
+
+**VPS fixes** (not in repo):
+- Created `frontend/.env` with `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, `NEXT_PUBLIC_PAYMENTS_CARD_FLAG=true`, `INTERNAL_API_URL`
+- Rebuilt frontend, fixed PM2 EADDRINUSE crash loop
+
+**Results**: 4/4 real-auth E2E tests passing against production:
+- Login ✅ | Add to cart ✅ | Card option visible (COD+Card) ✅ | Stripe Elements flow ✅
+- Stripe test card 4242: order 201 → payment init 200 → Elements loaded → card entered
 
 ---
 


### PR DESCRIPTION
## Summary
- **Stabilize card-payment-real-auth E2E tests** against production by resolving an in-stock product via API in `beforeAll` instead of clicking the first product card (which could be OOS or demo fallback)
- **Fix URL regex** from `/\d+/` to `/[^/]+/` to handle slug-based product routes
- **VPS config** (not in this PR): Created `frontend/.env` with `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, `NEXT_PUBLIC_PAYMENTS_CARD_FLAG=true`, `INTERNAL_API_URL` and rebuilt

## Test Results (production)
```
4 passed (1.3m)
1. UI login with real credentials          ✅
2. Add product to cart and reach checkout   ✅
3. Card payment option visible (COD+Card)  ✅
4. Stripe Elements card payment flow        ✅
   - Order: 201 → Payment init: 200 → Elements loaded → Card 4242 entered
```

## Test plan
- [x] `BASE_URL=https://dixis.gr npx playwright test card-payment-real-auth.spec.ts` — 4/4 passed
- [x] `BASE_URL=https://dixis.gr npx playwright test card-payment-smoke.spec.ts` — 3 skipped (expected: mock auth)
- [x] `BASE_URL=https://dixis.gr npx playwright test card-payment-confirm-guards.spec.ts` — 3 skipped (expected: mock auth)
- [x] `curl -sI https://dixis.gr/api/healthz` — 200 OK
- [ ] CI smoke tests pass