### PR TITLE
fix: producer dashboard calls Laravel directly via apiClient

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -985,6 +985,31 @@ class ApiClient {
     const qs = searchParams.toString();
     return this.request<AdminOrdersResponse>(`admin/orders${qs ? `?${qs}` : ''}`);
   }
+
+  // AUTH-UNIFY-01: Producer profile/status (replaces mock /api/producer/status)
+  async getProducerMe(): Promise<{
+    producer: {
+      id: number;
+      name: string;
+      slug: string;
+      status: string;
+      is_active: boolean;
+      business_name?: string;
+      description?: string;
+      location?: string;
+      phone?: string;
+      email?: string;
+    };
+  }> {
+    return this.request('producer/me');
+  }
+
+  // AUTH-UNIFY-01: Delete a producer product
+  async deleteProducerProduct(productId: number): Promise<void> {
+    await this.request(`producer/products/${productId}`, {
+      method: 'DELETE',
+    });
+  }
 }
 
 export const apiClient = new ApiClient();


### PR DESCRIPTION
## Summary

- **Problem**: The producer dashboard (`/my/products`) was completely broken because it called Next.js API routes (`/api/producer/status`, `/api/me/products`) that require a `dixis_session` JWT cookie (phone+OTP auth), but producers authenticate via Laravel Sanctum (email+password → Bearer token in localStorage).
- **Solution**: Replace all `fetch()` calls with `apiClient` methods that call Laravel directly with the Sanctum Bearer token. This follows the same pattern already working in `/my/orders`.
- Added `getProducerMe()` and `deleteProducerProduct()` methods to `ApiClient`
- Rewrote `checkProducerStatus()`, `loadProducts()`, and `handleDeleteConfirm()` in `/my/products/page.tsx`

## Test plan

- [ ] Login as `producer@example.com` → navigate to `/my/products`
- [ ] Products list loads correctly (3 products from Laravel)
- [ ] Search filtering works
- [ ] Category filtering works
- [ ] Delete product works
- [ ] TypeScript compilation passes (verified: 0 errors)