### PR TITLE
feat: add producer profile page + fix product count

### DIFF
--- a/frontend/src/app/api/public/producers/[slug]/route.ts
+++ b/frontend/src/app/api/public/producers/[slug]/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Public Producer Detail API
+ * Returns a single approved producer with their active products.
+ * Pattern follows api/public/products/[id]/route.ts
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params
+  if (!slug) {
+    return NextResponse.json({ error: 'missing slug' }, { status: 400 })
+  }
+
+  try {
+    const producer = await prisma.producer.findFirst({
+      where: {
+        OR: [{ slug }, { id: slug }],
+        isActive: true,
+        approvalStatus: 'approved',
+      },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        region: true,
+        category: true,
+        description: true,
+        imageUrl: true,
+        Product: {
+          where: { isActive: true },
+          orderBy: { createdAt: 'desc' },
+          select: {
+            id: true,
+            slug: true,
+            title: true,
+            price: true,
+            unit: true,
+            stock: true,
+            imageUrl: true,
+            category: true,
+          },
+        },
+      },
+    })
+
+    if (!producer) {
+      return NextResponse.json({ error: 'not found' }, { status: 404 })
+    }
+
+    const data = {
+      id: producer.id,
+      slug: producer.slug,
+      name: producer.name,
+      region: producer.region,
+      category: producer.category,
+      description: producer.description,
+      image_url: producer.imageUrl,
+      products: producer.Product.map((p) => ({
+        id: p.id,
+        slug: p.slug,
+        name: p.title,
+        price: p.price,
+        unit: p.unit,
+        stock: p.stock,
+        image_url: p.imageUrl,
+        category: p.category,
+      })),
+    }
+
+    return NextResponse.json(
+      { ok: true, data },
+      { headers: { 'cache-control': 'no-store' } }
+    )
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : 'unknown error'
+    console.error('[API] public/producers/[slug] error:', message)
+    return NextResponse.json(
+      { error: 'Database error', message },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/src/app/api/public/producers/route.ts
+++ b/frontend/src/app/api/public/producers/route.ts
@@ -32,7 +32,7 @@ export async function GET(req: Request) {
         category: true,
         description: true,
         imageUrl: true,
-        products: true,
+        _count: { select: { Product: { where: { isActive: true } } } },
       },
     })
 
@@ -44,7 +44,7 @@ export async function GET(req: Request) {
       category: p.category,
       description: p.description,
       image_url: p.imageUrl,
-      products_count: p.products,
+      products_count: p._count.Product,
     }))
 
     return NextResponse.json(


### PR DESCRIPTION
## Summary

- **New** `/producers/[slug]` profile page — shows producer info + their products grid
- **New** API route `/api/public/producers/[slug]` — fetches producer by slug/id with products
- **Fix** product count: uses Prisma `_count` of real Product records instead of denormalized `products` Int field (was showing 0)
- **Reuses** existing `ProductCard` component for the producer's products — no new components needed

## Context

After restoring the producers listing (PR #2701), three issues were found:
1. ~~Product count shows "0 προϊόντα"~~ → **Fixed**: now counts actual Product records
2. ~~Clicking a card leads to 404~~ → **Fixed**: profile page now exists
3. No filters (region/category) → **Separate PR** (next)

## Files Changed (271 LOC)

| File | Change | LOC |
|------|--------|-----|
| `api/public/producers/route.ts` | EDIT (fix _count) | +2 -2 |
| `api/public/producers/[slug]/route.ts` | NEW | 88 |
| `producers/[slug]/page.tsx` | NEW | 181 |

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] CI passes (typecheck, build, e2e, smoke)
- [ ] `/producers` cards show correct product count (Malis: 6, Lemnos: 4)
- [ ] `/producers/malis-garden` shows profile + 6 products
- [ ] `/producers/lemnos-honey-co` shows profile + 4 products
- [ ] Clicking ProductCard inside profile navigates to product detail
- [ ] SEO: title + OpenGraph metadata present
- [ ] 404 for non-existent slug
- [ ] Production deploy + healthz 200