### PR TITLE
fix: producer create/edit pages call Laravel directly via apiClient

### DIFF
--- a/frontend/src/app/my/products/create/page.tsx
+++ b/frontend/src/app/my/products/create/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
 import UploadImage from '@/components/UploadImage.client';
+import { apiClient } from '@/lib/api';
 
 type Category = {
   id: string;
@@ -59,26 +60,18 @@ function CreateProductContent() {
     setBusy(true);
 
     try {
-      const response = await fetch('/api/me/products', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          slug,
-          title,
-          category,
-          price: parseFloat(price),
-          unit,
-          stock: parseInt(stock),
-          description: description || undefined,
-          imageUrl,
-          isActive,
-        }),
+      // AUTH-UNIFY-02: Call Laravel directly via apiClient (snake_case fields)
+      await apiClient.createProducerProduct({
+        name: title,
+        slug,
+        category,
+        price: parseFloat(price),
+        unit,
+        stock: parseInt(stock),
+        description: description || undefined,
+        image_url: imageUrl,
+        is_active: isActive,
       });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Αποτυχία δημιουργίας προϊόντος');
-      }
 
       router.push('/my/products');
     } catch (err: any) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,11 +10,14 @@ export interface ApiResponse<T = unknown> {
 export interface Product {
   id: number;
   name: string;
+  slug?: string;
   price: string;
   unit: string;
   stock: number | null;
   is_active: boolean;
   description: string | null;
+  category?: string;
+  image_url?: string | null;
   categories: Category[];
   images: ProductImage[];
   producer: Producer;
@@ -1008,6 +1011,49 @@ class ApiClient {
   async deleteProducerProduct(productId: number): Promise<void> {
     await this.request(`producer/products/${productId}`, {
       method: 'DELETE',
+    });
+  }
+
+  // AUTH-UNIFY-02: Get a single producer product by ID
+  async getProducerProduct(productId: number | string): Promise<{
+    data: Product;
+  }> {
+    return this.request<{ data: Product }>(`producer/products/${productId}`);
+  }
+
+  // AUTH-UNIFY-02: Create a new producer product
+  async createProducerProduct(data: {
+    name: string;
+    slug?: string;
+    category?: string;
+    price: number;
+    unit?: string;
+    stock: number;
+    description?: string;
+    image_url?: string | null;
+    is_active?: boolean;
+  }): Promise<{ data: Product }> {
+    return this.request<{ data: Product }>('producer/products', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  // AUTH-UNIFY-02: Update an existing producer product
+  async updateProducerProduct(productId: number | string, data: {
+    name?: string;
+    slug?: string;
+    category?: string;
+    price?: number;
+    unit?: string;
+    stock?: number;
+    description?: string;
+    image_url?: string | null;
+    is_active?: boolean;
+  }): Promise<{ data: Product }> {
+    return this.request<{ data: Product }>(`producer/products/${productId}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
     });
   }
 }


### PR DESCRIPTION
## Summary

Follows up on #2721 (AUTH-UNIFY-01) which fixed the products list page.

- **Problem**: Producer create (`/my/products/create`) and edit (`/my/products/[id]/edit`) pages called Next.js proxy routes (`/api/me/products`) that require `dixis_session` JWT cookie, but producers authenticate via Laravel Sanctum (Bearer token).
- **Solution**: Replace all `fetch()` calls with `apiClient` methods that call Laravel directly with the Sanctum Bearer token.
- Added `getProducerProduct()`, `createProducerProduct()`, `updateProducerProduct()` methods to `ApiClient`
- Extended `Product` interface with `slug`, `category`, `image_url` fields
- Fixed field mapping: `title`→`name`, `imageUrl`→`image_url`, `isActive`→`is_active`

## Test plan

- [ ] Login as `producer@example.com` → navigate to `/my/products`
- [ ] Click "Επεξεργασία" on a product → edit page loads with data
- [ ] Change a field and save → redirects to list with updated data
- [ ] Click "+ Νέο Προϊόν" → create page loads
- [ ] Fill form and submit → new product appears in list
- [ ] TypeScript compilation passes (verified: 0 errors)