### PR TITLE
fix(admin): cleanup duplicate code, fix deprecated endpoint, add confirm dialog

### DIFF
--- a/frontend/src/app/admin/products/moderation/page.tsx
+++ b/frontend/src/app/admin/products/moderation/page.tsx
@@ -156,7 +156,7 @@ export default function ModerationQueuePage() {
                     ) : (
                       <div className="flex items-center justify-center gap-2">
                         <button
-                          onClick={() => handleApprove(p.id)}
+                          onClick={() => { if (window.confirm(`Έγκριση του "${p.title}";`)) handleApprove(p.id); }}
                           className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white text-sm rounded-md font-medium transition-colors"
                           data-testid={`approve-btn-${p.id}`}
                         >


### PR DESCRIPTION
## Summary

Admin code quality fixes discovered during page-by-page admin audit:

- **Remove duplicate SkeletonRow** — component was accidentally defined twice in `AdminOrdersMain.tsx` (lines 281-285 nested inside `go()` function body, and lines 299-303 at correct scope). Removed the misplaced first definition.
- **Fix deprecated API endpoint** — switched from `/api/v1/admin/orders` (direct Laravel) to `/api/admin/orders` (Next.js proxy route that handles cookie-based auth properly). Response parsing now handles both proxy format (`{items, count}`) and Laravel format (`{orders, meta}`).
- **Add approval confirmation** — product approval in moderation queue now shows `window.confirm()` dialog before executing. Rejection already had a modal with reason input.

## Test plan

- [ ] CI passes (typecheck, build, e2e)
- [ ] `/admin/orders` loads order list without errors
- [ ] `/admin/products/moderation` shows confirm dialog when clicking Approve
- [ ] PR ≤ 300 LOC (actual: 19 insertions, 17 deletions)