### PR TITLE
fix(cart): toast notification on product detail + imageUrl in cart

### DIFF
--- a/frontend/src/app/(storefront)/products/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/page.tsx
@@ -228,10 +228,10 @@ export default async function Page({ params }:{ params: Promise<{ id:string }> }
             </div>
           )}
 
-          {/* Add to Cart */}
+          {/* Add to Cart — Pass CART-UX-FEEDBACK-01: include imageUrl */}
           <div className="mt-auto">
             <Add
-              product={p}
+              product={{ ...p, imageUrl: p.imageUrl || null }}
               translations={{
                 addToCart: t('product.addToCart'),
                 cartAdded: t('cart.added')

--- a/frontend/src/app/(storefront)/products/[id]/ui/Add.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/ui/Add.tsx
@@ -1,13 +1,15 @@
 'use client';
 import { useCart } from '@/lib/cart';
 import { useState } from 'react';
+import { useToast } from '@/contexts/ToastContext';
 
 /**
  * Pass FIX-STOCK-GUARD-01: Added stock field for OOS awareness
+ * Pass CART-UX-FEEDBACK-01: Added toast notification + imageUrl
  */
 interface AddProps {
   // Pass HOTFIX-MP-CHECKOUT-GUARD-01: Include producerId for multi-producer cart detection
-  product: { id: string; title: string; price: number; producerId?: string | number | null; producerName?: string | null; stock?: number | null };
+  product: { id: string; title: string; price: number; imageUrl?: string | null; producerId?: string | number | null; producerName?: string | null; stock?: number | null };
   translations: {
     addToCart: string;
     cartAdded: string;
@@ -18,6 +20,7 @@ interface AddProps {
 export default function Add({ product, translations }: AddProps) {
   const add = useCart(s => s.add);
   const [added, setAdded] = useState(false);
+  const { showSuccess } = useToast();
 
   // Pass FIX-STOCK-GUARD-01: Check if product is out of stock
   const isOutOfStock = typeof product.stock === 'number' && product.stock <= 0;
@@ -33,15 +36,18 @@ export default function Add({ product, translations }: AddProps) {
     const priceCents = Math.round(Number(product.price || 0) * 100);
 
     // Pass HOTFIX-MP-CHECKOUT-GUARD-01: Include producerId for multi-producer cart detection
+    // Pass CART-UX-FEEDBACK-01: Include imageUrl for cart thumbnails
     add({
       id: String(product.id),
       title: product.title,
       priceCents: priceCents,
+      imageUrl: product.imageUrl || undefined,
       producerId: product.producerId ? String(product.producerId) : undefined,
       producerName: product.producerName || undefined,
     });
 
     setAdded(true);
+    showSuccess(`${product.title} προστέθηκε στο καλάθι`, 2000);
     setTimeout(() => setAdded(false), 2000);
   };
 

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -59,7 +59,8 @@ export function ProductCard({ id, title, producer, producerId, priceCents, image
         <span data-testid="product-card-price" className="text-lg font-bold text-neutral-900">{price}</span>
         <div data-testid="product-card-add">
           {/* Pass FIX-STOCK-GUARD-01: Include stock for OOS check */}
-          <AddToCartButton id={String(id)} title={title} priceCents={priceCents} producerId={producerId ? String(producerId) : undefined} producerName={producer || undefined} stock={stock} />
+          {/* Pass CART-UX-FEEDBACK-01: Include imageUrl for cart thumbnails */}
+          <AddToCartButton id={String(id)} title={title} priceCents={priceCents} imageUrl={image || undefined} producerId={producerId ? String(producerId) : undefined} producerName={producer || undefined} stock={stock} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Product detail page (`/products/[id]`) now shows a toast notification when adding to cart, matching the product listing behavior
- Passes `imageUrl` through to the cart store from both the product detail page and listing cards, so thumbnails display when images are available

## What Changed
- `ui/Add.tsx`: Added `useToast()` import + `showSuccess()` call after adding to cart; included `imageUrl` in cart item
- `products/[id]/page.tsx`: Passes `imageUrl` to the `<Add>` component  
- `ProductCard.tsx`: Passes `image` prop to `<AddToCartButton>` as `imageUrl`

## Root Cause
The product detail page used a simpler `<p>` text indicator for "added to cart" feedback, while the listing page used the toast system (`useToast`). This inconsistency made the detail page feel unresponsive.

## Test Plan
- [ ] Go to `/products/[id]` → click "Προσθήκη στο καλάθι" → toast appears
- [ ] Go to `/products` listing → click "Προσθήκη" on card → toast appears (already worked)
- [ ] Cart badge counter increments on both pages
- [ ] `npm run build` passes with 0 errors

Pass: CART-UX-FEEDBACK-01