### PR TITLE
fix: homepage featured products not rendering

### DIFF
--- a/frontend/src/components/marketing/FeaturedProducts.tsx
+++ b/frontend/src/components/marketing/FeaturedProducts.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { ProductCard, ProductCardSkeleton } from '@/components/ProductCard';
+import { getServerApiUrl } from '@/env';
 
 /**
  * Featured Products Section - Mobile-first product showcase
@@ -12,19 +13,22 @@ import { ProductCard, ProductCardSkeleton } from '@/components/ProductCard';
  * - Fallback UI for loading/error states
  */
 
-interface Product {
-  id: number;
+interface ApiProduct {
+  id: string | number;
   name: string;
-  price_cents: number;
-  producer_id?: number;
-  producer_name?: string;
-  image_url?: string;
+  slug: string;
+  price: number;
+  unit: string;
+  stock: number;
+  image_url?: string | null;
+  producer_id?: string | number;
+  producer?: { id: string; name: string; slug: string } | null;
 }
 
-async function getProducts(): Promise<Product[]> {
+async function getProducts(): Promise<ApiProduct[]> {
   try {
-    const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
-    const res = await fetch(`${apiUrl}/public/products?limit=8`, {
+    const base = getServerApiUrl();
+    const res = await fetch(`${base}/public/products?limit=8`, {
       next: { revalidate: 3600 }, // Revalidate every hour
     });
 
@@ -77,10 +81,11 @@ export default async function FeaturedProducts() {
                 key={product.id}
                 id={product.id}
                 title={product.name}
-                producer={product.producer_name || null}
+                producer={product.producer?.name || null}
                 producerId={product.producer_id}
-                priceCents={product.price_cents}
+                priceCents={Math.round(product.price * 100)}
                 image={product.image_url || null}
+                stock={product.stock}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary

- **Bug**: Homepage "Προτεινόμενα Προϊόντα" section showed skeletons instead of real products
- **Root causes** (2 bugs in `FeaturedProducts.tsx`):
  1. Wrong API URL — used `NEXT_PUBLIC_API_BASE_URL` (= `https://dixis.gr`) + `/public/products` = 404. Fixed to use `getServerApiUrl()` (= `http://127.0.0.1:3000/api`) like the products page does
  2. Wrong field mapping — interface expected `price_cents` + `producer_name` but API returns `price` (float in euros) + `producer.name` (nested object)

## Files changed (1, 27 LOC)

| File | Change |
|------|--------|
| `components/marketing/FeaturedProducts.tsx` | FIX (+16 -11) |

## Acceptance Criteria

- [ ] Homepage shows 8 product cards with correct names, prices, producers
- [ ] Prices display correctly in EUR (e.g., "5,50 €" not "0,06 €")
- [ ] Producer names show (e.g., "Malis Garden") not "Παραγωγός"
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes

## Test plan

- [ ] Visit dixis.gr → scroll to "Προτεινόμενα Προϊόντα" → verify product cards
- [ ] Click a product card → navigates to product detail page
- [ ] Verify prices match API data