### PR TITLE
fix: product category filters + expand to 13 categories

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -77,7 +77,7 @@ async function getData(search?: string): Promise<{ items: ApiItem[]; total: numb
       producerName: p.producer?.name || null,
       priceCents: Math.round(parseFloat(p.price) * 100),
       imageUrl: p.image_url,
-      categorySlug: p.category?.slug || null,
+      categorySlug: p.category || null,
       stock: typeof p.stock === 'number' ? p.stock : null,
     }));
 

--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -13,6 +13,9 @@ import {
   Leaf,
   Cherry,
   Soup,
+  Wine,
+  Milk,
+  Apple,
   LayoutGrid,
 } from 'lucide-react';
 
@@ -28,6 +31,9 @@ const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   Leaf,
   Cherry,
   Soup,
+  Wine,
+  Milk,
+  Apple,
 };
 
 interface CategoryStripProps {

--- a/frontend/src/data/categories.ts
+++ b/frontend/src/data/categories.ts
@@ -82,6 +82,27 @@ export const CATEGORIES: Category[] = [
     labelEn: 'Sauces, Preserves & Pickles',
     icon: 'Soup',
   },
+  {
+    id: 11,
+    slug: 'beverages',
+    labelEl: 'Ποτά & Αποστάγματα',
+    labelEn: 'Beverages & Spirits',
+    icon: 'Wine',
+  },
+  {
+    id: 12,
+    slug: 'dairy',
+    labelEl: 'Γαλακτοκομικά',
+    labelEn: 'Dairy Products',
+    icon: 'Milk',
+  },
+  {
+    id: 13,
+    slug: 'fruits-vegetables',
+    labelEl: 'Φρούτα & Λαχανικά',
+    labelEn: 'Fruits & Vegetables',
+    icon: 'Apple',
+  },
 ];
 
 // Helper to get category by slug


### PR DESCRIPTION
## Summary

Part 1/4 of CATEGORY-FIX series. Fixes the most critical issue: product filters completely broken.

**Bug**: `categorySlug: p.category?.slug || null` — `p.category` is a plain string (e.g. `"pasta"`), NOT an object. `.slug` on a string = `undefined`. No products ever matched any filter.

**Fix**: Changed to `categorySlug: p.category || null`

Also expands the official category list from 10 to 13 to cover existing products:
- `beverages` (Ποτά & Αποστάγματα) — Wine icon
- `dairy` (Γαλακτοκομικά) — Milk icon
- `fruits-vegetables` (Φρούτα & Λαχανικά) — Apple icon

## Files changed (3, 29 LOC)

| File | Change |
|------|--------|
| `products/page.tsx` | FIX line 80: `.category?.slug` → `.category` |
| `data/categories.ts` | ADD 3 new category entries (ids 11-13) |
| `CategoryStrip.tsx` | ADD Wine, Milk, Apple icon imports + mappings |

## Test plan

- [ ] `/products?cat=pasta` → shows Τραχανάς
- [ ] `/products?cat=herbs-spices` → shows Ρίγανη
- [ ] `/products?cat=beverages` → shows Τσίπουρο + Κρασί
- [ ] `/products?cat=dairy` → shows Φέτα
- [ ] `/products?cat=fruits-vegetables` → shows Πορτοκάλια + Πατάτες
- [ ] CategoryStrip shows 13 pills with correct icons
- [ ] All 10 products visible in "Όλα" view