### PR TITLE
fix(api): add missing product detail route (BUG-C03)

### DIFF
--- a/frontend/src/app/api/public/products/[id]/route.ts
+++ b/frontend/src/app/api/public/products/[id]/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Public Product by ID API
+ * Mirrors /api/public/products (listing) but returns a single product.
+ * Used by (storefront)/products/[id]/page.tsx via INTERNAL_API_URL.
+ *
+ * Returns Laravel-compatible format so the detail page mapping works.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: 'missing id' }, { status: 400 });
+  }
+
+  try {
+    const product = await prisma.product.findFirst({
+      where: {
+        OR: [{ id }, { slug: id }],
+        isActive: true,
+      },
+      include: {
+        producer: {
+          select: { id: true, name: true, slug: true },
+        },
+      },
+    });
+
+    if (!product) {
+      return NextResponse.json({ error: 'not found' }, { status: 404 });
+    }
+
+    // Map to Laravel API format expected by getProductById() in detail page
+    const data = {
+      id: product.id,
+      name: product.title,
+      slug: product.slug,
+      description: product.description,
+      price: product.price,
+      unit: product.unit || 'kg',
+      stock: product.stock ?? 0,
+      is_active: product.isActive,
+      category: product.category,
+      image_url: product.imageUrl,
+      producer_id: product.producerId,
+      producer: product.producer
+        ? {
+            id: product.producer.id,
+            name: product.producer.name,
+            slug: product.producer.slug,
+          }
+        : null,
+    };
+
+    return NextResponse.json(
+      { data },
+      { headers: { 'cache-control': 'no-store' } }
+    );
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : 'unknown error';
+    console.error('[API] public/products/[id] error:', message);
+    return NextResponse.json(
+      { error: 'Database error', message },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- **Add** `/api/public/products/[id]` route — product detail pages were showing 404 because this route didn't exist
- **Fix** `/api/public/products` listing route — was returning hardcoded "Demo Producer" instead of real producer names
- Both routes now use same Prisma data layer with Laravel-compatible response format

## Root Cause
The storefront `products/[id]/page.tsx` fetches from `INTERNAL_API_URL/public/products/[id]`. In production, `INTERNAL_API_URL=http://127.0.0.1:3000/api`, so the fetch hits `/api/public/products/[id]` — but only the listing route (`/api/public/products`) existed. The `/api/v1/public/products/[id]` route is CI-only (returns 503 in production).

## Fixes
- BUG-C03: Product detail pages show "Η σελίδα δεν βρέθηκε" (404)
- Partial BUG-X04: Product cards show "DEMO PRODUCER" instead of real producer name

## Test Plan
- [ ] CI passes (TypeScript, build, E2E)
- [ ] Product detail page loads at `/products/[id]` on production
- [ ] Product cards show real producer names on `/products`
- [ ] Add to cart works from product detail page

## Impact
- 2 files changed, +112/-26 lines (within 300 LOC limit)
- No breaking changes — existing response format preserved