### PR TITLE
fix: forms store category slug instead of Greek name

### DIFF
--- a/frontend/src/app/admin/products/page.tsx
+++ b/frontend/src/app/admin/products/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useToast } from '@/contexts/ToastContext'
 import AdminLoading from '@/app/admin/components/AdminLoading'
 import AdminEmptyState from '@/app/admin/components/AdminEmptyState'
+import { CATEGORIES } from '@/data/categories'
 
 interface Product {
   id: string
@@ -597,7 +598,12 @@ function AdminProductsContent() {
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
                 <div>
                   <label style={{ display: 'block', fontSize: 14, fontWeight: 500, marginBottom: 4 }}>Κατηγορία *</label>
-                  <input name="category" required placeholder="π.χ. Λάδι" style={{ width: '100%', padding: 10, border: '1px solid #ddd', borderRadius: 8, boxSizing: 'border-box' }} data-testid="create-category-input" />
+                  <select name="category" required style={{ width: '100%', padding: 10, border: '1px solid #ddd', borderRadius: 8, boxSizing: 'border-box' }} data-testid="create-category-input">
+                    <option value="">Επιλέξτε κατηγορία...</option>
+                    {CATEGORIES.map((cat) => (
+                      <option key={cat.id} value={cat.slug}>{cat.labelEl}</option>
+                    ))}
+                  </select>
                 </div>
                 <div>
                   <label style={{ display: 'block', fontSize: 14, fontWeight: 500, marginBottom: 4 }}>Μονάδα *</label>
@@ -685,14 +691,17 @@ function AdminProductsContent() {
                 <label style={{ display: 'block', fontSize: 14, fontWeight: 500, marginBottom: 8 }}>
                   Κατηγορία *
                 </label>
-                <input
-                  type="text"
+                <select
                   value={editForm.category}
                   onChange={e => setEditForm(prev => ({ ...prev, category: e.target.value }))}
-                  placeholder="Κατηγορία προϊόντος..."
                   style={{ width: '100%', padding: 12, border: '1px solid #ddd', borderRadius: 8, boxSizing: 'border-box' }}
                   data-testid="edit-category-input"
-                />
+                >
+                  <option value="">Επιλέξτε κατηγορία...</option>
+                  {CATEGORIES.map((cat) => (
+                    <option key={cat.id} value={cat.slug}>{cat.labelEl}</option>
+                  ))}
+                </select>
               </div>
 
               <div>

--- a/frontend/src/app/my/products/[id]/edit/page.tsx
+++ b/frontend/src/app/my/products/[id]/edit/page.tsx
@@ -224,7 +224,7 @@ function EditProductContent() {
                     {categoriesLoading ? 'Φόρτωση...' : 'Επιλέξτε κατηγορία'}
                   </option>
                   {categories.map((cat) => (
-                    <option key={cat.id} value={cat.name}>
+                    <option key={cat.id} value={cat.slug}>
                       {cat.icon ? `${cat.icon} ${cat.name}` : cat.name}
                     </option>
                   ))}

--- a/frontend/src/app/my/products/create/page.tsx
+++ b/frontend/src/app/my/products/create/page.tsx
@@ -168,7 +168,7 @@ function CreateProductContent() {
                     {categoriesLoading ? 'Φόρτωση...' : 'Επιλέξτε κατηγορία'}
                   </option>
                   {categories.map((cat) => (
-                    <option key={cat.id} value={cat.name}>
+                    <option key={cat.id} value={cat.slug}>
                       {cat.icon ? `${cat.icon} ${cat.name}` : cat.name}
                     </option>
                   ))}

--- a/frontend/src/app/my/products/page.tsx
+++ b/frontend/src/app/my/products/page.tsx
@@ -342,7 +342,7 @@ function ProducerProductsContent() {
                 >
                   <option value="">Όλες οι κατηγορίες</option>
                   {categories.map((cat) => (
-                    <option key={cat.id} value={cat.name}>
+                    <option key={cat.id} value={cat.slug}>
                       {cat.icon ? `${cat.icon} ${cat.name}` : cat.name}
                     </option>
                   ))}


### PR DESCRIPTION
## Summary
- **Producer create form**: `value={cat.name}` → `value={cat.slug}` — stores slug (e.g. "honey-bee") instead of Greek name (e.g. "Μέλι & Κυψέλη")
- **Producer edit form**: Same fix
- **Producer product listing filter**: Use slug as filter value for consistency
- **Admin product forms**: Replace free-text `<input>` with `<select>` dropdown using official 13 CATEGORIES from `data/categories.ts`

Part of CATEGORY-FIX series (PR 3/4). Follows #2713.

## Verification
- [ ] Create product via producer form → DB stores category as slug
- [ ] Edit product → dropdown shows correct selected category
- [ ] Admin create/edit → dropdown instead of free-text
- [ ] Producer product listing filter works correctly

## Test plan
- [ ] Typecheck passes
- [ ] Build passes
- [ ] E2E tests pass