### PR TITLE
fix: align categories in seed + producer label + DB sync script

### DIFF
--- a/frontend/prisma/seed.ts
+++ b/frontend/prisma/seed.ts
@@ -5,17 +5,21 @@ const prisma = new PrismaClient();
 async function main() {
   console.log('🌱 Starting production seed (idempotent)...');
 
-  // Seed categories (idempotent)
+  // Seed categories — must match src/data/categories.ts (13 official)
   const CATEGORIES = [
-    { slug: 'vegetables', name: 'Λαχανικά', icon: '🥬', sortOrder: 1 },
-    { slug: 'fruits', name: 'Φρούτα', icon: '🍎', sortOrder: 2 },
-    { slug: 'dairy', name: 'Γαλακτοκομικά', icon: '🧀', sortOrder: 3 },
-    { slug: 'meat', name: 'Κρέατα', icon: '🥩', sortOrder: 4 },
-    { slug: 'fish', name: 'Ψάρια', icon: '🐟', sortOrder: 5 },
-    { slug: 'bakery', name: 'Αρτοσκευάσματα', icon: '🥖', sortOrder: 6 },
-    { slug: 'honey-sweets', name: 'Μέλι & Γλυκά', icon: '🍯', sortOrder: 7 },
-    { slug: 'olive-oil', name: 'Ελαιόλαδο', icon: '🫒', sortOrder: 8 },
-    { slug: 'other', name: 'Άλλο', icon: '📦', sortOrder: 99 }
+    { slug: 'olive-oil-olives', name: 'Ελαιόλαδο & Ελιές', icon: '🫒', sortOrder: 1 },
+    { slug: 'honey-bee', name: 'Μέλι & Κυψέλη', icon: '🍯', sortOrder: 2 },
+    { slug: 'legumes', name: 'Όσπρια', icon: '🫘', sortOrder: 3 },
+    { slug: 'grains-rice', name: 'Δημητριακά & Ρύζια', icon: '🌾', sortOrder: 4 },
+    { slug: 'pasta', name: 'Ζυμαρικά', icon: '🍝', sortOrder: 5 },
+    { slug: 'flours-bakery', name: 'Αλεύρια & Αρτοποιία', icon: '🥐', sortOrder: 6 },
+    { slug: 'nuts-dried', name: 'Ξηροί Καρποί & Αποξηραμένα', icon: '🥜', sortOrder: 7 },
+    { slug: 'herbs-spices', name: 'Βότανα & Μπαχαρικά', icon: '🌿', sortOrder: 8 },
+    { slug: 'sweets-spreads', name: 'Γλυκά, Μαρμελάδες & Αλείμματα', icon: '🍒', sortOrder: 9 },
+    { slug: 'sauces-preserves', name: 'Σάλτσες, Conserves & Τουρσιά', icon: '🥫', sortOrder: 10 },
+    { slug: 'beverages', name: 'Ποτά & Αποστάγματα', icon: '🍷', sortOrder: 11 },
+    { slug: 'dairy', name: 'Γαλακτοκομικά', icon: '🧀', sortOrder: 12 },
+    { slug: 'fruits-vegetables', name: 'Φρούτα & Λαχανικά', icon: '🍎', sortOrder: 13 },
   ];
 
   for (const cat of CATEGORIES) {
@@ -77,7 +81,7 @@ async function main() {
     where: { slug: 'thymarisio-meli-450g' },
     update: {
       title: 'Θυμαρίσιο Μέλι 450g',
-      category: 'Honey & Sweets',
+      category: 'honey-bee',
       price: 7.9,
       unit: 'jar',
       stock: 50,
@@ -88,7 +92,7 @@ async function main() {
     create: {
       slug: 'thymarisio-meli-450g',
       title: 'Θυμαρίσιο Μέλι 450g',
-      category: 'Honey & Sweets',
+      category: 'honey-bee',
       price: 7.9,
       unit: 'jar',
       stock: 50,
@@ -102,7 +106,7 @@ async function main() {
     where: { slug: 'exairetiko-partheno-elaiolado-1l' },
     update: {
       title: 'Εξαιρετικό Παρθένο Ελαιόλαδο 1L',
-      category: 'Olive Oil',
+      category: 'olive-oil-olives',
       price: 10.9,
       unit: 'bottle',
       stock: 30,
@@ -113,7 +117,7 @@ async function main() {
     create: {
       slug: 'exairetiko-partheno-elaiolado-1l',
       title: 'Εξαιρετικό Παρθένο Ελαιόλαδο 1L',
-      category: 'Olive Oil',
+      category: 'olive-oil-olives',
       price: 10.9,
       unit: 'bottle',
       stock: 30,
@@ -127,7 +131,7 @@ async function main() {
     where: { slug: 'glyko-koutaliou-syko-380g' },
     update: {
       title: 'Γλυκό Κουταλιού Σύκο 380g',
-      category: 'Honey & Sweets',
+      category: 'sweets-spreads',
       price: 4.5,
       unit: 'jar',
       stock: 40,
@@ -138,7 +142,7 @@ async function main() {
     create: {
       slug: 'glyko-koutaliou-syko-380g',
       title: 'Γλυκό Κουταλιού Σύκο 380g',
-      category: 'Honey & Sweets',
+      category: 'sweets-spreads',
       price: 4.5,
       unit: 'jar',
       stock: 40,
@@ -153,7 +157,7 @@ async function main() {
     where: { slug: 'feta-pop-mytilinis' },
     update: {
       title: 'Φέτα ΠΟΠ Μυτιλήνης 400g',
-      category: 'Dairy',
+      category: 'dairy',
       price: 6.5,
       unit: 'pack',
       stock: 25,
@@ -164,7 +168,7 @@ async function main() {
     create: {
       slug: 'feta-pop-mytilinis',
       title: 'Φέτα ΠΟΠ Μυτιλήνης 400g',
-      category: 'Dairy',
+      category: 'dairy',
       price: 6.5,
       unit: 'pack',
       stock: 25,
@@ -179,7 +183,7 @@ async function main() {
     where: { slug: 'tsipouro-paradosiako' },
     update: {
       title: 'Τσίπουρο Παραδοσιακό 700ml',
-      category: 'Beverages',
+      category: 'beverages',
       price: 12.9,
       unit: 'bottle',
       stock: 15,
@@ -190,7 +194,7 @@ async function main() {
     create: {
       slug: 'tsipouro-paradosiako',
       title: 'Τσίπουρο Παραδοσιακό 700ml',
-      category: 'Beverages',
+      category: 'beverages',
       price: 12.9,
       unit: 'bottle',
       stock: 15,
@@ -205,7 +209,7 @@ async function main() {
     where: { slug: 'portokalia-viologika' },
     update: {
       title: 'Πορτοκάλια Βιολογικά 5kg',
-      category: 'Fruits & Vegetables',
+      category: 'fruits-vegetables',
       price: 8.9,
       unit: 'box',
       stock: 20,
@@ -216,7 +220,7 @@ async function main() {
     create: {
       slug: 'portokalia-viologika',
       title: 'Πορτοκάλια Βιολογικά 5kg',
-      category: 'Fruits & Vegetables',
+      category: 'fruits-vegetables',
       price: 8.9,
       unit: 'box',
       stock: 20,
@@ -231,7 +235,7 @@ async function main() {
     where: { slug: 'rigani-vounou' },
     update: {
       title: 'Ρίγανη Βουνού 100g',
-      category: 'Herbs & Spices',
+      category: 'herbs-spices',
       price: 3.5,
       unit: 'pack',
       stock: 60,
@@ -242,7 +246,7 @@ async function main() {
     create: {
       slug: 'rigani-vounou',
       title: 'Ρίγανη Βουνού 100g',
-      category: 'Herbs & Spices',
+      category: 'herbs-spices',
       price: 3.5,
       unit: 'pack',
       stock: 60,
@@ -257,7 +261,7 @@ async function main() {
     where: { slug: 'patates-naxou' },
     update: {
       title: 'Πατάτες Νάξου 3kg',
-      category: 'Fruits & Vegetables',
+      category: 'fruits-vegetables',
       price: 4.9,
       unit: 'bag',
       stock: 35,
@@ -268,7 +272,7 @@ async function main() {
     create: {
       slug: 'patates-naxou',
       title: 'Πατάτες Νάξου 3kg',
-      category: 'Fruits & Vegetables',
+      category: 'fruits-vegetables',
       price: 4.9,
       unit: 'bag',
       stock: 35,
@@ -283,7 +287,7 @@ async function main() {
     where: { slug: 'krasi-limnou-erythro' },
     update: {
       title: 'Κρασί Λήμνου Ερυθρό 750ml',
-      category: 'Beverages',
+      category: 'beverages',
       price: 9.9,
       unit: 'bottle',
       stock: 18,
@@ -294,7 +298,7 @@ async function main() {
     create: {
       slug: 'krasi-limnou-erythro',
       title: 'Κρασί Λήμνου Ερυθρό 750ml',
-      category: 'Beverages',
+      category: 'beverages',
       price: 9.9,
       unit: 'bottle',
       stock: 18,
@@ -309,7 +313,7 @@ async function main() {
     where: { slug: 'trachanas-spitikos' },
     update: {
       title: 'Τραχανάς Σπιτικός 500g',
-      category: 'Pasta & Grains',
+      category: 'pasta',
       price: 5.5,
       unit: 'pack',
       stock: 40,
@@ -320,7 +324,7 @@ async function main() {
     create: {
       slug: 'trachanas-spitikos',
       title: 'Τραχανάς Σπιτικός 500g',
-      category: 'Pasta & Grains',
+      category: 'pasta',
       price: 5.5,
       unit: 'pack',
       stock: 40,

--- a/frontend/scripts/ops/sync-categories.ts
+++ b/frontend/scripts/ops/sync-categories.ts
@@ -1,0 +1,73 @@
+/**
+ * One-time migration: Sync DB Category table with official 13 categories.
+ *
+ * What it does:
+ * 1. Upserts the 13 official categories (from src/data/categories.ts)
+ * 2. Deactivates any Category rows not in the official 13
+ *
+ * Usage:
+ *   cd frontend && npx tsx scripts/ops/sync-categories.ts
+ *
+ * Safe to re-run (idempotent).
+ */
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// Official 13 categories — must match src/data/categories.ts
+const OFFICIAL_CATEGORIES = [
+  { slug: 'olive-oil-olives', name: 'Ελαιόλαδο & Ελιές', sortOrder: 1 },
+  { slug: 'honey-bee', name: 'Μέλι & Κυψέλη', sortOrder: 2 },
+  { slug: 'legumes', name: 'Όσπρια', sortOrder: 3 },
+  { slug: 'grains-rice', name: 'Δημητριακά & Ρύζια', sortOrder: 4 },
+  { slug: 'pasta', name: 'Ζυμαρικά', sortOrder: 5 },
+  { slug: 'flours-bakery', name: 'Αλεύρια & Αρτοποιία', sortOrder: 6 },
+  { slug: 'nuts-dried', name: 'Ξηροί Καρποί & Αποξηραμένα', sortOrder: 7 },
+  { slug: 'herbs-spices', name: 'Βότανα & Μπαχαρικά', sortOrder: 8 },
+  { slug: 'sweets-spreads', name: 'Γλυκά, Μαρμελάδες & Αλείμματα', sortOrder: 9 },
+  { slug: 'sauces-preserves', name: 'Σάλτσες, Conserves & Τουρσιά', sortOrder: 10 },
+  { slug: 'beverages', name: 'Ποτά & Αποστάγματα', sortOrder: 11 },
+  { slug: 'dairy', name: 'Γαλακτοκομικά', sortOrder: 12 },
+  { slug: 'fruits-vegetables', name: 'Φρούτα & Λαχανικά', sortOrder: 13 },
+];
+
+async function main() {
+  console.log('🔄 Syncing categories to official 13...\n');
+
+  const officialSlugs = OFFICIAL_CATEGORIES.map((c) => c.slug);
+
+  // 1. Upsert official categories
+  for (const cat of OFFICIAL_CATEGORIES) {
+    await prisma.category.upsert({
+      where: { slug: cat.slug },
+      update: { name: cat.name, sortOrder: cat.sortOrder, isActive: true },
+      create: { slug: cat.slug, name: cat.name, sortOrder: cat.sortOrder, isActive: true },
+    });
+    console.log(`  ✅ ${cat.slug} → ${cat.name}`);
+  }
+
+  // 2. Deactivate non-official categories
+  const deactivated = await prisma.category.updateMany({
+    where: { slug: { notIn: officialSlugs } },
+    data: { isActive: false },
+  });
+
+  if (deactivated.count > 0) {
+    console.log(`\n  ⚠️  Deactivated ${deactivated.count} non-official categories`);
+  }
+
+  // 3. Summary
+  const active = await prisma.category.count({ where: { isActive: true } });
+  const total = await prisma.category.count();
+  console.log(`\n📊 Result: ${active} active / ${total} total categories`);
+  console.log('✅ Category sync complete!');
+}
+
+main()
+  .catch((e) => {
+    console.error('❌ Sync failed:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/frontend/src/app/producers/page.tsx
+++ b/frontend/src/app/producers/page.tsx
@@ -111,7 +111,7 @@ export default async function ProducersPage({ searchParams }: PageProps) {
         <Suspense fallback={null}>
           <div className="flex flex-col gap-2 mb-6">
             <FilterStrip label="Περιοχή" options={allRegions} selected={regionFilter} paramName="region" basePath="/producers" />
-            <FilterStrip label="Κατηγορία" options={allCategories} selected={categoryFilter} paramName="cat" basePath="/producers" />
+            <FilterStrip label="Δραστηριότητα" options={allCategories} selected={categoryFilter} paramName="cat" basePath="/producers" />
           </div>
         </Suspense>
 


### PR DESCRIPTION
## Summary
- **Producer page**: Rename misleading "Κατηγορία" filter label to "Δραστηριότητα" — producer.category describes business type (e.g. "Beekeeping"), not product category
- **seed.ts**: Replace 9 incorrect Category table slugs with official 13 categories matching `src/data/categories.ts`
- **seed.ts**: Fix product categories from English names (`"Honey & Sweets"`) to correct slugs (`"honey-bee"`, `"sweets-spreads"`, etc.)
- **New `scripts/ops/sync-categories.ts`**: One-time migration script — upserts 13 official categories and deactivates stale rows in production DB

Part of CATEGORY-FIX series (PR 2/4). Follows #2710.

## Verification
- [ ] `/producers` → filter label reads "ΔΡΑΣΤΗΡΙΟΤΗΤΑ" instead of "ΚΑΤΗΓΟΡΙΑ"
- [ ] `npx prisma db seed` → uses correct slugs (no English names)
- [ ] `npx tsx scripts/ops/sync-categories.ts` → 13 active categories

## Test plan
- [ ] Typecheck passes (`npx tsc --noEmit`)
- [ ] Build passes
- [ ] E2E tests pass (no regressions)