### PR TITLE
fix(producers): remove English category from producer cards

### DIFF
--- a/frontend/src/app/producers/page.tsx
+++ b/frontend/src/app/producers/page.tsx
@@ -119,7 +119,6 @@ export default async function ProducersPage({ searchParams }: PageProps) {
                 slug={p.slug}
                 name={p.name}
                 region={p.region}
-                category={p.category}
                 description={p.description}
                 imageUrl={p.image_url}
                 productsCount={p.products_count}

--- a/frontend/src/components/ProducerCard.tsx
+++ b/frontend/src/components/ProducerCard.tsx
@@ -6,13 +6,13 @@ type Props = {
   slug: string
   name: string
   region: string
-  category: string
+  category?: string
   description?: string | null
   imageUrl?: string | null
   productsCount: number
 }
 
-export function ProducerCard({ id, slug, name, region, category, description, imageUrl, productsCount }: Props) {
+export function ProducerCard({ id, slug, name, region, description, imageUrl, productsCount }: Props) {
   const hasImage = imageUrl && imageUrl.length > 0
   const href = `/producers/${slug || id}`
 
@@ -40,10 +40,7 @@ export function ProducerCard({ id, slug, name, region, category, description, im
       </div>
 
       <div className="px-4 pt-4 pb-2 flex-grow flex flex-col">
-        <span className="text-xs font-semibold text-primary uppercase tracking-wider">
-          {category}
-        </span>
-        <h2 className="text-base font-bold text-gray-900 line-clamp-1 mt-1 leading-tight">
+        <h2 className="text-base font-bold text-gray-900 line-clamp-1 leading-tight">
           {name}
         </h2>
         <p className="text-xs text-gray-500 mt-1 flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Remove "Beekeeping" / "Organic Farming" text display from ProducerCard component
- These English labels break the Greek UI and add no value with only 2 producers
- `category` prop kept as optional for backward compatibility

## Changes
- `ProducerCard.tsx`: Remove category `<span>`, make prop optional (-4 lines)
- `producers/page.tsx`: Stop passing `category` prop (-1 line)

## Test plan
- [ ] Producer cards show name, region, description — no English category text
- [ ] Typecheck passes