### PR TITLE
feat: storefront reads products/producers from Laravel (SSOT)

### DIFF
--- a/docs/AGENT/research/DUAL-DB-RESEARCH.md
+++ b/docs/AGENT/research/DUAL-DB-RESEARCH.md
@@ -1,0 +1,327 @@
+# DUAL-DB Research — February 2026
+
+## Executive Summary
+
+The Dixis platform operates with **two completely separate PostgreSQL databases** that store products and producers independently. The **storefront** reads from Prisma/Neon DB, while the **producer dashboard** reads from Laravel/local DB. **Products created by producers never appear on the storefront** because they live in different databases with no sync mechanism.
+
+**Recommendation**: Make **Laravel the single source of truth** (SSOT) for products, producers, and orders. The storefront should read from Laravel's public API instead of Prisma.
+
+---
+
+## Architecture: Two Separate Worlds
+
+### Database A: Prisma (Neon PostgreSQL)
+
+| Aspect | Details |
+|--------|---------|
+| **Host** | Neon cloud (connection string in `.env`) |
+| **Used by** | Storefront pages (SSR), Next.js API routes, Admin panel |
+| **Products** | 10 Greek products (seed data) |
+| **Producers** | 2 producers: Malis Garden, Lemnos Honey Co |
+| **Categories** | 13 Greek categories with emojis |
+| **IDs** | CUIDs (e.g., `cmidw9n4e000ljv0b7b86iec2`) |
+| **Orders** | Has Order/OrderItem models (legacy, being replaced) |
+| **Auth** | AdminUser table (phone+OTP for admin panel) |
+
+### Database B: Laravel (Local VPS PostgreSQL)
+
+| Aspect | Details |
+|--------|---------|
+| **Host** | Local VPS (`127.0.0.1:5432`) |
+| **Used by** | Producer dashboard, checkout/orders, auth (login/register) |
+| **Products** | 7 English + 6 Greek products (seed data) |
+| **Producers** | 3 producers: Green Farm Co., Cretan Honey, Mt. Olympus Dairy |
+| **Categories** | 8 English categories (pivot table `product_category`) |
+| **IDs** | Auto-increment integers |
+| **Orders** | Full order system (Order, OrderItem, CheckoutSession, OrderShippingLine) |
+| **Auth** | User table (email+password via Sanctum) |
+
+### The Gap
+
+```
+Producer creates product → saved in Laravel DB
+                              ↓
+Customer visits /products → reads from Prisma DB → product NOT FOUND
+```
+
+---
+
+## How Data Flows Today
+
+### Storefront Product List (`/products`)
+
+```
+Browser GET /products
+  → Next.js SSR (getServerApiUrl() = http://127.0.0.1:3000/api)
+    → Next.js API route: /api/public/products/route.ts
+      → prisma.product.findMany({ where: { isActive: true } })
+        → Prisma/Neon DB → 10 Greek products
+```
+
+### Storefront Product Detail (`/products/[id]`)
+
+```
+Browser GET /products/cmidw9...
+  → Next.js SSR (getServerApiUrl() = http://127.0.0.1:3000/api)
+    → Next.js API route: /api/public/products/[id]/route.ts
+      → prisma.product.findFirst({ where: { OR: [{id}, {slug}] } })
+        → Prisma/Neon DB → single product
+```
+
+### Producer Dashboard (`/my/products`)
+
+```
+Browser GET /my/products
+  → AuthGuard → apiClient.getProducerMe() → Laravel /api/v1/producer/me
+  → apiClient.getProducerProducts() → Laravel /api/v1/producer/products
+    → Laravel DB → 3 products (Green Farm Co.)
+```
+
+### Checkout/Orders
+
+```
+Browser POST /checkout
+  → apiClient.createOrder() → Laravel POST /api/v1/public/orders
+    → OrderController@store → Laravel DB
+    → OrderItem.product_id → FK to Laravel Product table
+```
+
+### Producers List Page (`/producers`)
+
+```
+Browser GET /producers
+  → Next.js SSR → fetch(getServerApiUrl() + '/producers')
+    → Next.js API route → prisma.producer.findMany()
+      → Prisma/Neon DB → 2 Greek producers
+```
+
+---
+
+## nginx Routing Rules (Production)
+
+```nginx
+# Exact match → Next.js (Prisma)
+location = /api/v1/public/products { proxy_pass http://127.0.0.1:3000/api/public/products; }
+
+# Prefix matches → Next.js (Prisma)
+location ^~ /api/public/     { proxy_pass http://127.0.0.1:3000; }
+location ^~ /api/auth/       { proxy_pass http://127.0.0.1:3000; }
+location ^~ /api/me/         { proxy_pass http://127.0.0.1:3000; }
+location ^~ /api/producer/   { proxy_pass http://127.0.0.1:3000; }
+location ^~ /api/admin/      { proxy_pass http://127.0.0.1:3000; }
+
+# General catch-all → Laravel
+location /api { ... fastcgi_pass php-fpm; }
+```
+
+**Critical issue**: The exact match `= /api/v1/public/products` sends the product list to Next.js/Prisma instead of Laravel. Meanwhile, Laravel has a perfectly good `GET /api/v1/public/products` endpoint (PublicProductController) that's being shadowed.
+
+---
+
+## Data Model Comparison
+
+### Products
+
+| Field | Prisma | Laravel | Notes |
+|-------|--------|---------|-------|
+| ID | CUID string | Auto-increment int | **Incompatible** |
+| Name | `title` | `name` | Different field name |
+| Slug | `slug` | `slug` | Same |
+| Price | Decimal | `decimal:2` | Same concept |
+| Unit | `unit` | `unit` | Same |
+| Stock | `stock` (Int?) | `stock` (Int) | Same |
+| Description | `description` | `description` | Same |
+| Image | `imageUrl` | `image_url` | snake vs camel |
+| Active | `isActive` | `is_active` | snake vs camel |
+| Category | `category` (string) | pivot `product_category` | **Different approach** |
+| Organic | - | `is_organic` | **Laravel only** |
+| Seasonal | - | `is_seasonal` | **Laravel only** |
+| Discount | - | `discount_price` | **Laravel only** |
+| Weight | - | `weight_per_unit` | **Laravel only** |
+| Approval | `approvalStatus` | `approval_status` | Both have it |
+| Producer FK | `producerId` (CUID) | `producer_id` (int) | Different ID types |
+
+### Producers
+
+| Field | Prisma | Laravel | Notes |
+|-------|--------|---------|-------|
+| ID | CUID string | Auto-increment int | **Incompatible** |
+| Name | `name` | `name` | Same |
+| Slug | `slug` | `slug` | Same |
+| Region | `region` | `location` | Different field name |
+| Description | `description` | `description` | Same |
+| Image | `imageUrl` | (via User?) | Different |
+| Active | `isActive` | `is_active` | snake vs camel |
+| Phone | `phone` | `phone` | Same |
+| Email | `email` | `email` | Same |
+| Tax ID | - | `tax_id`, `tax_office` | **Laravel only** |
+| Business | - | `business_name` | **Laravel only** |
+| Geo | - | `latitude`, `longitude` | **Laravel only** |
+| Shipping | - | `uses_custom_shipping_rates`, `free_shipping_threshold_eur` | **Laravel only** |
+| User FK | - | `user_id` (FK to User) | **Laravel only** |
+
+### Categories
+
+| Prisma (13 categories) | Laravel (8 categories) |
+|------------------------|----------------------|
+| olive-oil-olives: Ελαιολαδο & Ελιες | olive-oil-olives: Olive Oil & Olives |
+| honey-bee: Μελι & Κυψελη | honey-preserves: Honey & Preserves |
+| legumes: Οσπρια | - |
+| grains-rice: Δημητριακα & Ρυζια | grains-cereals: Grains & Cereals |
+| pasta: Ζυμαρικα | - |
+| flours-bakery: Αλευρια & Αρτοποιια | - |
+| nuts-dried: Ξηροι Καρποι | - |
+| herbs-spices: Βοτανα & Μπαχαρικα | herbs-spices: Herbs & Spices |
+| sweets-spreads: Γλυκα & Μαρμελαδες | - |
+| sauces-preserves: Σαλτσες & Τουρσια | - |
+| beverages: Ποτα & Αποσταγματα | wine-beverages: Wine & Beverages |
+| dairy: Γαλακτοκομικα | dairy-products: Dairy Products |
+| fruits-vegetables: Φρουτα & Λαχανικα | fruits: Fruits + vegetables: Vegetables |
+
+---
+
+## Orders: Already on Laravel
+
+Orders are **fully managed by Laravel** as of recent passes:
+
+- `Order`, `OrderItem`, `CheckoutSession`, `OrderShippingLine` — all Laravel models
+- `OrderItem.product_id` → FK to Laravel `Product.id`
+- Denormalized: `product_name`, `unit_price`, `product_unit` snapshots
+- Checkout flow: `apiClient.createOrder()` → Laravel `POST /api/v1/public/orders`
+- Multi-producer support via `CheckoutSession` grouping
+- Stock decrement happens in Laravel transaction
+
+**Prisma still has Order/OrderItem models** but they're legacy — the frontend checkout already calls Laravel.
+
+---
+
+## Recommendation: Laravel as SSOT
+
+### Why Laravel
+
+1. **Auth lives there**: User registration, login, password reset, Sanctum tokens
+2. **Producer management**: Producer profiles, product CRUD, approval workflow
+3. **Orders already there**: Full checkout with multi-producer support, stock management
+4. **Richer data model**: `is_organic`, `is_seasonal`, `discount_price`, `weight_per_unit`, product images, category pivot table, producer geo/tax/shipping fields
+5. **Public API exists**: `PublicProductController` with search, filtering, pagination, caching headers — currently shadowed by nginx
+6. **Checkout references Laravel products**: `OrderItem.product_id` is FK to Laravel products — if storefront shows Prisma products, checkout would reference wrong IDs
+
+### Why NOT Prisma
+
+1. **No auth**: No User model, no login system
+2. **Seed data only**: 10 hardcoded Greek products, never updated by users
+3. **No product CRUD**: No API for producers to create/edit products
+4. **Simpler model**: Missing organic, seasonal, discount, weight, images, etc.
+5. **Orders migrating away**: Checkout already calls Laravel
+6. **ID mismatch**: CUID IDs incompatible with Laravel integer FKs
+
+---
+
+## Implementation Plan
+
+### Phase 1: Switch Storefront to Laravel Public API (PR ~200 LOC)
+
+**Goal**: Make `/products` and `/products/[id]` read from Laravel instead of Prisma.
+
+**Option A — nginx route fix (simplest)**:
+Remove the exact match rule that sends `/api/v1/public/products` to Next.js. Let it fall through to Laravel's catch-all `/api` → PHP-FPM. The Laravel `PublicProductController` already handles this endpoint.
+
+```nginx
+# REMOVE this line:
+location = /api/v1/public/products { proxy_pass http://127.0.0.1:3000/api/public/products; }
+
+# The general /api catch-all will send it to Laravel automatically
+```
+
+**Option B — Change SSR fetch URL**:
+Make `getServerApiUrl()` return the Laravel URL for public product endpoints. This requires updating `env.ts` or the storefront pages.
+
+**Preferred: Option A** — single nginx config change, zero code changes.
+
+**But also needed**: Update the storefront product pages to handle Laravel's response format (snake_case, different field names, different ID type).
+
+**Changes needed in storefront pages**:
+1. `/products` list page — update response mapping (`name` vs `title`, integer IDs, `is_active` vs `isActive`)
+2. `/products/[id]` detail page — same field mapping + handle integer IDs in URLs
+3. `/producers` list page — update response mapping
+4. `/producers/[slug]` detail page — same
+
+### Phase 2: Sync Categories (PR ~100 LOC)
+
+Align Laravel categories with the 13 Greek categories from Prisma:
+- Add missing categories to Laravel seeder (legumes, pasta, flours-bakery, nuts-dried, sweets-spreads, sauces-preserves)
+- Add Greek names to Laravel categories
+- The frontend `/api/categories` route (used by create/edit product forms) should read from Laravel instead of Prisma
+
+### Phase 3: Migrate Seed Data (PR ~80 LOC)
+
+- Add the 10 Greek products to Laravel's seeder (or create them via producer dashboard)
+- Create matching producers in Laravel for Malis Garden and Lemnos Honey Co
+- This ensures existing storefront content still appears after the switch
+
+### Phase 4: Clean Up Prisma Product/Producer Models (future)
+
+- Mark Prisma Product/Producer models as deprecated
+- Remove Next.js API routes that duplicate Laravel functionality
+- Keep Prisma for: AdminUser, AdminAuditLog, Category (if still needed), RateLimit, Event, Notification
+
+---
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Storefront breaks during switch | High | Test on staging, keep Prisma routes as fallback |
+| SEO: URLs change (CUID → int/slug) | Medium | Use slugs in URLs (both systems support slugs) |
+| Category mismatch | Low | Align categories in Phase 2 before switching |
+| Existing Prisma orders reference Prisma product IDs | Low | Orders already moving to Laravel; Prisma orders are legacy |
+| Cart references break | Medium | Cart uses localStorage with product data; needs client-side update |
+
+---
+
+## Files Reference
+
+### Storefront (reads from Prisma — needs to switch to Laravel)
+
+| File | What it does |
+|------|-------------|
+| `frontend/src/app/(storefront)/products/page.tsx` | Product list (SSR) |
+| `frontend/src/app/(storefront)/products/[id]/page.tsx` | Product detail (SSR) |
+| `frontend/src/app/(storefront)/producers/page.tsx` | Producer list (SSR) |
+| `frontend/src/app/(storefront)/producers/[slug]/page.tsx` | Producer detail (SSR) |
+| `frontend/src/app/api/public/products/route.ts` | Next.js API → Prisma (to deprecate) |
+| `frontend/src/app/api/public/products/[id]/route.ts` | Next.js API → Prisma (to deprecate) |
+
+### Producer Dashboard (already uses Laravel — working)
+
+| File | Status |
+|------|--------|
+| `frontend/src/app/my/products/page.tsx` | Fixed (AUTH-UNIFY-01) |
+| `frontend/src/app/my/products/create/page.tsx` | Fixed (AUTH-UNIFY-02) |
+| `frontend/src/app/my/products/[id]/edit/page.tsx` | Fixed (AUTH-UNIFY-02) |
+| `frontend/src/lib/api.ts` | apiClient methods added |
+
+### Laravel API (already exists — needs nginx unblocking)
+
+| Endpoint | Controller | Purpose |
+|----------|-----------|---------|
+| `GET /api/v1/public/products` | PublicProductController@index | Product list with search/filter |
+| `GET /api/v1/public/products/{id}` | PublicProductController@show | Product detail |
+| `GET /api/v1/public/producers` | PublicProducerController@index | Producer list |
+| `GET /api/v1/public/producers/{id}` | PublicProducerController@show | Producer detail |
+
+### nginx Config
+
+| File | Location |
+|------|----------|
+| `/etc/nginx/sites-enabled/dixis.gr` | Production VPS |
+
+---
+
+## Decision Log
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-02-11 | Laravel = SSOT for products/producers/orders | Auth, CRUD, orders all on Laravel; Prisma is seed-data-only |
+| 2026-02-11 | Phase 1: nginx fix + storefront field mapping | Lowest risk, zero backend changes |
+| 2026-02-11 | Keep Prisma for admin/audit/notifications | These features work and have no Laravel equivalent |

--- a/frontend/src/app/api/public/producers/[slug]/route.ts
+++ b/frontend/src/app/api/public/producers/[slug]/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from 'next/server'
-import { prisma } from '@/lib/prisma'
+import { getLaravelInternalUrl } from '@/env'
 
 export const dynamic = 'force-dynamic'
 
 /**
- * Public Producer Detail API
- * Returns a single approved producer with their active products.
- * Pattern follows api/public/products/[id]/route.ts
+ * STOREFRONT-LARAVEL-01: Public Producer Detail API
+ * Proxies to Laravel PublicProducerController@show instead of querying Prisma.
+ * Returns producer with their active products.
+ *
+ * Laravel is the SSOT for producers (see docs/AGENT/research/DUAL-DB-RESEARCH.md).
  */
 export async function GET(
   _request: Request,
@@ -18,59 +20,63 @@ export async function GET(
   }
 
   try {
-    const producer = await prisma.producer.findFirst({
-      where: {
-        OR: [{ slug }, { id: slug }],
-        isActive: true,
-        approvalStatus: 'approved',
-      },
-      select: {
-        id: true,
-        slug: true,
-        name: true,
-        region: true,
-        category: true,
-        description: true,
-        imageUrl: true,
-        Product: {
-          where: { isActive: true },
-          orderBy: { createdAt: 'desc' },
-          select: {
-            id: true,
-            slug: true,
-            title: true,
-            price: true,
-            unit: true,
-            stock: true,
-            imageUrl: true,
-            category: true,
-          },
-        },
-      },
+    const laravelBase = getLaravelInternalUrl()
+    const res = await fetch(`${laravelBase}/public/producers/${slug}`, {
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      cache: 'no-store',
     })
 
-    if (!producer) {
+    if (!res.ok) {
+      if (res.status === 404) {
+        return NextResponse.json({ error: 'not found' }, { status: 404 })
+      }
+      console.error('[API] Laravel public/producers/', slug, 'failed:', res.status)
+      return NextResponse.json(
+        { error: `Laravel API error: ${res.status}` },
+        { status: res.status }
+      )
+    }
+
+    const json = await res.json()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = json?.data ?? json
+
+    if (!p || !p.id) {
       return NextResponse.json({ error: 'not found' }, { status: 404 })
     }
 
+    // Map Laravel format to the format expected by /producers/[slug] page
+    // Laravel returns: { id, name, slug, description, location, products: [...] }
+    // Frontend expects: { id, slug, name, region, category, description, image_url, products: [...] }
+    const products = p.products || []
+
     const data = {
-      id: producer.id,
-      slug: producer.slug,
-      name: producer.name,
-      region: producer.region,
-      category: producer.category,
-      description: producer.description,
-      image_url: producer.imageUrl,
-      products: producer.Product.map((p) => ({
-        id: p.id,
-        slug: p.slug,
-        name: p.title,
-        price: p.price,
-        unit: p.unit,
-        stock: p.stock,
-        image_url: p.imageUrl,
-        category: p.category,
-      })),
+      id: p.id,
+      slug: p.slug,
+      name: p.name,
+      // Laravel uses 'location', frontend expects 'region'
+      region: p.location || p.region || '',
+      category: p.category || '',
+      description: p.description,
+      image_url: p.image_url || null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      products: products.map((prod: any) => {
+        const categories = prod.categories || []
+        const images = prod.images || []
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const primaryImage = images.find((img: any) => img.is_primary) || images[0]
+
+        return {
+          id: prod.id,
+          slug: prod.slug,
+          name: prod.name,
+          price: typeof prod.price === 'string' ? parseFloat(prod.price) : prod.price,
+          unit: prod.unit || 'kg',
+          stock: typeof prod.stock === 'number' ? prod.stock : 0,
+          image_url: primaryImage?.url || prod.image_url || null,
+          category: categories[0]?.slug || prod.category || null,
+        }
+      }),
     }
 
     return NextResponse.json(
@@ -79,9 +85,9 @@ export async function GET(
     )
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'unknown error'
-    console.error('[API] public/producers/[slug] error:', message)
+    console.error('[API] public/producers/[slug] proxy error:', message)
     return NextResponse.json(
-      { error: 'Database error', message },
+      { error: 'Proxy error', message },
       { status: 500 }
     )
   }

--- a/frontend/src/app/api/public/producers/route.ts
+++ b/frontend/src/app/api/public/producers/route.ts
@@ -1,59 +1,66 @@
 import { NextResponse } from 'next/server'
-import { prisma } from '@/lib/prisma'
+import { getLaravelInternalUrl } from '@/env'
 
 export const dynamic = 'force-dynamic'
 
 /**
- * Public Producers Listing API
- * Returns approved, active producers for the public /producers page.
- * Pattern follows api/public/products/route.ts
+ * STOREFRONT-LARAVEL-01: Public Producers Listing API
+ * Proxies to Laravel PublicProducerController instead of querying Prisma.
+ * This ensures the storefront shows the same producers that exist in Laravel.
+ *
+ * Laravel is the SSOT for producers (see docs/AGENT/research/DUAL-DB-RESEARCH.md).
  */
 export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url)
-    const q = searchParams.get('q')?.trim() || searchParams.get('search')?.trim() || ''
+    const search = searchParams.get('search')?.trim() || searchParams.get('q')?.trim() || ''
 
-    const where: Record<string, unknown> = {
-      isActive: true,
-      approvalStatus: 'approved',
-    }
-    if (q) {
-      where.name = { contains: q }
-    }
+    // Build Laravel URL with query params
+    const laravelBase = getLaravelInternalUrl()
+    const url = new URL(`${laravelBase}/public/producers`)
+    if (search) url.searchParams.set('search', search)
+    url.searchParams.set('per_page', '100')
 
-    const items = await prisma.producer.findMany({
-      where,
-      orderBy: { name: 'asc' },
-      select: {
-        id: true,
-        slug: true,
-        name: true,
-        region: true,
-        category: true,
-        description: true,
-        imageUrl: true,
-        _count: { select: { Product: { where: { isActive: true } } } },
-      },
+    const res = await fetch(url.toString(), {
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      cache: 'no-store',
     })
 
-    const data = items.map((p) => ({
+    if (!res.ok) {
+      console.error('[API] Laravel public/producers failed:', res.status, res.statusText)
+      return NextResponse.json(
+        { ok: false, error: `Laravel API error: ${res.status}` },
+        { status: res.status }
+      )
+    }
+
+    const json = await res.json()
+    const producers = json?.data ?? []
+
+    // Map Laravel format to the format expected by /producers page
+    // Laravel returns: { id, name, slug, description, location, is_active, products_count }
+    // Frontend expects: { id, slug, name, region, category, description, image_url, products_count }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data = producers.map((p: any) => ({
       id: p.id,
       slug: p.slug,
       name: p.name,
-      region: p.region,
-      category: p.category,
+      // Laravel uses 'location', frontend expects 'region'
+      region: p.location || p.region || '',
+      // Laravel producers don't have a single category field; use empty string
+      category: p.category || '',
       description: p.description,
-      image_url: p.imageUrl,
-      products_count: p._count.Product,
+      image_url: p.image_url || null,
+      products_count: p.products_count ?? 0,
     }))
 
     return NextResponse.json(
       { ok: true, count: data.length, data },
-      { headers: { 'cache-control': 'no-store' } }
+      { headers: { 'cache-control': 'public, s-maxage=60, stale-while-revalidate=30' } }
     )
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'unknown error'
-    console.error('[API] public/producers error:', message)
+    console.error('[API] public/producers proxy error:', message)
     return NextResponse.json({ ok: false, error: message }, { status: 500 })
   }
 }

--- a/frontend/src/app/api/public/products/[id]/route.ts
+++ b/frontend/src/app/api/public/products/[id]/route.ts
@@ -1,14 +1,14 @@
 import { NextResponse } from 'next/server';
-import { prisma } from '@/lib/prisma';
+import { getLaravelInternalUrl } from '@/env';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * Public Product by ID API
- * Mirrors /api/public/products (listing) but returns a single product.
+ * STOREFRONT-LARAVEL-01: Public Product by ID/slug API
+ * Proxies to Laravel PublicProductController@show instead of querying Prisma.
  * Used by (storefront)/products/[id]/page.tsx via INTERNAL_API_URL.
  *
- * Returns Laravel-compatible format so the detail page mapping works.
+ * Laravel is the SSOT for products (see docs/AGENT/research/DUAL-DB-RESEARCH.md).
  */
 export async function GET(
   _request: Request,
@@ -20,40 +20,54 @@ export async function GET(
   }
 
   try {
-    const product = await prisma.product.findFirst({
-      where: {
-        OR: [{ id }, { slug: id }],
-        isActive: true,
-      },
-      include: {
-        producer: {
-          select: { id: true, name: true, slug: true },
-        },
-      },
+    const laravelBase = getLaravelInternalUrl();
+    const res = await fetch(`${laravelBase}/public/products/${id}`, {
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      cache: 'no-store',
     });
 
-    if (!product) {
+    if (!res.ok) {
+      if (res.status === 404) {
+        return NextResponse.json({ error: 'not found' }, { status: 404 });
+      }
+      console.error('[API] Laravel public/products/', id, 'failed:', res.status);
+      return NextResponse.json(
+        { error: `Laravel API error: ${res.status}` },
+        { status: res.status }
+      );
+    }
+
+    const json = await res.json();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = json?.data ?? json;
+
+    if (!p || !p.id) {
       return NextResponse.json({ error: 'not found' }, { status: 404 });
     }
 
-    // Map to Laravel API format expected by getProductById() in detail page
+    // Map Laravel response to format expected by getProductById() in detail page
+    const categories = p.categories || [];
+    const images = p.images || [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const primaryImage = images.find((img: any) => img.is_primary) || images[0];
+
     const data = {
-      id: product.id,
-      name: product.title,
-      slug: product.slug,
-      description: product.description,
-      price: product.price,
-      unit: product.unit || 'kg',
-      stock: product.stock ?? 0,
-      is_active: product.isActive,
-      category: product.category,
-      image_url: product.imageUrl,
-      producer_id: product.producerId,
-      producer: product.producer
+      id: p.id,
+      name: p.name,
+      slug: p.slug,
+      description: p.description,
+      price: p.price,
+      unit: p.unit || 'kg',
+      stock: typeof p.stock === 'number' ? p.stock : 0,
+      is_active: p.is_active,
+      category: categories[0]?.slug || p.category || null,
+      image_url: primaryImage?.url || p.image_url || null,
+      producer_id: p.producer_id || p.producer?.id || null,
+      producer: p.producer
         ? {
-            id: product.producer.id,
-            name: product.producer.name,
-            slug: product.producer.slug,
+            id: p.producer.id,
+            name: p.producer.name,
+            slug: p.producer.slug,
           }
         : null,
     };
@@ -64,9 +78,9 @@ export async function GET(
     );
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'unknown error';
-    console.error('[API] public/products/[id] error:', message);
+    console.error('[API] public/products/[id] proxy error:', message);
     return NextResponse.json(
-      { error: 'Database error', message },
+      { error: 'Proxy error', message },
       { status: 500 }
     );
   }

--- a/frontend/src/app/api/public/products/route.ts
+++ b/frontend/src/app/api/public/products/route.ts
@@ -1,51 +1,79 @@
 import { NextResponse } from 'next/server'
-import { prisma } from '@/lib/prisma'
+import { getLaravelInternalUrl } from '@/env'
 
 export const dynamic = 'force-dynamic'
 
 /**
- * Public Products Listing API
- * Used by (storefront)/products/page.tsx via INTERNAL_API_URL.
- * Returns Laravel-compatible format for the product catalog.
+ * STOREFRONT-LARAVEL-01: Public Products Listing API
+ * Proxies to Laravel PublicProductController instead of querying Prisma.
+ * This ensures the storefront shows the same products that producers manage.
+ *
+ * Laravel is the SSOT for products (see docs/AGENT/research/DUAL-DB-RESEARCH.md).
  */
 export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url)
-    const q = searchParams.get('q')?.trim() || searchParams.get('search')?.trim() || ''
-    const where: Record<string, unknown> = { isActive: true }
-    if (q) where.title = { contains: q }
-    const items = await prisma.product.findMany({
-      where,
-      orderBy: { createdAt: 'desc' },
-      include: {
-        producer: { select: { id: true, name: true, slug: true } },
-      },
+    const search = searchParams.get('search')?.trim() || searchParams.get('q')?.trim() || ''
+    const category = searchParams.get('category')?.trim() || ''
+
+    // Build Laravel URL with query params
+    const laravelBase = getLaravelInternalUrl()
+    const url = new URL(`${laravelBase}/public/products`)
+    if (search) url.searchParams.set('search', search)
+    if (category) url.searchParams.set('category', category)
+    // Request up to 100 products (Laravel default is 15)
+    url.searchParams.set('per_page', '100')
+
+    const res = await fetch(url.toString(), {
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      cache: 'no-store',
     })
-    // Transform to Laravel API format expected by products page
+
+    if (!res.ok) {
+      console.error('[API] Laravel public/products failed:', res.status, res.statusText)
+      return NextResponse.json(
+        { ok: false, error: `Laravel API error: ${res.status}` },
+        { status: res.status }
+      )
+    }
+
+    const json = await res.json()
+    const products = json?.data ?? []
+
+    // Map Laravel format to the format expected by storefront pages
+    // Laravel returns: { id, name, slug, description, price, unit, stock, is_active,
+    //   is_organic, image_url, producer: { id, name, slug, location }, categories, images }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data = items.map((p: any) => ({
-      id: p.id,
-      name: p.title,
-      slug: p.slug,
-      description: p.description,
-      price: p.price,
-      unit: p.unit || 'kg',
-      stock: p.stock ?? 0,
-      is_active: p.isActive,
-      category: p.category,
-      image_url: p.imageUrl,
-      producer_id: p.producerId,
-      producer: p.producer
-        ? { id: p.producer.id, name: p.producer.name, slug: p.producer.slug }
-        : null,
-    }))
+    const data = products.map((p: any) => {
+      const categories = p.categories || []
+      const images = p.images || []
+      const primaryImage = images.find((img: any) => img.is_primary) || images[0]
+
+      return {
+        id: p.id,
+        name: p.name,
+        slug: p.slug,
+        description: p.description,
+        price: p.price,
+        unit: p.unit || 'kg',
+        stock: typeof p.stock === 'number' ? p.stock : 0,
+        is_active: p.is_active,
+        category: categories[0]?.slug || p.category || null,
+        image_url: primaryImage?.url || p.image_url || null,
+        producer_id: p.producer_id || p.producer?.id || null,
+        producer: p.producer
+          ? { id: p.producer.id, name: p.producer.name, slug: p.producer.slug }
+          : null,
+      }
+    })
+
     return NextResponse.json(
       { ok: true, count: data.length, data },
-      { headers: { 'cache-control': 'no-store' } }
+      { headers: { 'cache-control': 'public, s-maxage=60, stale-while-revalidate=30' } }
     )
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'unknown error'
-    console.error('[API] public/products error:', message)
+    console.error('[API] public/products proxy error:', message)
     return NextResponse.json({ ok: false, error: message }, { status: 500 })
   }
 }

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -7,7 +7,8 @@
  *
  * Canonical env vars (set in .env / .env.ci / VPS):
  *   NEXT_PUBLIC_API_BASE_URL  — Browser-side API base (e.g. https://dixis.gr/api/v1)
- *   INTERNAL_API_URL          — Server-side only, for SSR server-to-server calls
+ *   INTERNAL_API_URL          — Server-side only, for SSR server-to-server calls (Next.js)
+ *   LARAVEL_INTERNAL_URL      — Server-side only, for SSR calls to Laravel backend
  *   NEXT_PUBLIC_SITE_URL      — Public site URL (e.g. https://dixis.gr)
  *   DATABASE_URL              — Neon PostgreSQL connection string
  *   NODE_ENV                  — production | development | test
@@ -71,6 +72,19 @@ export function getServerApiUrl(): string {
   return process.env.INTERNAL_API_URL
     || process.env.NEXT_PUBLIC_API_BASE_URL
     || '/api/v1';
+}
+
+/**
+ * Get Laravel API base URL for server-side calls.
+ * Used by Next.js API routes that proxy to Laravel (e.g. public products/producers).
+ * Falls back to NEXT_PUBLIC_API_BASE_URL (goes through nginx → Laravel).
+ *
+ * Set LARAVEL_INTERNAL_URL on production VPS for direct server-to-server calls.
+ */
+export function getLaravelInternalUrl(): string {
+  return process.env.LARAVEL_INTERNAL_URL
+    || process.env.NEXT_PUBLIC_API_BASE_URL
+    || 'http://127.0.0.1:8001/api/v1';
 }
 
 export const API_BASE_URL = getApiBaseUrlFromEnv();


### PR DESCRIPTION
## Summary

- **Problem**: Storefront (`/products`, `/producers`) read from Prisma/Neon DB (seed data only), while producers manage products in Laravel DB. Products created by producers never appeared on the storefront.
- **Fix**: Convert 4 Next.js API routes from Prisma queries to Laravel API proxies
- **New**: `getLaravelInternalUrl()` in `env.ts` for server-side Laravel access
- **Docs**: `DUAL-DB-RESEARCH.md` documenting the dual-DB architecture and migration plan

### Files changed (5 code + 1 doc)

| File | Change |
|------|--------|
| `env.ts` | Add `getLaravelInternalUrl()` + `LARAVEL_INTERNAL_URL` env var |
| `api/public/products/route.ts` | Prisma query → Laravel proxy |
| `api/public/products/[id]/route.ts` | Prisma query → Laravel proxy |
| `api/public/producers/route.ts` | Prisma query → Laravel proxy, map `location`→`region` |
| `api/public/producers/[slug]/route.ts` | Prisma query → Laravel proxy, map fields |

### Deployment steps

1. Merge PR
2. SSH to production
3. Add `LARAVEL_INTERNAL_URL=https://dixis.gr/api/v1` to `frontend.env`
4. Remove nginx exact match rule: `= /api/v1/public/products`
5. `nginx -t && systemctl reload nginx`
6. `git pull && npm run build && pm2 restart dixis-frontend`

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] TypeScript passes (`tsc --noEmit`)
- [ ] After deploy: `/products` shows Laravel products (Organic Tomatoes, Fresh Lettuce, etc.)
- [ ] After deploy: `/products/{id}` shows product detail
- [ ] After deploy: `/producers` shows Laravel producers (Green Farm Co., etc.)
- [ ] After deploy: `/producers/{slug}` shows producer with products
- [ ] Add to cart still works
- [ ] Checkout still works