### PR TITLE
docs: pass summaries for PRODUCER-I18N-01 + PRODUCERS-LISTING-01

### DIFF
--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -1,6 +1,6 @@
 # AGENT-STATE — Dixis Canonical Entry Point
 
-**Updated**: 2026-02-09 (ADMIN-CLEANUP-01 deployed)
+**Updated**: 2026-02-10 (PRODUCERS-LISTING-01 deployed)
 
 > **This is THE entry point.** Read this first on every agent session. Single source of truth.
 
@@ -47,6 +47,8 @@ See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 
 ## Recently Done (last 10)
 
+- **PRODUCERS-LISTING-01** — Restore public producers listing page with SSR + Prisma (PR #2701, deployed 2026-02-10) ✅
+- **PRODUCER-I18N-01** — Producer analytics dashboard translated to Greek (PR #2699, deployed 2026-02-10) ✅
 - **ADMIN-CLEANUP-01** — Admin code cleanup + complete i18n (PRs #2694-#2698, deployed 2026-02-09) ✅
 - **QA-FULL-E2E-01** — Full QA pass + bug fixes + deploy hardening (PRs #2686-#2689, deployed 2026-02-09) ✅
 - **ADMIN-EMAIL-OTP-01** — Admin login via email OTP (PRs #2665-2667, deployed 2026-02-06) ✅

--- a/docs/AGENT/PASSES/SUMMARY-Pass-PRODUCER-I18N-01.md
+++ b/docs/AGENT/PASSES/SUMMARY-Pass-PRODUCER-I18N-01.md
@@ -1,0 +1,60 @@
+# Pass PRODUCER-I18N-01 — Producer Analytics i18n to Greek
+
+**Date**: 2026-02-09
+**Status**: ✅ DONE
+**PRs**: #2699
+
+---
+
+## What was done
+
+### PR #2699 — Producer analytics i18n + docs
+
+**analytics/page.tsx** (~10 strings):
+- Breadcrumbs: "Home" → "Αρχική", "Producer Dashboard" → "Πίνακας Παραγωγού"
+- Header: "Producer Analytics" → "Αναλυτικά Παραγωγού"
+- Info box: full translation (title + 4 list items)
+
+**ProducerAnalyticsDashboard.tsx** (~50 strings):
+- Chart labels: Sales/Orders/Revenue → Πωλήσεις/Παραγγελίες/Έσοδα
+- Chart titles: all 3 charts translated
+- Error state: "Error Loading Analytics" → "Σφάλμα Φόρτωσης Αναλυτικών"
+- Header + buttons: Daily/Monthly → Ημερήσια/Μηνιαία
+- KPI cards: 3 labels translated
+- Table headers: Product/Price/Quantity/Revenue/Orders → Greek
+- Stats section: Total Products/Active/Out of Stock/Best Seller → Greek
+
+**producer-analytics.ts** (~8 strings):
+- Error throws: token/access messages → Greek
+- handleProducerError(): 5 return messages → Greek
+- Updated includes() patterns to match new Greek throw messages
+
+---
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| Production healthz | ✅ SHA `e83091fe`, status ok |
+| Typecheck | ✅ `npx tsc --noEmit` passes |
+| Build | ✅ `npm run build` passes |
+| CI | ✅ All checks pass (19/19) |
+| LOC | ✅ ~133 LOC (limit 300) |
+
+---
+
+## Files changed
+
+| File | Insertions | Deletions |
+|------|-----------|-----------|
+| frontend/src/app/producer/analytics/page.tsx | ~15 | ~15 |
+| frontend/src/components/producer/ProducerAnalyticsDashboard.tsx | ~40 | ~40 |
+| frontend/src/lib/api/producer-analytics.ts | ~15 | ~15 |
+| docs/* (3 files) | ~30 | ~5 |
+
+---
+
+## Out of scope (separate pass)
+
+- settings/page.tsx deprecated `/api/v1/producer/` endpoints — functional via nginx
+- producer-analytics.ts localStorage token — works, low priority

--- a/docs/AGENT/PASSES/SUMMARY-Pass-PRODUCERS-LISTING-01.md
+++ b/docs/AGENT/PASSES/SUMMARY-Pass-PRODUCERS-LISTING-01.md
@@ -1,0 +1,39 @@
+# SUMMARY — PRODUCERS-LISTING-01
+
+**Date**: 2026-02-10
+**PR**: #2701 (squash-merged)
+**SHA**: `c42baf17`
+**LOC**: 289 (+289 -16)
+
+## Problem
+
+Commit `133f9bc7` (AG-UI-08) replaced the functional producers listing page with a static "Γίνε μέλος του Dixis" landing page. The `/producers` URL showed no producer data.
+
+## Solution
+
+Restored the producers listing using the proven SSR + Prisma pattern from the products page:
+
+| File | Type | Lines |
+|------|------|-------|
+| `api/public/producers/route.ts` | NEW | 59 |
+| `components/ProducerCard.tsx` | NEW | 72 |
+| `producers/page.tsx` | REWRITTEN | 137 |
+| `producers/join/page.tsx` | NEW | 21 |
+
+### Architecture
+
+- **Data**: Prisma → Neon PostgreSQL (NOT Laravel backend)
+- **Rendering**: SSR Server Component with `revalidate: 60`
+- **Search**: URL params (`?search=`), server-side, HTML form (no client JS)
+- **Card**: Image with fallback, category badge, region pin, products count, link to profile
+- **Landing**: Preserved at `/producers/join` with CTA banner on listing page
+
+## Verification
+
+- [x] `npx tsc --noEmit` — pass
+- [x] `npm run build` — pass
+- [x] CI 19/19 checks pass
+- [x] Production: `/producers` returns 200, shows 2 producers
+- [x] Production: `/producers/join` returns 200
+- [x] Production: `api/public/producers` returns JSON with 2 producers
+- [x] healthz 200

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,11 +1,43 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-09 (ADMIN-CLEANUP-01)
+**Last Updated**: 2026-02-10 (PRODUCERS-LISTING-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~460 lines (target ≤350). ⚠️ Over limit — archive next pass.
 >
 > **Key Docs**: [DEPLOY SOP](DEPLOY.md) | [STATE Archive](STATE-ARCHIVE/)
+
+---
+
+## 2026-02-10 — PRODUCERS-LISTING-01: Restore Public Producers Listing
+
+**Status**: ✅ DONE (PR #2701)
+
+**What was done**:
+- Restored `/producers` page from static landing to functional SSR listing
+- New API route `api/public/producers` using Prisma (same pattern as products)
+- New `ProducerCard` component with image fallback, region, category, products count
+- Server-side search via URL params, ISR revalidate=60
+- Landing page preserved at `/producers/join`
+
+**Production**: SHA `c42baf17`, deployed 01:50 UTC, healthz 200, 2 producers visible
+
+**Pass summary**: `docs/AGENT/PASSES/SUMMARY-Pass-PRODUCERS-LISTING-01.md`
+
+---
+
+## 2026-02-10 — PRODUCER-I18N-01: Producer Analytics i18n
+
+**Status**: ✅ DONE (PR #2699)
+
+**What was done**:
+- Translated producer analytics dashboard to Greek (page, component, API lib)
+- ~50 English strings converted to Greek across 3 files
+- Error messages + includes() patterns matched to Greek throws
+
+**Production**: SHA `e83091fe`, deployed 23:45 UTC, healthz 200
+
+**Pass summary**: `docs/AGENT/PASSES/SUMMARY-Pass-PRODUCER-I18N-01.md`
 
 ---
 


### PR DESCRIPTION
## Summary

- Update AGENT-STATE.md with 2 new completed passes
- Update OPS/STATE.md with detailed pass records
- Add pass summary: PRODUCER-I18N-01 (PR #2699)
- Add pass summary: PRODUCERS-LISTING-01 (PR #2701)

## Test plan

- [ ] Docs-only change, no code impact