### PR TITLE
docs: resolve P3 audit backlog — env vars + OPS/STATE sync

### DIFF
--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -1,6 +1,6 @@
 # AGENT-STATE — Dixis Canonical Entry Point
 
-**Updated**: 2026-02-11 (ADMIN-BULK-STATUS-01 deployed)
+**Updated**: 2026-02-11 (P3-DOCS-CLEANUP complete)
 
 > **This is THE entry point.** Read this first on every agent session. Single source of truth.
 
@@ -47,6 +47,7 @@ See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 
 ## Recently Done (last 10)
 
+- **P3-DOCS-CLEANUP** — 13 env vars documented in .env.example, OPS/STATE.md synced, audit backlog cleared (2026-02-11) ✅
 - **ADMIN-BULK-STATUS-01** — Bulk order status update with checkboxes + toolbar (PR #2744, deployed 2026-02-11) ✅
 - **CLEANUP-SPRINT-01** — Codebase health: PrismaClient singleton (#2738), SQLite compat (#2739), docs sync (#2740), XSS fix (#2741), mock cleanup (#2743) ✅
 - **DUAL-DB-MIGRATION** — Phases 5.5a-d: Laravel SSOT for products (PRs #2734-#2737, deployed 2026-02-11) ✅

--- a/docs/AGENT/AUDIT-BACKLOG.md
+++ b/docs/AGENT/AUDIT-BACKLOG.md
@@ -1,7 +1,7 @@
 # Audit Backlog — Codebase Health Issues
 
 **Created**: 2026-02-11 (from full codebase health audit)
-**Last Updated**: 2026-02-11 (P1 fixes in PR #2743)
+**Last Updated**: 2026-02-11 (P3 items resolved)
 
 > Items discovered during a 5-agent parallel audit. Critical items (PRs #2738-#2741) already fixed.
 > This file tracks remaining issues for future sprints.
@@ -21,6 +21,8 @@
 | Viva-verify does DB mutation on GET request | #2741 | MERGED |
 | Producer onboarding mock (always userId=1) | #2743 | MERGED |
 | Producer status mock (hardcoded fake data) | #2743 | MERGED |
+| 13 env vars undocumented in .env.example | P3-DOCS | MERGED |
+| OPS/STATE.md missing pass entries | P3-DOCS | MERGED |
 
 ---
 
@@ -51,20 +53,13 @@
    - Fix: Create shared `apiError(message, status)` helper, migrate routes incrementally.
    - Effort: High (82 routes, spread across multiple PRs)
 
-### P3: Documentation / DX
+### P3: Documentation / DX — ✅ ALL RESOLVED
 
-5. **13 env vars undocumented in .env.example**
-   - Problem: Variables like `LARAVEL_INTERNAL_URL`, `CI_SEED_TOKEN`, `DIXIS_AGG_PROVIDER`, `SMTP_DEV_MAILBOX`, etc. are used in code but not listed in `.env.example`.
-   - Impact: New developers / fresh deployments miss configuration.
-   - Fix: Add all env vars to `.env.example` with comments.
-   - Effort: Low
+5. ~~**13 env vars undocumented in .env.example**~~ — RESOLVED
+   - Fixed: Added all missing env vars to `.env.example` with section headers and comments.
 
-6. **OPS/STATE.md outdated**
-   - File: `docs/OPS/STATE.md`
-   - Problem: Missing entries for AUTH-UNIFY, DUAL-DB-MIGRATION, CLEANUP-SPRINT passes.
-   - Impact: Historical record incomplete.
-   - Fix: Add missing entries.
-   - Effort: Low
+6. ~~**OPS/STATE.md outdated**~~ — RESOLVED
+   - Fixed: Added AUTH-UNIFY, DUAL-DB-MIGRATION, CLEANUP-SPRINT-01, ADMIN-BULK-STATUS-01 entries.
 
 ---
 

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,11 +1,81 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-10 (FEATURED-PRODUCTS-FIX-01)
+**Last Updated**: 2026-02-11 (P3-DOCS-CLEANUP)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
-> **Current size**: ~500 lines (target ≤350). ⚠️ Over limit — archive next pass.
+> **Current size**: ~600 lines (target ≤350). ⚠️ Over limit — archive next pass.
 >
 > **Key Docs**: [DEPLOY SOP](DEPLOY.md) | [STATE Archive](STATE-ARCHIVE/)
+
+---
+
+## 2026-02-11 — P3-DOCS-CLEANUP: Documentation & .env.example Sync
+
+**Status**: ✅ DONE
+
+**What was done**:
+- Added 13+ undocumented env vars to `.env.example` with comments (LARAVEL_INTERNAL_URL, CI_SEED_TOKEN, DIXIS_AGG_PROVIDER, SMTP_DEV_MAILBOX, OPS_TOKEN, OPS_KEY, STRIPE_SECRET_KEY, VIVA_WALLET_VERIFICATION_KEY, etc.)
+- Fixed ADMIN_PHONES formatting bug (was concatenated to comment line)
+- Updated `docs/OPS/STATE.md` with missing pass entries (AUTH-UNIFY, DUAL-DB-MIGRATION, CLEANUP-SPRINT-01, ADMIN-BULK-STATUS-01)
+- Updated `docs/AGENT/AUDIT-BACKLOG.md` to mark P3 items resolved
+
+**Impact**: New developers / fresh deployments now have complete configuration reference.
+
+---
+
+## 2026-02-11 — ADMIN-BULK-STATUS-01: Bulk Order Status Update
+
+**Status**: ✅ DONE (PR #2744, deployed)
+
+**What was done**:
+- New API endpoint `POST /api/admin/orders/bulk/status` with transition validation, audit logging, and email
+- Checkbox selection + bulk action toolbar in admin orders list
+- Max 50 orders per batch, same state machine as individual route
+- CodeQL compliance: log injection prevention with format specifiers
+
+**Production**: Deployed, healthz 200
+
+---
+
+## 2026-02-11 — CLEANUP-SPRINT-01: Codebase Health Fixes
+
+**Status**: ✅ DONE (PRs #2738-#2743)
+
+**What was done**:
+- PrismaClient unified to single singleton (#2738)
+- `prismaSafe.ts` anti-pattern removed (#2738)
+- `mode: 'insensitive'` removed from 6 Prisma queries for SQLite CI compat (#2739)
+- CLAUDE.md ports fixed, AGENT-STATE.md updated (#2740)
+- Contact form XSS fix, viva-verify GET mutation fixed (#2741)
+- Producer onboarding/status mock cleanup (#2743)
+
+**Impact**: 9 codebase health issues resolved from 5-agent audit.
+
+---
+
+## 2026-02-11 — DUAL-DB-MIGRATION (Phases 5.5a-d): Laravel SSOT for Products
+
+**Status**: ✅ DONE (PRs #2734-#2737, deployed)
+
+**What was done**:
+- Phase 5.5a: Created `apiClient` in `src/lib/api.ts` for Laravel proxy calls
+- Phase 5.5b: Migrated products page to use Laravel API via apiClient
+- Phase 5.5c: Migrated product detail page + SEO metadata
+- Phase 5.5d: Migrated admin product moderation to Laravel API
+
+**Impact**: Products now served from Laravel/PostgreSQL (single source of truth). Frontend proxies via `apiClient`.
+
+---
+
+## 2026-02-10 — AUTH-UNIFY: Fix Producer Dashboard Auth
+
+**Status**: ✅ DONE (PRs #2721-#2722, deployed)
+
+**What was done**:
+- Fixed producer dashboard authentication (Laravel Sanctum Bearer token)
+- Unified auth flow between admin (JWT cookie) and producer (Bearer token)
+
+**Production**: Deployed, both admin and producer dashboards functional.
 
 ---
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -74,7 +74,8 @@ DIXIS_CRON_KEY="change-me-strong"
 # ── API Guardrails & Ops (Passes 118–120) ────────────────────────────
 # Rate limiting uses DB-backed time-bucket strategy
 # Automatic cleanup via /api/jobs/maintenance/rl-clean (weekly cron)
-# Ops metrics dashboard: /ops/metrics (dev-only or DIXIS_DEV=1)ADMIN_PHONES=+306900000084
+# Ops metrics dashboard: /ops/metrics (dev-only or DIXIS_DEV=1)
+ADMIN_PHONES=+306900000084
 
 # Environment identifier
 DIXIS_ENV=local
@@ -134,6 +135,63 @@ VIVA_WALLET_SOURCE_CODE=
 PAYMENT_PROVIDER=fake
 # Frontend needs this to know which flow to use
 NEXT_PUBLIC_PAYMENT_PROVIDER=fake
+
+# ── Internal API (server-side only) ────────────────────────────────
+# Laravel backend URL for server-to-server calls (SSR / API routes)
+# Falls back to NEXT_PUBLIC_API_BASE_URL if not set
+LARAVEL_INTERNAL_URL=http://127.0.0.1:8001/api/v1
+INTERNAL_API_URL=http://127.0.0.1:8001/api/v1
+
+# ── Ops Endpoints ──────────────────────────────────────────────────
+# Authentication tokens for /api/ops/* and /api/ci/* endpoints
+# Set strong random strings on VPS; leave empty locally
+OPS_TOKEN=
+OPS_KEY=
+
+# CI seed token (used by /api/ci/seed/* endpoints in test environments)
+CI_SEED_TOKEN=
+
+# ── Aggregation & Caching ─────────────────────────────────────────
+# Aggregation provider for admin order facets: pg | demo (default: demo)
+DIXIS_AGG_PROVIDER=demo
+# Enable facets caching: 1 to enable (default: off)
+DIXIS_CACHE=
+# Cache TTL in milliseconds (default: 60000)
+DIXIS_CACHE_TTL_MS=60000
+# Enable metrics collection: 1 to enable (default: off)
+DIXIS_METRICS=
+
+# ── Email extras ───────────────────────────────────────────────────
+# Reply-to address for outbound emails (default: support@dixis.gr)
+MAIL_REPLY_TO="support@dixis.gr"
+# Dev mailbox: set to 1 to capture emails locally instead of sending
+SMTP_DEV_MAILBOX=
+# Default recipient for dev mailbox (only used when SMTP_DEV_MAILBOX=1)
+DEVMAIL_DEFAULT_TO=
+
+# ── Admin ──────────────────────────────────────────────────────────
+# Admin contact email for notifications (contact form, waitlist, etc.)
+ADMIN_EMAIL=
+# Admin email mapping for OTP verification (JSON: {"phone":"email"})
+# ADMIN_EMAIL_MAPPING=
+
+# ── Stripe (server-side) ──────────────────────────────────────────
+# Stripe secret key (set only on VPS; never commit)
+STRIPE_SECRET_KEY=
+
+# ── Viva Wallet Webhooks ──────────────────────────────────────────
+# Webhook verification key from Viva Wallet dashboard
+VIVA_WALLET_VERIFICATION_KEY=
+
+# ── Shipping (server-side) ────────────────────────────────────────
+# Flat shipping fee in EUR (default: 3.5)
+SHIPPING_FLAT_EUR=3.5
+# Free shipping threshold in EUR (default: 35)
+SHIPPING_FREE_OVER_EUR=35
+
+# ── Stock Alerts ──────────────────────────────────────────────────
+# Low stock threshold for admin alerts (default: 3)
+LOW_STOCK_THRESHOLD=3
 
 # ── Analytics (Pass ANALYTICS-BASIC-01) ─────────────────────────────
 # Privacy-friendly, cookie-less analytics (no consent banner required)


### PR DESCRIPTION
## Summary

- Add 13+ undocumented env vars to `.env.example` with section headers and comments
- Fix `ADMIN_PHONES` formatting bug (was concatenated to end of comment line)
- Add 5 missing pass entries to `docs/OPS/STATE.md` (AUTH-UNIFY, DUAL-DB-MIGRATION, CLEANUP-SPRINT-01, ADMIN-BULK-STATUS-01, P3-DOCS-CLEANUP)
- Mark P3 items as resolved in `docs/AGENT/AUDIT-BACKLOG.md`
- Update `docs/AGENT-STATE.md` recently done list

Resolves audit backlog items #5 and #6 (P3: Documentation / DX).

## Test plan

- [x] `npm run build` passes (0 errors, 0 warnings)
- [x] Docs-only + config-only changes — no runtime impact
- [x] All env vars have descriptive comments and defaults