### PR TITLE
docs: protect frontend .env during VPS deploys

### DIFF
--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -1,6 +1,6 @@
 # AGENT-STATE — Dixis Canonical Entry Point
 
-**Updated**: 2026-02-06 (REORDER-01 + TRACKING-DISPLAY-01 merged)
+**Updated**: 2026-02-06 (PRODUCER-NOTIFY-01 discovered working)
 
 > **This is THE entry point.** Read this first on every agent session. Single source of truth.
 
@@ -28,9 +28,9 @@ _(empty — pick from NEXT)_
 
 | Priority | Pass ID | Feature | Why |
 |----------|---------|---------|-----|
-| 1 | **OAUTH-GOOGLE-01** | Google OAuth frontend | Backend ready |
-| 2 | **ADMIN-SHIPPING-UI-01** | Admin shipping labels UI | Service exists |
-| 3 | **PRODUCER-NOTIFY-01** | Producer new order notifications | Email service ready |
+| 1 | **ADMIN-SHIPPING-UI-01** | Admin shipping labels UI | Component exists, needs wiring |
+| 2 | **OAUTH-GOOGLE-01** | Google OAuth login | Backend NOT ready (needs Socialite) |
+| 3 | **WISHLIST-01** | User wishlist feature | No implementation yet |
 
 See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 
@@ -47,6 +47,7 @@ See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 
 ## Recently Done (last 10)
 
+- **PRODUCER-NOTIFY-01** — Producer emails discovered working (47 records, enabled since Jan) ✅
 - **REORDER-01** — Reorder button on order details (PR #2659, deployed 2026-02-06) ✅
 - **TRACKING-DISPLAY-01** — Public order tracking via UUID token (PR #2657, deployed 2026-02-06) ✅
 - **CART-SYNC-01** — Cart persistence discovered working (AuthContext sync on login) ✅


### PR DESCRIPTION
## Summary
- Add .env backup/restore steps to SOP-VPS-DEPLOY.md
- Prevent site fallback to demo mode when .env is lost during deploy

## Incident
On 2026-02-06, frontend .env was deleted during deploy, causing "DB offline" fallback.

## Changes
- Step 2: backup .env before git operations
- Step 5: restore .env if missing after git checkout
- Verification: check healthz for `"env":"ok"`
- One-liner: includes .env protection
- Troubleshooting: "DB offline" symptom entry
- AGENT-STATE: updated with PRODUCER-NOTIFY-01 discovery