### PR TITLE
fix(build): guard sitemap against invalid product dates

### DIFF
--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -66,12 +66,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
       productPages = products
         .filter((p) => p.is_active)
-        .map((product) => ({
-          url: `${BASE_URL}/products/${product.id}`,
-          lastModified: new Date(product.updated_at),
-          changeFrequency: 'weekly' as const,
-          priority: 0.8,
-        }));
+        .map((product) => {
+          const date = new Date(product.updated_at);
+          const lastModified = isNaN(date.getTime()) ? new Date() : date;
+          return {
+            url: `${BASE_URL}/products/${product.id}`,
+            lastModified,
+            changeFrequency: 'weekly' as const,
+            priority: 0.8,
+          };
+        });
     }
   } catch (error) {
     console.error('[Sitemap] Error fetching products from API:', error);


### PR DESCRIPTION
## Summary
- Guard `new Date(product.updated_at)` in sitemap.ts against invalid date values
- Falls back to `new Date()` when the parsed date is NaN
- Prevents `RangeError: Invalid time value` that blocks the entire Next.js production build

## Context
Discovered during `prod-deploy-clean.sh` run — TypeScript compiled successfully but static page generation crashed on `/sitemap.xml` because a product in the database has an invalid `updated_at` timestamp.

## Test plan
- [x] Build passes locally with invalid date inputs
- [ ] `prod-deploy-clean.sh` completes successfully after merge

Generated-by: claude-code