### PR TITLE
feat: restore public producers listing page with SSR + Prisma

### DIFF
--- a/frontend/src/app/api/public/producers/route.ts
+++ b/frontend/src/app/api/public/producers/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Public Producers Listing API
+ * Returns approved, active producers for the public /producers page.
+ * Pattern follows api/public/products/route.ts
+ */
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const q = searchParams.get('q')?.trim() || searchParams.get('search')?.trim() || ''
+
+    const where: Record<string, unknown> = {
+      isActive: true,
+      approvalStatus: 'approved',
+    }
+    if (q) {
+      where.name = { contains: q }
+    }
+
+    const items = await prisma.producer.findMany({
+      where,
+      orderBy: { name: 'asc' },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        region: true,
+        category: true,
+        description: true,
+        imageUrl: true,
+        products: true,
+      },
+    })
+
+    const data = items.map((p) => ({
+      id: p.id,
+      slug: p.slug,
+      name: p.name,
+      region: p.region,
+      category: p.category,
+      description: p.description,
+      image_url: p.imageUrl,
+      products_count: p.products,
+    }))
+
+    return NextResponse.json(
+      { ok: true, count: data.length, data },
+      { headers: { 'cache-control': 'no-store' } }
+    )
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : 'unknown error'
+    console.error('[API] public/producers error:', message)
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}

--- a/frontend/src/app/producers/join/page.tsx
+++ b/frontend/src/app/producers/join/page.tsx
@@ -1,0 +1,21 @@
+export const metadata = { title: 'Για Παραγωγούς | Dixis' };
+
+export default function ProducersLanding(){
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold">Γίνε μέλος του Dixis</h1>
+      <p className="text-neutral-600 mt-2 max-w-2xl">
+        Φέρνουμε τους τοπικούς παραγωγούς πιο κοντά σε καταναλωτές & επιχειρήσεις. Χωρίς αποθήκες — απευθείας από εσένα.
+      </p>
+      <ul className="mt-6 grid sm:grid-cols-2 gap-3 text-sm">
+        <li className="border rounded-md p-3 bg-white">✔ Κατάλογος προϊόντων & παραγγελίες</li>
+        <li className="border rounded-md p-3 bg-white">✔ Υποστήριξη πιστοποιήσεων & συμμόρφωσης</li>
+        <li className="border rounded-md p-3 bg-white">✔ Δίκαιη προμήθεια, διαφανείς όροι</li>
+        <li className="border rounded-md p-3 bg-white">✔ Προώθηση & SEO για τα προϊόντα σου</li>
+      </ul>
+      <a href="/producers/waitlist" className="inline-flex h-10 px-4 rounded-md bg-brand text-white text-sm mt-6 items-center">
+        Εκδήλωση ενδιαφέροντος →
+      </a>
+    </main>
+  );
+}

--- a/frontend/src/app/producers/page.tsx
+++ b/frontend/src/app/producers/page.tsx
@@ -1,21 +1,142 @@
-export const metadata = { title: 'Για Παραγωγούς | Dixis' };
+import { Suspense } from 'react';
+import Link from 'next/link';
+import { ProducerCard } from '@/components/ProducerCard';
+import { getServerApiUrl } from '@/env';
 
-export default function ProducersLanding(){
+export const metadata = { title: 'Παραγωγοί | Dixis' };
+
+type ApiProducer = {
+  id: string | number;
+  slug: string;
+  name: string;
+  region: string;
+  category: string;
+  description?: string | null;
+  image_url?: string | null;
+  products_count: number;
+};
+
+/**
+ * Fetch approved producers from Next.js API route (Prisma → Neon DB).
+ * Pattern follows (storefront)/products/page.tsx.
+ */
+async function getData(search?: string): Promise<{ items: ApiProducer[]; total: number }> {
+  const isServer = typeof window === 'undefined';
+  const base = isServer
+    ? getServerApiUrl()
+    : (process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1');
+
+  try {
+    const qs = search?.trim() ? `?search=${encodeURIComponent(search.trim())}` : '';
+    const res = await fetch(`${base}/public/producers${qs}`, {
+      next: { revalidate: 60 },
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (!res.ok) {
+      console.error('[Producers] API fetch failed:', res.status);
+      return { items: [], total: 0 };
+    }
+
+    const json = await res.json();
+    const items: ApiProducer[] = json?.data ?? [];
+    return { items, total: items.length };
+  } catch (err) {
+    console.error('[Producers] Fetch error:', err);
+    return { items: [], total: 0 };
+  }
+}
+
+interface PageProps {
+  searchParams: Promise<{ search?: string }>;
+}
+
+export default async function ProducersPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const searchQuery = params.search || null;
+  const { items, total } = await getData(searchQuery || undefined);
+
+  const getEmptyMessage = () => {
+    if (searchQuery) {
+      return `Δεν βρέθηκαν παραγωγοί για "${searchQuery}".`;
+    }
+    return 'Δεν υπάρχουν παραγωγοί αυτή τη στιγμή.';
+  };
+
   return (
-    <main className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold">Γίνε μέλος του Dixis</h1>
-      <p className="text-neutral-600 mt-2 max-w-2xl">
-        Φέρνουμε τους τοπικούς παραγωγούς πιο κοντά σε καταναλωτές & επιχειρήσεις. Χωρίς αποθήκες — απευθείας από εσένα.
-      </p>
-      <ul className="mt-6 grid sm:grid-cols-2 gap-3 text-sm">
-        <li className="border rounded-md p-3 bg-white">✔ Κατάλογος προϊόντων & παραγγελίες</li>
-        <li className="border rounded-md p-3 bg-white">✔ Υποστήριξη πιστοποιήσεων & συμμόρφωσης</li>
-        <li className="border rounded-md p-3 bg-white">✔ Δίκαιη προμήθεια, διαφανείς όροι</li>
-        <li className="border rounded-md p-3 bg-white">✔ Προώθηση & SEO για τα προϊόντα σου</li>
-      </ul>
-      <a href="/producers/waitlist" className="inline-flex h-10 px-4 rounded-md bg-brand text-white text-sm mt-6 items-center">
-        Εκδήλωση ενδιαφέροντος →
-      </a>
+    <main className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6 gap-4">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Παραγωγοί</h1>
+            <p className="mt-1 text-sm text-gray-600">
+              {searchQuery
+                ? `${total} αποτέλεσμα${total !== 1 ? 'τα' : ''} για "${searchQuery}"`
+                : `Γνώρισε τους τοπικούς παραγωγούς μας — ${total} συνολικά.`}
+            </p>
+          </div>
+
+          {/* Search Form */}
+          <Suspense fallback={<div className="h-10 w-full max-w-md bg-gray-100 rounded-lg animate-pulse" />}>
+            <ProducerSearchForm defaultValue={searchQuery || ''} />
+          </Suspense>
+        </div>
+
+        {/* CTA banner */}
+        <div className="mb-6 p-3 bg-green-50 border border-green-200 rounded-lg text-green-800 text-sm flex items-center justify-between">
+          <span>Είσαι παραγωγός; Γίνε μέλος του Dixis!</span>
+          <Link href="/producers/join" className="font-medium underline hover:text-green-900">
+            Μάθε περισσότερα →
+          </Link>
+        </div>
+
+        {items.length > 0 ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+            {items.map((p) => (
+              <ProducerCard
+                key={p.id}
+                id={p.id}
+                slug={p.slug}
+                name={p.name}
+                region={p.region}
+                category={p.category}
+                description={p.description}
+                imageUrl={p.image_url}
+                productsCount={p.products_count}
+              />
+            ))}
+          </div>
+        ) : (
+          <div
+            className="text-center py-20 bg-white rounded-xl border border-dashed border-gray-300"
+            data-testid="no-results"
+          >
+            <p className="text-gray-500 text-lg">{getEmptyMessage()}</p>
+          </div>
+        )}
+      </div>
     </main>
+  );
+}
+
+/**
+ * Simple server-rendered search form (no client JS needed for basic HTML form).
+ */
+function ProducerSearchForm({ defaultValue }: { defaultValue: string }) {
+  return (
+    <form action="/producers" method="GET" className="w-full max-w-md">
+      <div className="relative">
+        <input
+          name="search"
+          type="search"
+          defaultValue={defaultValue}
+          placeholder="Αναζήτηση παραγωγού..."
+          className="w-full h-10 pl-10 pr-4 rounded-lg border border-gray-300 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+        />
+        <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+      </div>
+    </form>
   );
 }

--- a/frontend/src/components/ProducerCard.tsx
+++ b/frontend/src/components/ProducerCard.tsx
@@ -1,0 +1,72 @@
+'use client'
+import Link from 'next/link'
+
+type Props = {
+  id: string | number
+  slug: string
+  name: string
+  region: string
+  category: string
+  description?: string | null
+  imageUrl?: string | null
+  productsCount: number
+}
+
+export function ProducerCard({ id, slug, name, region, category, description, imageUrl, productsCount }: Props) {
+  const hasImage = imageUrl && imageUrl.length > 0
+  const href = `/producers/${slug || id}`
+
+  return (
+    <Link
+      href={href}
+      data-testid="producer-card"
+      className="group flex flex-col h-full bg-white border border-neutral-200 rounded-xl overflow-hidden hover:shadow-card-hover hover:border-primary/20 transition-all duration-300"
+    >
+      <div className="relative aspect-[4/3] w-full bg-neutral-100 overflow-hidden">
+        {hasImage ? (
+          <img
+            src={imageUrl}
+            alt={name}
+            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-gray-400">
+            <svg className="w-16 h-16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+            </svg>
+          </div>
+        )}
+      </div>
+
+      <div className="px-4 pt-4 pb-2 flex-grow flex flex-col">
+        <span className="text-xs font-semibold text-primary uppercase tracking-wider">
+          {category}
+        </span>
+        <h2 className="text-base font-bold text-gray-900 line-clamp-1 mt-1 leading-tight">
+          {name}
+        </h2>
+        <p className="text-xs text-gray-500 mt-1 flex items-center gap-1">
+          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          {region}
+        </p>
+        {description && (
+          <p className="text-sm text-gray-600 mt-2 line-clamp-2">{description}</p>
+        )}
+      </div>
+
+      <div className="px-4 pb-4 mt-auto pt-2 border-t border-neutral-100 flex items-center justify-between">
+        <span className="text-sm text-gray-500">
+          {productsCount} {productsCount === 1 ? 'προϊόν' : 'προϊόντα'}
+        </span>
+        <span className="text-sm font-medium text-primary group-hover:underline">
+          Προφίλ →
+        </span>
+      </div>
+    </Link>
+  )
+}
+


### PR DESCRIPTION
## Summary

- **Restores** the public `/producers` page from static landing to functional SSR listing
- **New API route** `api/public/producers` queries Prisma directly (same pattern as `api/public/products`)
- **New ProducerCard** component following ProductCard design with image, region, category, products count
- **Search** via URL params (`?search=`), server-side, no client JS needed
- **Landing page preserved** at `/producers/join` (moved from `/producers`)

## Context

Commit `133f9bc7` (AG-UI-08) replaced the functional producers listing with a static "Γίνε μέλος" landing page. This PR restores a proper listing using the proven SSR + Prisma pattern from the products page.

## Files Changed (289 LOC)

| File | Change |
|------|--------|
| `api/public/producers/route.ts` | NEW — Prisma query for active+approved producers |
| `components/ProducerCard.tsx` | NEW — Card component with image fallback |
| `producers/page.tsx` | REWRITTEN — SSR listing with search |
| `producers/join/page.tsx` | NEW — Landing page moved here |

## Test plan

- [ ] `npx tsc --noEmit` passes ✅
- [ ] `npm run build` passes ✅
- [ ] CI pipeline passes (typecheck, build, e2e, smoke)
- [ ] `/producers` shows producer listing (or empty state if no approved producers)
- [ ] `/producers?search=query` filters by name
- [ ] `/producers/join` shows the original landing page
- [ ] Production deploy + healthz 200