### PR TITLE
feat: Phase 5.1-5.3 — Admin CRUD → Laravel proxy + producer auth fallback

### DIFF
--- a/frontend/src/app/api/admin/producers/route.ts
+++ b/frontend/src/app/api/admin/producers/route.ts
@@ -1,8 +1,15 @@
 import { NextResponse } from 'next/server'
-import { prisma } from '@/lib/db/client'
 import { z } from 'zod'
 import { getRequestId, logWithId } from '@/lib/observability/request'
 import { requireAdmin } from '@/lib/auth/admin'
+import { getLaravelInternalUrl } from '@/env'
+import { cookies } from 'next/headers'
+
+/**
+ * Phase 5.2: Admin producer routes now proxy to Laravel (SSOT).
+ * Admin authentication still uses Prisma AdminUser table.
+ * Producer CRUD goes to Laravel so producers appear on the storefront.
+ */
 
 const CreateSchema = z.object({
   name: z.string().min(2),
@@ -14,6 +21,11 @@ const CreateSchema = z.object({
   phone: z.string().optional(),
   isActive: z.boolean().optional()
 })
+
+async function getSessionToken(): Promise<string | null> {
+  const cookieStore = await cookies()
+  return cookieStore.get('dixis_session')?.value ?? null
+}
 
 export async function GET(req: Request) {
   const rid = getRequestId(req.headers)
@@ -29,31 +41,58 @@ export async function GET(req: Request) {
   const active = searchParams.get('active') || ''
   const sort = searchParams.get('sort') || 'name-asc'
 
-  // UX-FILTERS: q (search), active (only/all), sort (name-asc/name-desc)
-  const items = await prisma.producer.findMany({
-    where: {
-      AND: [
-        q ? { name: { contains: q } } : {},
-        active === 'only' ? { isActive: true } : {}
-      ]
-    },
-    select: {
-      id: true,
-      name: true,
-      region: true,
-      category: true,
-      isActive: true,
-      approvalStatus: true,
-      rejectionReason: true
-    },
-    orderBy: { name: sort === 'name-desc' ? 'desc' : 'asc' },
-    take: 100
-  })
+  try {
+    // Proxy to Laravel public producers endpoint
+    const laravelBase = getLaravelInternalUrl()
+    const url = new URL(`${laravelBase}/public/producers`)
+    if (q) url.searchParams.set('search', q)
+    url.searchParams.set('per_page', '100')
 
-  const res = NextResponse.json({ items })
-  res.headers.set('x-request-id', rid)
-  logWithId(rid, 'GET /api/admin/producers', { count: items.length, q, active, sort })
-  return res
+    const res = await fetch(url.toString(), {
+      headers: { 'Accept': 'application/json' },
+      cache: 'no-store',
+    })
+
+    if (!res.ok) {
+      console.error('[Admin] Laravel producers fetch failed:', res.status)
+      return NextResponse.json({ error: 'Σφάλμα ανάκτησης παραγωγών' }, { status: res.status })
+    }
+
+    const json = await res.json()
+    const producers = json?.data ?? []
+
+    // Map Laravel format to admin panel format and apply filters
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let items = producers.map((p: any) => ({
+      id: String(p.id),
+      name: p.name,
+      region: p.location || p.region || '',
+      category: p.category || '',
+      isActive: p.is_active !== false,
+      approvalStatus: p.approval_status || 'approved',
+      rejectionReason: p.rejection_reason || null,
+    }))
+
+    // Apply active filter
+    if (active === 'only') {
+      items = items.filter((p: { isActive: boolean }) => p.isActive)
+    }
+
+    // Apply sort
+    if (sort === 'name-desc') {
+      items.sort((a: { name: string }, b: { name: string }) => b.name.localeCompare(a.name, 'el'))
+    } else {
+      items.sort((a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name, 'el'))
+    }
+
+    const response = NextResponse.json({ items })
+    response.headers.set('x-request-id', rid)
+    logWithId(rid, 'GET /api/admin/producers [laravel-proxy]', { count: items.length, q, active, sort })
+    return response
+  } catch (error) {
+    console.error('[Admin] Producers proxy error:', error)
+    return NextResponse.json({ error: 'Σφάλμα διακομιστή' }, { status: 500 })
+  }
 }
 
 export async function POST(req: Request) {
@@ -78,21 +117,63 @@ export async function POST(req: Request) {
     return res
   }
 
-  const item = await prisma.producer.create({
-    data: {
+  try {
+    const sessionToken = await getSessionToken()
+    const laravelBase = getLaravelInternalUrl()
+    const url = new URL(`${laravelBase}/producers`)
+
+    // Map to Laravel format
+    const laravelPayload = {
       name: parsed.data.name,
       slug: parsed.data.slug,
-      region: parsed.data.region,
-      category: parsed.data.category,
-      description: parsed.data.description,
-      email: parsed.data.email,
-      phone: parsed.data.phone,
-      isActive: parsed.data.isActive ?? true
+      location: parsed.data.region,
+      description: parsed.data.description || null,
+      email: parsed.data.email || null,
+      phone: parsed.data.phone || null,
+      is_active: parsed.data.isActive ?? true,
     }
-  })
 
-  const res = NextResponse.json({ item }, { status: 201 })
-  res.headers.set('x-request-id', rid)
-  logWithId(rid, 'POST /api/admin/producers [created]', { id: item.id, name: item.name })
-  return res
+    const headers: Record<string, string> = {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    }
+    if (sessionToken) {
+      headers['Authorization'] = `Bearer ${sessionToken}`
+    }
+
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(laravelPayload),
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      console.error('[Admin] Laravel producer create failed:', response.status, errorData)
+      return NextResponse.json(
+        { error: errorData.message || 'Σφάλμα δημιουργίας παραγωγού' },
+        { status: response.status }
+      )
+    }
+
+    const result = await response.json()
+    const producer = result.data || result
+
+    const item = {
+      id: String(producer.id),
+      name: producer.name,
+      slug: producer.slug,
+      region: producer.location || parsed.data.region,
+      category: parsed.data.category,
+      isActive: producer.is_active !== false,
+    }
+
+    const res = NextResponse.json({ item }, { status: 201 })
+    res.headers.set('x-request-id', rid)
+    logWithId(rid, 'POST /api/admin/producers [created via laravel]', { id: item.id, name: item.name })
+    return res
+  } catch (error) {
+    console.error('[Admin] Producer create proxy error:', error)
+    return NextResponse.json({ error: 'Σφάλμα δημιουργίας παραγωγού' }, { status: 500 })
+  }
 }


### PR DESCRIPTION
## Summary
- **5.1** Admin product GET/POST now proxies to Laravel (not Prisma). Products created by admin will appear on the storefront.
- **5.2** Admin producer GET/POST now proxies to Laravel. Producers created by admin will appear on the storefront.
- **5.3** `requireProducer()` falls back to Laravel when Prisma record is missing. Prevents auth failures for Laravel-only producers.
- Admin authentication (AdminUser table) and audit logging stay in Prisma — correct separation.

## Context
Phase 5 of STOREFRONT-LARAVEL-01. After Phases 1–4, the storefront reads from Laravel but the admin panel still wrote to Prisma — meaning admin-created products/producers never appeared on the site. This PR fixes that gap.

## Test plan
- [x] `npm run build` passes
- [x] Admin auth unchanged (still checks Prisma AdminUser)
- [x] Audit logging preserved (still writes to Prisma AdminAuditLog)
- [x] Product/producer CRUD proxies to Laravel API
- [x] Producer auth falls back to Laravel lookup