### PR TITLE
fix(producers): hide activity filter until proper taxonomy

### DIFF
--- a/frontend/src/app/producers/page.tsx
+++ b/frontend/src/app/producers/page.tsx
@@ -49,31 +49,27 @@ async function getData(search?: string): Promise<{ items: ApiProducer[]; total: 
 }
 
 interface PageProps {
-  searchParams: Promise<{ search?: string; region?: string; cat?: string }>;
+  searchParams: Promise<{ search?: string; region?: string }>;
 }
 
 export default async function ProducersPage({ searchParams }: PageProps) {
   const params = await searchParams;
   const searchQuery = params.search || null;
   const regionFilter = params.region || null;
-  const categoryFilter = params.cat || null;
   const { items: allItems } = await getData(searchQuery || undefined);
 
   // Extract unique filter options from ALL fetched items (pre-filter)
   const allRegions = [...new Set(allItems.map((p) => p.region))].sort();
-  const allCategories = [...new Set(allItems.map((p) => p.category))].sort();
 
   // Apply client-side filters
   const filtered = allItems
-    .filter((p) => !regionFilter || p.region === regionFilter)
-    .filter((p) => !categoryFilter || p.category === categoryFilter);
+    .filter((p) => !regionFilter || p.region === regionFilter);
   const total = filtered.length;
 
   const getEmptyMessage = () => {
     const parts: string[] = [];
     if (searchQuery) parts.push(`αναζήτηση "${searchQuery}"`);
     if (regionFilter) parts.push(`περιοχή "${regionFilter}"`);
-    if (categoryFilter) parts.push(`κατηγορία "${categoryFilter}"`);
     if (parts.length > 0) {
       return `Δεν βρέθηκαν παραγωγοί για ${parts.join(' και ')}.`;
     }
@@ -111,7 +107,6 @@ export default async function ProducersPage({ searchParams }: PageProps) {
         <Suspense fallback={null}>
           <div className="flex flex-col gap-2 mb-6">
             <FilterStrip label="Περιοχή" options={allRegions} selected={regionFilter} paramName="region" basePath="/producers" />
-            <FilterStrip label="Δραστηριότητα" options={allCategories} selected={categoryFilter} paramName="cat" basePath="/producers" />
           </div>
         </Suspense>
 


### PR DESCRIPTION
## Summary
- Remove "Δραστηριότητα" filter from producers page
- With only 2 producers, the filter adds no value
- Current values are in English (Beekeeping, Organic Farming) which breaks the Greek UI
- Will re-add when a proper Greek activity taxonomy is defined and more producers exist

## Changes
- `producers/page.tsx`: Remove `categoryFilter`, `allCategories`, and the FilterStrip for activity (-7 lines)

## Test plan
- [ ] Producers page loads with only the "Περιοχή" filter
- [ ] No "Δραστηριότητα" filter visible
- [ ] Region filter still works
- [ ] Typecheck passes