### PR TITLE
fix: replace mock producer onboarding with coming soon

### DIFF
--- a/frontend/src/app/api/producer/onboarding/route.ts
+++ b/frontend/src/app/api/producer/onboarding/route.ts
@@ -1,91 +1,20 @@
-import { NextRequest, NextResponse } from 'next/server';
-
-interface OnboardingRequest {
-  displayName: string;
-  taxId?: string;
-  phone?: string;
-}
+import { NextResponse } from 'next/server';
 
 /**
  * POST /api/producer/onboarding
- * Creates or updates a producer profile with status=pending
+ *
+ * DISABLED: Producer onboarding is not yet implemented.
+ * This route previously returned mock data (always userId=1, no DB write),
+ * which misled users into thinking registration succeeded.
+ *
+ * TODO: Wire to Laravel producer registration API when backend is ready.
  */
-export async function POST(request: NextRequest) {
-  try {
-    const body: OnboardingRequest = await request.json();
-
-    // Mock authentication
-    const userToken = request.headers.get('authorization');
-    const userId = getCurrentUserId(userToken);
-
-    if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    // Validate required fields
-    if (!body.displayName?.trim()) {
-      return NextResponse.json(
-        { error: 'Το όνομα εμφάνισης είναι υποχρεωτικό' },
-        { status: 400 }
-      );
-    }
-
-    // Mock producer profile creation/update
-    const producerProfile = await createOrUpdateProducerProfile(userId, {
-      displayName: body.displayName.trim(),
-      taxId: body.taxId?.trim() || undefined,
-      phone: body.phone?.trim() || undefined,
-    });
-
-    return NextResponse.json({
-      success: true,
-      message: 'Η αίτηση υποβλήθηκε επιτυχώς',
-      profile: producerProfile,
-    });
-
-  } catch (error) {
-    console.error('Producer onboarding error:', error);
-    return NextResponse.json(
-      { error: 'Παρουσιάστηκε σφάλμα κατά την υποβολή' },
-      { status: 500 }
-    );
-  }
-}
-
-// Mock helper functions
-function getCurrentUserId(token: string | null): number | null {
-  if (!token) return null;
-  return 1; // Mock user ID for testing
-}
-
-async function createOrUpdateProducerProfile(
-  userId: number,
-  data: { displayName: string; taxId?: string; phone?: string }
-) {
-  // Mock database operation
-  // In real app: use Prisma/ORM to create/update producer profile
-
-  const now = new Date().toISOString();
-
-  const profile = {
-    id: Math.floor(Math.random() * 1000), // Mock ID
-    user_id: userId,
-    name: data.displayName,
-    business_name: data.displayName, // Use display name as business name initially
-    tax_id: data.taxId,
-    phone: data.phone,
-    status: 'pending' as const,
-    slug: data.displayName.toLowerCase().replace(/[^a-z0-9]/g, '-'),
-    is_active: false,
-    verified: false,
-    uses_custom_shipping_rates: false,
-    created_at: now,
-    updated_at: now,
-  };
-
-  // Mock: store to in-memory cache or localStorage in browser
-  // In real app: INSERT or UPDATE into producers table
-  console.log('Mock: Created/Updated producer profile:', profile);
-
-  return profile;
+export async function POST() {
+  return NextResponse.json(
+    {
+      success: false,
+      error: 'Η εγγραφή παραγωγών δεν είναι διαθέσιμη αυτή τη στιγμή. Επικοινωνήστε μαζί μας στο info@dixis.gr.',
+    },
+    { status: 503 }
+  );
 }

--- a/frontend/src/app/api/producer/status/route.ts
+++ b/frontend/src/app/api/producer/status/route.ts
@@ -1,71 +1,22 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 
 /**
  * GET /api/producer/status
- * Returns the current producer profile status for the authenticated user
+ *
+ * DISABLED: Producer status check is not yet implemented.
+ * This route previously returned hardcoded mock data (always userId=1,
+ * fake profile "Δημήτρης Παπαδόπουλος"), which masked the fact that
+ * no real producer registration exists.
+ *
+ * Returns null status so the onboarding page shows the form
+ * (which itself returns 503 on submit with an honest message).
+ *
+ * TODO: Wire to Laravel GET /api/v1/producer/me when backend has
+ *       a registration flow for NEW producers (not existing ones).
  */
-export async function GET(request: NextRequest) {
-  try {
-    // Mock authentication - in real app this would come from session/JWT
-    const userToken = request.headers.get('authorization');
-    const userId = getCurrentUserId(userToken);
-
-    if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    // Mock producer profile lookup
-    // In real app this would query the database
-    const mockProducerProfile = getMockProducerProfile(userId);
-
-    return NextResponse.json({
-      status: mockProducerProfile?.status || null,
-      profile: mockProducerProfile,
-      submittedAt: mockProducerProfile?.created_at,
-    });
-
-  } catch (error) {
-    console.error('Producer status error:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
-  }
-}
-
-// Mock helper functions (replace with actual database queries)
-function getCurrentUserId(token: string | null): number | null {
-  // Mock user extraction from token
-  // In real app: verify JWT, extract user ID from session
-  if (!token) return null;
-
-  // For testing purposes, return mock user ID
-  return 1;
-}
-
-function getMockProducerProfile(userId: number) {
-  // Mock producer profiles for testing
-  const mockProfiles: Record<number, any> = {
-    1: {
-      id: 1,
-      user_id: userId,
-      name: 'Δημήτρης Παπαδόπουλος',
-      business_name: 'Παπαδόπουλος Αγρόκτημα',
-      tax_id: '123456789',
-      phone: '+30 210 1234567',
-      status: 'pending', // Can be: 'pending' | 'active' | 'inactive'
-      created_at: '2025-09-15T20:00:00.000Z',
-      updated_at: '2025-09-15T20:00:00.000Z',
-    },
-    2: {
-      id: 2,
-      user_id: userId,
-      name: 'Μαρία Γιαννοπούλου',
-      status: 'active',
-      created_at: '2025-09-14T15:30:00.000Z',
-      updated_at: '2025-09-15T10:15:00.000Z',
-    },
-  };
-
-  return mockProfiles[userId] || null;
+export async function GET() {
+  return NextResponse.json({
+    status: null,
+    profile: null,
+  });
 }


### PR DESCRIPTION
## Summary
- Producer onboarding API (`/api/producer/onboarding`) was a mock that always returned `userId: 1` with no DB write — users thought they registered but nothing was saved
- Producer status API (`/api/producer/status`) returned hardcoded fake profile data
- Replaced both with honest responses: 503 "not available" + "coming soon" page with contact email
- Updated AUDIT-BACKLOG.md: documented P1 rate-limit acceptance decision, corrected P2 audit-log (not actually an issue)

## Files changed
- `frontend/src/app/api/producer/onboarding/route.ts` — mock → 503 with honest message
- `frontend/src/app/api/producer/status/route.ts` — mock data → null (honest)
- `frontend/src/app/producer/onboarding/page.tsx` — form → "coming soon" with contact link
- `docs/AGENT/AUDIT-BACKLOG.md` — updated with findings

## Test plan
- [x] Build passes (0 errors, 0 warnings)
- [ ] Visit `/producer/onboarding` — shows "coming soon" with email link
- [ ] "Coming soon" page has no broken form submission