### PR TITLE
fix(i18n): translate admin panel English strings to Greek

### DIFF
--- a/frontend/src/app/admin/analytics/AnalyticsContent.tsx
+++ b/frontend/src/app/admin/analytics/AnalyticsContent.tsx
@@ -11,24 +11,24 @@ export default function AnalyticsContent() {
         <nav className="flex mb-8" data-testid="breadcrumb">
           <ol className="flex items-center space-x-2 text-sm text-gray-500">
             <li>
-              <Link href="/" className="hover:text-green-600">Home</Link>
+              <Link href="/" className="hover:text-green-600">Αρχική</Link>
             </li>
             <li>/</li>
             <li>
-              <Link href="/admin" className="hover:text-green-600">Admin</Link>
+              <Link href="/admin" className="hover:text-green-600">Διαχείριση</Link>
             </li>
             <li>/</li>
-            <li className="text-gray-900">Analytics</li>
+            <li className="text-gray-900">Αναλυτικά</li>
           </ol>
         </nav>
 
         {/* Page Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            Analytics Dashboard
+            Πίνακας Αναλυτικών
           </h1>
           <p className="text-gray-600">
-            Monitor user behavior and marketplace performance metrics
+            Παρακολουθήστε τη συμπεριφορά χρηστών και τις μετρήσεις απόδοσης της αγοράς
           </p>
         </div>
 
@@ -45,18 +45,19 @@ export default function AnalyticsContent() {
             </div>
             <div className="ml-3">
               <h3 className="text-sm font-medium text-blue-800">
-                Analytics Information
+                Πληροφορίες Αναλυτικών
               </h3>
               <div className="mt-2 text-sm text-blue-700">
                 <p>
-                  This dashboard displays real-time analytics data from user interactions across the Dixis marketplace.
-                  Events are tracked client-side and include page views, product interactions, cart activities, and order completions.
+                  Αυτός ο πίνακας εμφανίζει δεδομένα αναλυτικών σε πραγματικό χρόνο από τις αλληλεπιδράσεις χρηστών
+                  στην αγορά Dixis. Τα γεγονότα καταγράφονται στην πλευρά του πελάτη και περιλαμβάνουν προβολές σελίδων,
+                  αλληλεπιδράσεις προϊόντων, δραστηριότητες καλαθιού και ολοκληρώσεις παραγγελιών.
                 </p>
                 <ul className="mt-2 list-disc list-inside space-y-1">
-                  <li>Data is updated in real-time as users interact with the platform</li>
-                  <li>Events are batched for optimal performance</li>
-                  <li>All data respects user privacy and GDPR compliance</li>
-                  <li>Session tracking helps understand user journeys</li>
+                  <li>Τα δεδομένα ενημερώνονται σε πραγματικό χρόνο</li>
+                  <li>Τα γεγονότα ομαδοποιούνται για βέλτιστη απόδοση</li>
+                  <li>Όλα τα δεδομένα σέβονται το απόρρητο χρηστών και τη συμμόρφωση GDPR</li>
+                  <li>Η παρακολούθηση συνεδριών βοηθά στην κατανόηση της πορείας των χρηστών</li>
                 </ul>
               </div>
             </div>

--- a/frontend/src/app/admin/categories/page.tsx
+++ b/frontend/src/app/admin/categories/page.tsx
@@ -199,7 +199,7 @@ function AdminCategoriesContent() {
             <thead className="bg-gray-50">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Icon
+                  Εικόνα
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Όνομα
@@ -315,7 +315,7 @@ function AdminCategoriesContent() {
                 {/* Icon Field */}
                 <div>
                   <label htmlFor="edit-icon" className="block text-sm font-medium text-gray-700 mb-1">
-                    Icon (Emoji)
+                    Εικόνα (Emoji)
                   </label>
                   <input
                     id="edit-icon"

--- a/frontend/src/app/admin/components/AdminSidebar.tsx
+++ b/frontend/src/app/admin/components/AdminSidebar.tsx
@@ -11,14 +11,14 @@ interface NavItem {
 }
 
 const NAV_ITEMS: NavItem[] = [
-  { href: '/admin', label: 'Dashboard', icon: '📊' },
+  { href: '/admin', label: 'Πίνακας Ελέγχου', icon: '📊' },
   { href: '/admin/orders', label: 'Παραγγελίες', icon: '📦' },
   { href: '/admin/products', label: 'Προϊόντα', icon: '🏷️' },
-  { href: '/admin/products/moderation', label: 'Moderation', icon: '🛡️' },
+  { href: '/admin/products/moderation', label: 'Έγκριση', icon: '🛡️' },
   { href: '/admin/producers', label: 'Παραγωγοί', icon: '🧑‍🌾' },
   { href: '/admin/producers/images', label: 'Εικόνες', icon: '🖼️' },
   { href: '/admin/categories', label: 'Κατηγορίες', icon: '📂' },
-  { href: '/admin/analytics', label: 'Analytics', icon: '📈' },
+  { href: '/admin/analytics', label: 'Αναλυτικά', icon: '📈' },
   { href: '/admin/customers', label: 'Πελάτες', icon: '🛒' },
   { href: '/admin/users', label: 'Διαχειριστές', icon: '👥' },
   { href: '/admin/settings', label: 'Ρυθμίσεις', icon: '⚙️' },

--- a/frontend/src/app/admin/orders/[id]/page.tsx
+++ b/frontend/src/app/admin/orders/[id]/page.tsx
@@ -46,7 +46,7 @@ export default function AdminOrderDetail({
 
   return (
     <main style={{ maxWidth: 960, margin: '40px auto', padding: 16 }}>
-      <h2 style={{ margin: 0 }}>Admin · Order Detail</h2>
+      <h2 style={{ margin: 0 }}>Διαχείριση · Παραγγελία</h2>
       <p style={{ color: '#6b7280', marginTop: 6 }}>
         Πλήρης σύνοψη παραγγελίας.
       </p>
@@ -71,13 +71,13 @@ export default function AdminOrderDetail({
           )}
 
           <div className="mb-2">
-            Order No:{' '}
+            Αρ. Παραγγελίας:{' '}
             <strong data-testid="detail-order-no">
               {orderNumber(data.id, data.createdAt)}
             </strong>
           </div>
           <div className="mb-2">
-            Order ID:{' '}
+            ID Παραγγελίας:{' '}
             <strong data-testid="detail-order-id">{data.id}</strong>
           </div>
           <div className="mb-2">
@@ -86,7 +86,7 @@ export default function AdminOrderDetail({
               className="text-blue-600 underline text-xs"
               data-testid="customer-view-link"
             >
-              Customer view →
+              Προβολή πελάτη →
             </a>
           </div>
           <table className="text-sm">
@@ -108,7 +108,7 @@ export default function AdminOrderDetail({
                 <td>{data.weightGrams ?? '-'}</td>
               </tr>
               <tr>
-                <td className="pr-4">Subtotal</td>
+                <td className="pr-4">Υποσύνολο</td>
                 <td>{String(data.subtotal ?? '-')}</td>
               </tr>
               <tr>
@@ -136,7 +136,7 @@ export default function AdminOrderDetail({
                 </tr>
               )}
               <tr>
-                <td className="pr-4">Payment</td>
+                <td className="pr-4">Πληρωμή</td>
                 <td>
                   {data.paymentStatus ?? 'PAID'}{' '}
                   {data.paymentRef ? `(${data.paymentRef})` : ''}
@@ -160,7 +160,7 @@ export default function AdminOrderDetail({
                 }
               }}
               className="border px-3 py-1 rounded"
-            >Resend receipt</button>
+            >Επαναποστολή απόδειξης</button>
           </div>
           <div className="mt-4">
             <a href="/admin/orders" className="underline">

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -86,8 +86,8 @@ export default async function Page() {
       <section className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <KpiCard label="Παραγγελίες (7ημ)" value={String(orders7Count)} />
         <KpiCard label="Έσοδα (7ημ)" value={fmtMoney(revenue7)} />
-        <KpiCard label="Pending" value={String(pendingCount)} accent={pendingCount > 0} />
-        <KpiCard label={`Low stock (\u2264 ${thr()})`} value={String(lowStockCount)} accent={lowStockCount > 0} />
+        <KpiCard label="Εκκρεμείς" value={String(pendingCount)} accent={pendingCount > 0} />
+        <KpiCard label={`Χαμηλό απόθεμα (\u2264 ${thr()})`} value={String(lowStockCount)} accent={lowStockCount > 0} />
       </section>
 
       {/* Quick Actions */}
@@ -100,7 +100,7 @@ export default async function Page() {
           <QuickAction href="/admin/products" icon="🏷️" label="Προϊόντα" />
           <QuickAction href="/admin/producers" icon="🧑‍🌾" label="Παραγωγοί" />
           <QuickAction href="/admin/categories" icon="📂" label="Κατηγορίες" />
-          <QuickAction href="/admin/analytics" icon="📈" label="Analytics" />
+          <QuickAction href="/admin/analytics" icon="📈" label="Αναλυτικά" />
         </div>
       </section>
 
@@ -120,7 +120,7 @@ export default async function Page() {
                 <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">Ημ/νία</th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">Πελάτης</th>
                 <th className="px-4 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">Σύνολο</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">Κατάσταση</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-neutral-100">
@@ -224,11 +224,18 @@ function StatusBadge({ status }: { status: string }) {
     DELIVERED: 'bg-emerald-100 text-emerald-800',
     CANCELLED: 'bg-red-100 text-red-800',
   };
+  const labels: Record<string, string> = {
+    PENDING: 'Εκκρεμής',
+    CONFIRMED: 'Επιβεβαιωμένη',
+    SHIPPED: 'Απεσταλμένη',
+    DELIVERED: 'Παραδοθείσα',
+    CANCELLED: 'Ακυρωθείσα',
+  };
   const cls = colors[status] || 'bg-neutral-100 text-neutral-700';
 
   return (
     <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold ${cls}`}>
-      {status}
+      {labels[status] || status}
     </span>
   );
 }

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -120,7 +120,7 @@ function RoleBadge({ role }: { role: string }) {
         color: isSuperAdmin ? '#92400e' : '#1e40af',
       }}
     >
-      {isSuperAdmin ? 'Super Admin' : 'Admin'}
+      {isSuperAdmin ? 'Υπερδιαχειριστής' : 'Διαχειριστής'}
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- Μετάφραση ~30 αγγλικών strings σε 6 αρχεία admin panel
- Μηδέν αλλαγές σε logic — μόνο UI labels

## Αλλαγές ανά αρχείο

| Αρχείο | Αλλαγές |
|--------|---------|
| AdminSidebar.tsx | Dashboard→Πίνακας Ελέγχου, Moderation→Έγκριση, Analytics→Αναλυτικά |
| admin/page.tsx | Status badges (PENDING→Εκκρεμής κλπ), KPI labels, table headers |
| orders/[id]/page.tsx | Heading, Subtotal→Υποσύνολο, Payment→Πληρωμή, Resend receipt |
| categories/page.tsx | Icon→Εικόνα |
| analytics/AnalyticsContent.tsx | Full page: breadcrumbs, heading, info box |
| users/page.tsx | Super Admin→Υπερδιαχειριστής |

## Test plan
- [ ] CI passes (typecheck + build)
- [ ] Admin sidebar shows Greek labels
- [ ] Dashboard status badges show Greek text
- [ ] Order detail page fully Greek
- [ ] Analytics page fully Greek