### PR TITLE
fix: map Laravel category slugs to storefront slugs

### DIFF
--- a/frontend/src/app/api/public/producers/[slug]/route.ts
+++ b/frontend/src/app/api/public/producers/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getLaravelInternalUrl } from '@/env'
+import { toStorefrontSlug } from '@/lib/category-map'
 
 export const dynamic = 'force-dynamic'
 
@@ -74,7 +75,7 @@ export async function GET(
           unit: prod.unit || 'kg',
           stock: typeof prod.stock === 'number' ? prod.stock : 0,
           image_url: primaryImage?.url || prod.image_url || null,
-          category: categories[0]?.slug || prod.category || null,
+          category: toStorefrontSlug(categories[0]?.slug || prod.category),
         }
       }),
     }

--- a/frontend/src/app/api/public/products/[id]/route.ts
+++ b/frontend/src/app/api/public/products/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getLaravelInternalUrl } from '@/env';
+import { toStorefrontSlug } from '@/lib/category-map';
 
 export const dynamic = 'force-dynamic';
 
@@ -60,7 +61,7 @@ export async function GET(
       unit: p.unit || 'kg',
       stock: typeof p.stock === 'number' ? p.stock : 0,
       is_active: p.is_active,
-      category: categories[0]?.slug || p.category || null,
+      category: toStorefrontSlug(categories[0]?.slug || p.category),
       image_url: primaryImage?.url || p.image_url || null,
       producer_id: p.producer_id || p.producer?.id || null,
       producer: p.producer

--- a/frontend/src/app/api/public/products/route.ts
+++ b/frontend/src/app/api/public/products/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getLaravelInternalUrl } from '@/env'
+import { toStorefrontSlug } from '@/lib/category-map'
 
 export const dynamic = 'force-dynamic'
 
@@ -58,7 +59,7 @@ export async function GET(req: Request) {
         unit: p.unit || 'kg',
         stock: typeof p.stock === 'number' ? p.stock : 0,
         is_active: p.is_active,
-        category: categories[0]?.slug || p.category || null,
+        category: toStorefrontSlug(categories[0]?.slug || p.category),
         image_url: primaryImage?.url || p.image_url || null,
         producer_id: p.producer_id || p.producer?.id || null,
         producer: p.producer

--- a/frontend/src/lib/category-map.ts
+++ b/frontend/src/lib/category-map.ts
@@ -1,0 +1,30 @@
+/**
+ * Category slug mapping between Laravel (English, 8 categories)
+ * and Prisma/storefront (Greek, 13 categories).
+ *
+ * STOREFRONT-LARAVEL-01 Phase 2: The storefront CategoryStrip uses Prisma
+ * slugs (e.g. "fruits-vegetables"), but Laravel products carry Laravel
+ * slugs (e.g. "fruits"). This mapping bridges the two until categories
+ * are fully unified in Laravel.
+ */
+
+/** Map a Laravel category slug to the corresponding Prisma/storefront slug. */
+const LARAVEL_TO_STOREFRONT: Record<string, string> = {
+  'fruits': 'fruits-vegetables',
+  'vegetables': 'fruits-vegetables',
+  'herbs-spices': 'herbs-spices',
+  'grains-cereals': 'grains-rice',
+  'dairy-products': 'dairy',
+  'olive-oil-olives': 'olive-oil-olives',
+  'wine-beverages': 'beverages',
+  'honey-preserves': 'honey-bee',
+};
+
+/**
+ * Convert a Laravel category slug to a storefront-compatible slug.
+ * Returns the input unchanged if no mapping exists.
+ */
+export function toStorefrontSlug(laravelSlug: string | null | undefined): string | null {
+  if (!laravelSlug) return null;
+  return LARAVEL_TO_STOREFRONT[laravelSlug] ?? laravelSlug;
+}


### PR DESCRIPTION
## Summary
- New `category-map.ts` maps Laravel English slugs (e.g. `fruits`, `dairy-products`) to Prisma/storefront Greek slugs (e.g. `fruits-vegetables`, `dairy`)
- Applied `toStorefrontSlug()` in all 3 product API proxy routes so CategoryStrip filtering works

## Context
Phase 1 (PR #2725) switched the storefront to read products from Laravel. However, Laravel uses 8 English category slugs while the storefront CategoryStrip uses 13 Greek/Prisma slugs. This mismatch caused category filtering to show zero products.

## Mapping
| Laravel slug | Storefront slug |
|---|---|
| `fruits` | `fruits-vegetables` |
| `vegetables` | `fruits-vegetables` |
| `dairy-products` | `dairy` |
| `honey-preserves` | `honey-bee` |
| `grains-cereals` | `grains-rice` |
| `wine-beverages` | `beverages` |
| `herbs-spices` | `herbs-spices` (same) |
| `olive-oil-olives` | `olive-oil-olives` (same) |

## Test plan
- [ ] Visit `/products` and click category "Φρούτα & Λαχανικά" → shows products
- [ ] Click category "Γαλακτοκομικά" → shows dairy products
- [ ] Click "Όλα" → shows all 7 products
- [ ] Product detail page shows correct Greek category name