### PR TITLE
fix(i18n): translate producer analytics to Greek

### DIFF
--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -47,7 +47,7 @@ See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 
 ## Recently Done (last 10)
 
-- **ADMIN-CLEANUP-01** — Remove duplicate SkeletonRow, fix deprecated API endpoint, add approve confirm, i18n sweep (PRs #2695-#2696, deployed 2026-02-09) ✅
+- **ADMIN-CLEANUP-01** — Admin code cleanup + complete i18n (PRs #2694-#2698, deployed 2026-02-09) ✅
 - **QA-FULL-E2E-01** — Full QA pass + bug fixes + deploy hardening (PRs #2686-#2689, deployed 2026-02-09) ✅
 - **ADMIN-EMAIL-OTP-01** — Admin login via email OTP (PRs #2665-2667, deployed 2026-02-06) ✅
 - **ADMIN-SHIPPING-UI-01** — Shipping labels UI wired to admin (PR #2662, deployed 2026-02-06) ✅

--- a/docs/AGENT/PASSES/SUMMARY-Pass-ADMIN-CLEANUP-01.md
+++ b/docs/AGENT/PASSES/SUMMARY-Pass-ADMIN-CLEANUP-01.md
@@ -1,0 +1,59 @@
+# Pass ADMIN-CLEANUP-01 — Admin Code Cleanup + i18n Completion
+
+**Date**: 2026-02-09
+**Status**: ✅ DONE
+**PRs**: #2694, #2695, #2696, #2698
+
+---
+
+## What was done
+
+### PR #2694 — Deploy infrastructure
+- Created `frontend/ecosystem.config.js` (PM2 config committed to repo)
+- Fixed `scripts/prod-deploy-clean.sh` PM2 restart path
+- Committed QA report and updated AGENT-STATE.md
+
+### PR #2695 — Admin i18n sweep (6 files)
+- Translated ~30 English strings across AdminSidebar, admin/page, orders/[id]/page, categories/page, AnalyticsContent, users/page
+- Added Greek `labels` map to StatusBadge component
+
+### PR #2696 — Admin code cleanup (3 fixes)
+- Removed duplicate SkeletonRow in AdminOrdersMain (was nested inside `go()`)
+- Switched from deprecated `/api/v1/admin/orders` to `/api/admin/orders` (Next.js proxy)
+- Added `window.confirm()` dialog before product approval in moderation
+
+### PR #2698 — AnalyticsDashboard i18n
+- Translated 25+ English strings in AnalyticsDashboard.tsx (chart titles, KPIs, table headers, error messages)
+- Removed unused `Link` import from admin/customers/page.tsx
+
+---
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| Production healthz | ✅ SHA `4f4eb217`, status ok |
+| Admin i18n (11 files scanned) | ✅ 11/11 PASS — zero English user-facing strings |
+| Deprecated `/api/v1/admin/orders` | ✅ 0 occurrences in codebase |
+| SkeletonRow duplicate | ✅ Only 1 definition (line 301) |
+| Approve confirm dialog | ✅ Present (moderation/page.tsx line 159) |
+| CI | ✅ All checks pass on all 4 PRs |
+
+---
+
+## Files changed
+
+| PR | Files | Insertions | Deletions |
+|----|-------|-----------|-----------|
+| #2694 | 3 | ~45 | ~5 |
+| #2695 | 6 | ~40 | ~30 |
+| #2696 | 2 | 19 | 17 |
+| #2698 | 3 | 33 | 33 |
+
+---
+
+## Remaining (low priority)
+
+- Error handling gaps in `products/page.tsx` (silent loadProducts/loadProducers failures)
+- Missing pagination on customers/users pages
+- localStorage auth token fallback in AdminOrdersMain (works but could be cookies-only)

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,11 +1,28 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-06 (SSOT-AUDIT-01)
+**Last Updated**: 2026-02-09 (ADMIN-CLEANUP-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~460 lines (target ≤350). ⚠️ Over limit — archive next pass.
 >
 > **Key Docs**: [DEPLOY SOP](DEPLOY.md) | [STATE Archive](STATE-ARCHIVE/)
+
+---
+
+## 2026-02-09 — ADMIN-CLEANUP-01: Admin Code Cleanup + i18n Completion
+
+**Status**: ✅ DONE (4 PRs: #2694, #2695, #2696, #2698)
+
+**What was done**:
+- Complete admin i18n: All 11 admin files verified 100% Greek
+- Deploy infra: `ecosystem.config.js` committed, PM2 path fixed
+- Code cleanup: duplicate SkeletonRow removed, deprecated API endpoint fixed
+- UX: `window.confirm()` added for product approval in moderation
+- AnalyticsDashboard: 25+ English strings translated to Greek
+
+**Production**: SHA `4f4eb217`, deployed 21:23 UTC, healthz 200
+
+**Pass summary**: `docs/AGENT/PASSES/SUMMARY-Pass-ADMIN-CLEANUP-01.md`
 
 ---
 

--- a/frontend/src/app/producer/analytics/page.tsx
+++ b/frontend/src/app/producer/analytics/page.tsx
@@ -27,7 +27,7 @@ export default function ProducerAnalytics() {
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600">Loading...</p>
+          <p className="mt-4 text-gray-600">Φόρτωση...</p>
         </div>
       </div>
     );
@@ -44,24 +44,24 @@ export default function ProducerAnalytics() {
         <nav className="flex mb-8" data-testid="breadcrumb">
           <ol className="flex items-center space-x-2 text-sm text-gray-500">
             <li>
-              <Link href="/" className="hover:text-green-600">Home</Link>
+              <Link href="/" className="hover:text-green-600">Αρχική</Link>
             </li>
             <li>/</li>
             <li>
-              <Link href="/producer/dashboard" className="hover:text-green-600">Producer Dashboard</Link>
+              <Link href="/producer/dashboard" className="hover:text-green-600">Πίνακας Παραγωγού</Link>
             </li>
             <li>/</li>
-            <li className="text-gray-900">Analytics</li>
+            <li className="text-gray-900">Αναλυτικά</li>
           </ol>
         </nav>
 
         {/* Page Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            Producer Analytics
+            Αναλυτικά Παραγωγού
           </h1>
           <p className="text-gray-600">
-            Monitor your products&apos; performance and sales analytics
+            Παρακολουθήστε την απόδοση των προϊόντων και τα αναλυτικά πωλήσεων
           </p>
         </div>
 
@@ -78,18 +78,18 @@ export default function ProducerAnalytics() {
             </div>
             <div className="ml-3">
               <h3 className="text-sm font-medium text-blue-800">
-                Producer Analytics Information
+                Πληροφορίες Αναλυτικών Παραγωγού
               </h3>
               <div className="mt-2 text-sm text-blue-700">
                 <p>
-                  This dashboard displays analytics data specific to your products and orders.
-                  Track your sales performance, order trends, and product popularity over time.
+                  Αυτός ο πίνακας εμφανίζει αναλυτικά δεδομένα για τα προϊόντα και τις παραγγελίες σας.
+                  Παρακολουθήστε πωλήσεις, τάσεις παραγγελιών και δημοτικότητα προϊόντων.
                 </p>
                 <ul className="mt-2 list-disc list-inside space-y-1">
-                  <li>Data shows only orders containing your products</li>
-                  <li>Sales analytics reflect revenue from your product sales</li>
-                  <li>Order analytics include all orders with your products</li>
-                  <li>Product rankings are based on your portfolio performance</li>
+                  <li>Τα δεδομένα αφορούν μόνο παραγγελίες που περιέχουν τα προϊόντα σας</li>
+                  <li>Τα αναλυτικά πωλήσεων αντικατοπτρίζουν τα έσοδα από τα προϊόντα σας</li>
+                  <li>Τα αναλυτικά παραγγελιών περιλαμβάνουν όλες τις παραγγελίες με τα προϊόντα σας</li>
+                  <li>Η κατάταξη προϊόντων βασίζεται στην απόδοση του χαρτοφυλακίου σας</li>
                 </ul>
               </div>
             </div>

--- a/frontend/src/components/producer/ProducerAnalyticsDashboard.tsx
+++ b/frontend/src/components/producer/ProducerAnalyticsDashboard.tsx
@@ -86,14 +86,14 @@ export default function ProducerAnalyticsDashboard() {
     labels: data.sales.data.map(item => item.date),
     datasets: [
       {
-        label: 'Sales (€)',
+        label: 'Πωλήσεις (€)',
         data: data.sales.data.map(item => item.total_sales),
         borderColor: 'rgb(34, 197, 94)',
         backgroundColor: 'rgba(34, 197, 94, 0.1)',
         tension: 0.1,
       },
       {
-        label: 'Orders',
+        label: 'Παραγγελίες',
         data: data.sales.data.map(item => item.order_count),
         borderColor: 'rgb(59, 130, 246)',
         backgroundColor: 'rgba(59, 130, 246, 0.1)',
@@ -114,7 +114,7 @@ export default function ProducerAnalyticsDashboard() {
       },
       title: {
         display: true,
-        text: `Your Product Sales (${period === 'daily' ? 'Daily' : 'Monthly'})`,
+        text: `Πωλήσεις Προϊόντων (${period === 'daily' ? 'Ημερήσιες' : 'Μηνιαίες'})`,
       },
     },
     scales: {
@@ -124,7 +124,7 @@ export default function ProducerAnalyticsDashboard() {
         position: 'left' as const,
         title: {
           display: true,
-          text: 'Sales (€)',
+          text: 'Πωλήσεις (€)',
         },
       },
       y1: {
@@ -133,7 +133,7 @@ export default function ProducerAnalyticsDashboard() {
         position: 'right' as const,
         title: {
           display: true,
-          text: 'Orders',
+          text: 'Παραγγελίες',
         },
         grid: {
           drawOnChartArea: false,
@@ -162,7 +162,7 @@ export default function ProducerAnalyticsDashboard() {
       },
       title: {
         display: true,
-        text: 'Orders with Your Products by Status',
+        text: 'Παραγγελίες ανά Κατάσταση',
       },
     },
   };
@@ -171,7 +171,7 @@ export default function ProducerAnalyticsDashboard() {
     labels: data.products.top_products.map(product => product.name),
     datasets: [
       {
-        label: 'Revenue (€)',
+        label: 'Έσοδα (€)',
         data: data.products.top_products.map(product => product.total_revenue),
         backgroundColor: 'rgba(168, 85, 247, 0.8)',
         borderColor: 'rgb(168, 85, 247)',
@@ -188,7 +188,7 @@ export default function ProducerAnalyticsDashboard() {
       },
       title: {
         display: true,
-        text: 'Your Top Products by Revenue',
+        text: 'Κορυφαία Προϊόντα ανά Έσοδα',
       },
     },
     scales: {
@@ -196,7 +196,7 @@ export default function ProducerAnalyticsDashboard() {
         beginAtZero: true,
         title: {
           display: true,
-          text: 'Revenue (€)',
+          text: 'Έσοδα (€)',
         },
       },
     },
@@ -232,14 +232,14 @@ export default function ProducerAnalyticsDashboard() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             <div>
-              <h3 className="text-red-800 font-medium">Error Loading Analytics</h3>
+              <h3 className="text-red-800 font-medium">Σφάλμα Φόρτωσης Αναλυτικών</h3>
               <p className="text-red-700 text-sm mt-1">{error}</p>
               <button
                 onClick={loadProducerAnalytics}
                 className="mt-3 text-sm bg-red-100 hover:bg-red-200 text-red-800 px-3 py-1 rounded"
                 data-testid="retry-button"
               >
-                Retry
+                Επανάληψη
               </button>
             </div>
           </div>
@@ -254,8 +254,8 @@ export default function ProducerAnalyticsDashboard() {
       <div className="bg-white rounded-lg shadow-md p-6">
         <div className="flex justify-between items-center mb-4">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900 mb-2">📊 Your Product Analytics</h1>
-            <p className="text-gray-600">Monitor your sales performance and product analytics</p>
+            <h1 className="text-2xl font-bold text-gray-900 mb-2">📊 Αναλυτικά Προϊόντων</h1>
+            <p className="text-gray-600">Παρακολουθήστε πωλήσεις και αναλυτικά προϊόντων</p>
           </div>
           <div className="flex space-x-2" data-testid="period-toggle">
             <button
@@ -267,7 +267,7 @@ export default function ProducerAnalyticsDashboard() {
               }`}
               data-testid="daily-button"
             >
-              Daily
+              Ημερήσια
             </button>
             <button
               onClick={() => setPeriod('monthly')}
@@ -278,7 +278,7 @@ export default function ProducerAnalyticsDashboard() {
               }`}
               data-testid="monthly-button"
             >
-              Monthly
+              Μηνιαία
             </button>
           </div>
         </div>
@@ -290,19 +290,19 @@ export default function ProducerAnalyticsDashboard() {
               <div className="text-2xl font-bold text-green-600">
                 {formatCurrency(data.sales.summary.total_revenue)}
               </div>
-              <div className="text-sm text-gray-600">Total Revenue ({period})</div>
+              <div className="text-sm text-gray-600">Συνολικά Έσοδα ({period === 'daily' ? 'ημερήσια' : 'μηνιαία'})</div>
             </div>
             <div className="bg-blue-50 border border-blue-200 rounded-lg p-4" data-testid="kpi-total-orders">
               <div className="text-2xl font-bold text-blue-600">
                 {data.sales.summary.total_orders}
               </div>
-              <div className="text-sm text-gray-600">Orders with Your Products</div>
+              <div className="text-sm text-gray-600">Παραγγελίες Προϊόντων</div>
             </div>
             <div className="bg-purple-50 border border-purple-200 rounded-lg p-4" data-testid="kpi-growth">
               <div className="text-2xl font-bold text-purple-600">
                 {formatPercentage(data.sales.summary.period_growth)}
               </div>
-              <div className="text-sm text-gray-600">Sales Growth</div>
+              <div className="text-sm text-gray-600">Ανάπτυξη Πωλήσεων</div>
             </div>
           </div>
         )}
@@ -341,25 +341,25 @@ export default function ProducerAnalyticsDashboard() {
       {/* Product Performance Table */}
       {data.products && (
         <div className="bg-white rounded-lg shadow-md p-6">
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">Your Product Performance</h2>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">Απόδοση Προϊόντων</h2>
           <div className="overflow-x-auto" data-testid="producer-products-table">
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Product
+                    Προϊόν
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Price
+                    Τιμή
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Quantity Sold
+                    Πωλ. Ποσότητα
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Revenue
+                    Έσοδα
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Orders
+                    Παραγγελίες
                   </th>
                 </tr>
               </thead>
@@ -392,25 +392,25 @@ export default function ProducerAnalyticsDashboard() {
       {/* Product Summary Stats */}
       {data.products && (
         <div className="bg-white rounded-lg shadow-md p-6">
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">Product Portfolio Overview</h2>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">Επισκόπηση Χαρτοφυλακίου Προϊόντων</h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4" data-testid="producer-product-stats">
             <div className="text-center">
               <div className="text-2xl font-bold text-gray-900">{data.products.summary.total_products}</div>
-              <div className="text-sm text-gray-600">Total Products</div>
+              <div className="text-sm text-gray-600">Συνολικά Προϊόντα</div>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-green-600">{data.products.summary.active_products}</div>
-              <div className="text-sm text-gray-600">Active Products</div>
+              <div className="text-sm text-gray-600">Ενεργά Προϊόντα</div>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-red-600">{data.products.summary.out_of_stock}</div>
-              <div className="text-sm text-gray-600">Out of Stock</div>
+              <div className="text-sm text-gray-600">Εξαντλημένα</div>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-purple-600">
-                {data.products.summary.best_seller_name || 'N/A'}
+                {data.products.summary.best_seller_name || 'Δ/Υ'}
               </div>
-              <div className="text-sm text-gray-600">Best Seller</div>
+              <div className="text-sm text-gray-600">Δημοφιλέστερο</div>
             </div>
           </div>
         </div>

--- a/frontend/src/lib/api/producer-analytics.ts
+++ b/frontend/src/lib/api/producer-analytics.ts
@@ -31,7 +31,7 @@ export const producerAnalyticsApi = {
   async getSales(period: 'daily' | 'monthly' = 'daily', limit = 30): Promise<ProducerSalesAnalytics> {
     const token = localStorage.getItem('token');
     if (!token) {
-      throw new Error('No authentication token found');
+      throw new Error('Δεν βρέθηκε token πιστοποίησης');
     }
 
     const params = new URLSearchParams({
@@ -49,7 +49,7 @@ export const producerAnalyticsApi = {
 
     if (!response.ok) {
       if (response.status === 403) {
-        throw new Error('Producer access required. Please ensure you are associated with a producer.');
+        throw new Error('Απαιτείται πρόσβαση παραγωγού. Βεβαιωθείτε ότι είστε συνδεδεμένος παραγωγός.');
       }
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -64,7 +64,7 @@ export const producerAnalyticsApi = {
   async getOrders(): Promise<ProducerOrdersAnalytics> {
     const token = localStorage.getItem('token');
     if (!token) {
-      throw new Error('No authentication token found');
+      throw new Error('Δεν βρέθηκε token πιστοποίησης');
     }
 
     const response = await fetch(`${API_BASE_URL}/producer/analytics/orders`, {
@@ -77,7 +77,7 @@ export const producerAnalyticsApi = {
 
     if (!response.ok) {
       if (response.status === 403) {
-        throw new Error('Producer access required. Please ensure you are associated with a producer.');
+        throw new Error('Απαιτείται πρόσβαση παραγωγού. Βεβαιωθείτε ότι είστε συνδεδεμένος παραγωγός.');
       }
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -92,7 +92,7 @@ export const producerAnalyticsApi = {
   async getProducts(limit = 10): Promise<ProducerProductsAnalytics> {
     const token = localStorage.getItem('token');
     if (!token) {
-      throw new Error('No authentication token found');
+      throw new Error('Δεν βρέθηκε token πιστοποίησης');
     }
 
     const params = new URLSearchParams({
@@ -109,7 +109,7 @@ export const producerAnalyticsApi = {
 
     if (!response.ok) {
       if (response.status === 403) {
-        throw new Error('Producer access required. Please ensure you are associated with a producer.');
+        throw new Error('Απαιτείται πρόσβαση παραγωγού. Βεβαιωθείτε ότι είστε συνδεδεμένος παραγωγός.');
       }
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -133,17 +133,17 @@ export function checkProducerAccess(): boolean {
  * Helper to handle producer-specific errors
  */
 export function handleProducerError(error: Error): string {
-  if (error.message.includes('Producer access required')) {
-    return 'You need to be associated with a producer to view analytics. Please contact support if you believe this is an error.';
+  if (error.message.includes('πρόσβαση παραγωγού')) {
+    return 'Πρέπει να είστε συνδεδεμένος παραγωγός για προβολή αναλυτικών. Επικοινωνήστε με την υποστήριξη αν πιστεύετε ότι πρόκειται για σφάλμα.';
   }
-  if (error.message.includes('No authentication token')) {
-    return 'Please log in to view your producer analytics.';
+  if (error.message.includes('token πιστοποίησης')) {
+    return 'Συνδεθείτε για προβολή αναλυτικών παραγωγού.';
   }
   if (error.message.includes('HTTP error! status: 401')) {
-    return 'Your session has expired. Please log in again.';
+    return 'Η συνεδρία σας έληξε. Συνδεθείτε ξανά.';
   }
   if (error.message.includes('HTTP error! status: 403')) {
-    return 'You do not have permission to view producer analytics.';
+    return 'Δεν έχετε δικαίωμα προβολής αναλυτικών παραγωγού.';
   }
-  return 'Failed to load analytics data. Please try again.';
+  return 'Αποτυχία φόρτωσης αναλυτικών. Δοκιμάστε ξανά.';
 }


### PR DESCRIPTION
## Summary
- Translate ~60 English user-facing strings in producer analytics to Greek
- Producer analytics page: breadcrumbs, headers, info text
- ProducerAnalyticsDashboard: chart labels/titles, KPIs, table headers, buttons, error messages
- producer-analytics.ts: error messages in `handleProducerError()` + throw statements
- Also includes ADMIN-CLEANUP-01 pass documentation

## Files changed (6)
- `frontend/src/app/producer/analytics/page.tsx` — breadcrumbs, headers, info box
- `frontend/src/components/producer/ProducerAnalyticsDashboard.tsx` — charts, KPIs, tables, stats
- `frontend/src/lib/api/producer-analytics.ts` — error messages
- `docs/AGENT-STATE.md` — updated pass history
- `docs/OPS/STATE.md` — added pass entry
- `docs/AGENT/PASSES/SUMMARY-Pass-ADMIN-CLEANUP-01.md` — pass documentation

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [ ] CI checks pass (typecheck, build, e2e, smoke)
- [ ] No English user-facing strings in changed files (HTML comments excluded)
- [ ] PR ≤ 300 LOC (~133 LOC)