### PR TITLE
fix: Laravel public controllers accept slug lookups

### DIFF
--- a/backend/app/Http/Controllers/Public/ProducerController.php
+++ b/backend/app/Http/Controllers/Public/ProducerController.php
@@ -65,13 +65,20 @@ class ProducerController extends Controller
     }
 
     /**
-     * Display the specified producer.
+     * Display the specified producer by ID or slug.
+     *
+     * STOREFRONT-LARAVEL-01: Accept both numeric ID and string slug
+     * so the Next.js storefront can look up producers by slug.
      */
-    public function show(int $id): JsonResponse
+    public function show(string $id): JsonResponse
     {
         $producer = Producer::with(['user:id,name,email'])
             ->where('is_active', true)
-            ->findOrFail($id);
+            ->where(function ($q) use ($id) {
+                $q->where('id', is_numeric($id) ? (int) $id : 0)
+                    ->orWhere('slug', $id);
+            })
+            ->firstOrFail();
 
         // Load active products with their categories and images
         $producer->load(['products' => function ($query) {


### PR DESCRIPTION
## Summary
- **ProducerController@show**: Changed `int $id` → `string $id`, queries by both `id` (if numeric) and `slug` using `firstOrFail()`
- **ProductController@show**: Replaced numeric-only validation with conditional slug/ID lookup

## Context
PR #2725 (STOREFRONT-LARAVEL-01) converted the Next.js storefront API routes to proxy to Laravel. The storefront passes slugs (e.g. `/public/producers/cretan-honey`), but the Laravel controllers only accepted numeric IDs — causing 404/500 errors on detail pages.

These fixes were applied to production and verified working. This PR brings the git repo in sync.

## Test plan
- [ ] `GET /api/v1/public/producers/cretan-honey` → returns producer with products
- [ ] `GET /api/v1/public/producers/1` → still works with numeric ID
- [ ] `GET /api/v1/public/products/organic-tomatoes` → returns product detail
- [ ] `GET /api/v1/public/products/1` → still works with numeric ID
- [ ] Non-existent slug → 404