### PR TITLE
chore: migrate shipping + order-intents from Prisma product to Laravel

### DIFF
--- a/frontend/src/app/api/order-intents/[id]/route.ts
+++ b/frontend/src/app/api/order-intents/[id]/route.ts
@@ -7,15 +7,11 @@ export async function GET(
 ) {
   try {
     const { id } = await params
+    // Phase 5.5c: Remove Product relation include.
+    // OrderItem already has titleSnap/priceSnap snapshots.
     const order = await prisma.order.findUnique({
       where: { id },
-      include: {
-        items: {
-          include: {
-            product: true
-          }
-        }
-      }
+      include: { items: true }
     })
 
     if (!order) {
@@ -41,7 +37,6 @@ export async function GET(
         price: item.price,
         titleSnap: item.titleSnap,
         priceSnap: item.priceSnap,
-        product: item.product
       }))
     })
   } catch (error) {


### PR DESCRIPTION
## Summary
- `shipping.ts`: Replace `prisma.product.findMany` with Laravel `/public/products/{id}` fetches for price lookup
- `order-intents/route.ts`: Replace `prisma.product.findMany` with Laravel product fetches; order creation stays in Prisma
- `order-intents/[id]/route.ts`: Remove `include: { product: true }` — use existing `titleSnap`/`priceSnap` snapshots

## Files changed
- `src/lib/shipping.ts` — product price lookup now from Laravel
- `src/app/api/order-intents/route.ts` — product data from Laravel, order creation stays Prisma
- `src/app/api/order-intents/[id]/route.ts` — removed Product relation include

## Test plan
- [ ] Shipping calculation works correctly
- [ ] Order creation via checkout flow works
- [ ] Order detail page shows item data from snapshots
- [ ] CI E2E tests pass