### PR TITLE
feat(legal): full terms of service and privacy policy in Greek

### DIFF
--- a/frontend/src/app/legal/privacy/page.tsx
+++ b/frontend/src/app/legal/privacy/page.tsx
@@ -1,11 +1,155 @@
-export const metadata = { title: 'Πολιτική Απορρήτου | Dixis' };
+import type { Metadata } from 'next';
+import Link from 'next/link';
 
-export default function Privacy() {
+export const metadata: Metadata = {
+  title: 'Πολιτική Απορρήτου | Dixis',
+  description: 'Πολιτική απορρήτου και προστασίας δεδομένων (GDPR) της πλατφόρμας Dixis.',
+};
+
+/**
+ * Pass LEGAL-PAGES-01: Full privacy policy in Greek (GDPR-aware)
+ */
+export default function PrivacyPage() {
   return (
-    <main className="container mx-auto px-4 py-8 max-w-4xl">
-      <h1 className="text-2xl font-bold mb-2">Πολιτική Απορρήτου</h1>
-      <p className="text-sm text-neutral-600 mb-4">Σύνοψη πολιτικής (προσωρινό κείμενο — θα εμπλουτιστεί).</p>
-      <p className="text-sm text-neutral-700">Σεβόμαστε τα προσωπικά σας δεδομένα και εφαρμόζουμε βέλτιστες πρακτικές ασφαλείας.</p>
+    <main className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
+      <article className="max-w-3xl mx-auto bg-white rounded-xl border p-6 sm:p-10">
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">Πολιτική Απορρήτου</h1>
+        <p className="text-sm text-gray-500 mb-8">Τελευταία ενημέρωση: Φεβρουάριος 2026</p>
+
+        <div className="prose prose-gray max-w-none space-y-6 text-[15px] leading-relaxed">
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">1. Εισαγωγή</h2>
+            <p>
+              Η πλατφόρμα <strong>Dixis</strong> (dixis.gr) σέβεται το απόρρητο των χρηστών
+              και εφαρμόζει τον Γενικό Κανονισμό Προστασίας Δεδομένων (GDPR - ΕΕ 2016/679).
+              Η παρούσα πολιτική εξηγεί ποια δεδομένα συλλέγουμε, γιατί, και πώς τα
+              προστατεύουμε.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">2. Δεδομένα που Συλλέγουμε</h2>
+            <ul className="list-disc pl-5 space-y-2">
+              <li>
+                <strong>Αριθμός τηλεφώνου</strong> — για ταυτοποίηση μέσω OTP και
+                επικοινωνία σχετικά με παραγγελίες.
+              </li>
+              <li>
+                <strong>Στοιχεία παράδοσης</strong> — όνομα, διεύθυνση, πόλη, ΤΚ — για
+                την αποστολή παραγγελιών.
+              </li>
+              <li>
+                <strong>Ιστορικό παραγγελιών</strong> — προϊόντα, ποσά, ημερομηνίες —
+                για την παρακολούθηση και εξυπηρέτηση.
+              </li>
+              <li>
+                <strong>Δεδομένα πληρωμής</strong> — δεν αποθηκεύονται στους servers μας.
+                Οι πληρωμές επεξεργάζονται από τον πάροχο Stripe (PCI DSS Level 1).
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">3. Σκοπός Επεξεργασίας</h2>
+            <p>Τα δεδομένα χρησιμοποιούνται αποκλειστικά για:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>Εκτέλεση και παράδοση παραγγελιών</li>
+              <li>Ταυτοποίηση χρήστη (OTP login)</li>
+              <li>Αποστολή ενημερώσεων κατάστασης παραγγελίας</li>
+              <li>Εξυπηρέτηση πελατών</li>
+              <li>Βελτίωση της πλατφόρμας (ανώνυμα αναλυτικά στοιχεία)</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">4. Νομική Βάση</h2>
+            <p>
+              Η επεξεργασία βασίζεται στην εκτέλεση σύμβασης (παραγγελία), στη συγκατάθεση
+              (εγγραφή), και σε έννομο συμφέρον (βελτίωση υπηρεσιών, ασφάλεια).
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">5. Cookies και Analytics</h2>
+            <p>
+              Η πλατφόρμα χρησιμοποιεί ελάχιστα τεχνικά cookies απαραίτητα για τη λειτουργία
+              (session, cart). Δεν χρησιμοποιούμε cookies παρακολούθησης τρίτων.
+            </p>
+            <p>
+              Τα αναλυτικά στοιχεία (αν ενεργοποιηθούν) είναι ανώνυμα και δεν χρησιμοποιούν
+              cookies — σύμφωνα με τις αρχές privacy-by-design.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">6. Διατήρηση Δεδομένων</h2>
+            <p>
+              Τα δεδομένα παραγγελιών διατηρούνται για 5 έτη (φορολογικές υποχρεώσεις).
+              Τα δεδομένα λογαριασμού διατηρούνται για όσο ο λογαριασμός είναι ενεργός.
+              Μετά τη διαγραφή, τα δεδομένα αφαιρούνται εντός 30 ημερών.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">7. Ασφάλεια</h2>
+            <p>
+              Εφαρμόζουμε τεχνικά και οργανωτικά μέτρα ασφαλείας: κρυπτογράφηση HTTPS,
+              HttpOnly cookies, rate limiting, και τακτικούς ελέγχους ασφαλείας.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">8. Δικαιώματα Χρηστών (GDPR)</h2>
+            <p>Έχετε δικαίωμα:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>Πρόσβασης στα δεδομένα σας</li>
+              <li>Διόρθωσης ανακριβών δεδομένων</li>
+              <li>Διαγραφής (&quot;δικαίωμα στη λήθη&quot;)</li>
+              <li>Περιορισμού ή εναντίωσης στην επεξεργασία</li>
+              <li>Φορητότητας δεδομένων</li>
+            </ul>
+            <p className="mt-2">
+              Για να ασκήσετε τα δικαιώματά σας, επικοινωνήστε μαζί μας μέσω της
+              σελίδας{' '}
+              <Link href="/contact" className="text-emerald-700 hover:underline">
+                Επικοινωνία
+              </Link>.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">9. Τρίτοι Πάροχοι</h2>
+            <p>Μοιραζόμαστε δεδομένα μόνο με:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li><strong>Stripe</strong> — επεξεργασία πληρωμών (PCI DSS Level 1)</li>
+              <li><strong>Παραγωγούς</strong> — στοιχεία παράδοσης για εκτέλεση παραγγελιών</li>
+              <li><strong>Resend</strong> — αποστολή email (αποδείξεις, ενημερώσεις)</li>
+            </ul>
+            <p className="mt-2">
+              Δεν πουλάμε και δεν μοιραζόμαστε δεδομένα με τρίτους για διαφημιστικούς σκοπούς.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">10. Αλλαγές στην Πολιτική</h2>
+            <p>
+              Σε περίπτωση ουσιωδών αλλαγών, θα ενημερώσουμε τους χρήστες μέσω email
+              ή μέσω ειδοποίησης στην πλατφόρμα.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">11. Επικοινωνία</h2>
+            <p>
+              Για ερωτήσεις σχετικά με την πολιτική απορρήτου ή τα δεδομένα σας,
+              επικοινωνήστε μαζί μας στη σελίδα{' '}
+              <Link href="/contact" className="text-emerald-700 hover:underline">
+                Επικοινωνία
+              </Link>.
+            </p>
+          </section>
+        </div>
+      </article>
     </main>
   );
 }

--- a/frontend/src/app/legal/terms/page.tsx
+++ b/frontend/src/app/legal/terms/page.tsx
@@ -1,11 +1,125 @@
-export const metadata = { title: 'Όροι Χρήσης | Dixis' };
+import type { Metadata } from 'next';
+import Link from 'next/link';
 
-export default function Terms() {
+export const metadata: Metadata = {
+  title: 'Όροι Χρήσης | Dixis',
+  description: 'Όροι χρήσης της πλατφόρμας Dixis — ηλεκτρονική αγορά τοπικών προϊόντων.',
+};
+
+/**
+ * Pass LEGAL-PAGES-01: Full terms of service in Greek
+ */
+export default function TermsPage() {
   return (
-    <main className="container mx-auto px-4 py-8 max-w-4xl">
-      <h1 className="text-2xl font-bold mb-2">Όροι Χρήσης</h1>
-      <p className="text-sm text-neutral-600 mb-4">Βασικοί όροι (προσωρινό κείμενο — θα εμπλουτιστεί).</p>
-      <p className="text-sm text-neutral-700">Η χρήση του ιστότοπου διέπεται από τους παρόντες όρους.</p>
+    <main className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
+      <article className="max-w-3xl mx-auto bg-white rounded-xl border p-6 sm:p-10">
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">Όροι Χρήσης</h1>
+        <p className="text-sm text-gray-500 mb-8">Τελευταία ενημέρωση: Φεβρουάριος 2026</p>
+
+        <div className="prose prose-gray max-w-none space-y-6 text-[15px] leading-relaxed">
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">1. Γενικά</h2>
+            <p>
+              Η πλατφόρμα <strong>Dixis</strong> (dixis.gr) λειτουργεί ως ηλεκτρονική αγορά που
+              συνδέει τοπικούς Έλληνες παραγωγούς με καταναλωτές. Η χρήση της πλατφόρμας
+              συνεπάγεται αποδοχή των παρόντων όρων.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">2. Εγγραφή και Λογαριασμός</h2>
+            <p>
+              Η πρόσβαση στην πλατφόρμα γίνεται μέσω αριθμού τηλεφώνου και κωδικού OTP.
+              Ο χρήστης ευθύνεται για την ασφάλεια της πρόσβασης στον λογαριασμό του.
+              Δεν επιτρέπεται η κοινοποίηση κωδικών σε τρίτους.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">3. Παραγγελίες και Πληρωμές</h2>
+            <p>
+              Οι τιμές αναγράφονται σε ευρώ (EUR) και περιλαμβάνουν ΦΠΑ.
+              Τα μεταφορικά υπολογίζονται κατά το checkout.
+              Αποδεκτοί τρόποι πληρωμής: αντικαταβολή, πιστωτική/χρεωστική κάρτα (μέσω Stripe).
+            </p>
+            <p>
+              Η παραγγελία ολοκληρώνεται μετά την επιβεβαίωση πληρωμής.
+              Ο παραγωγός ευθύνεται για την ετοιμασία και αποστολή.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">4. Αποστολή και Παράδοση</h2>
+            <p>
+              Ο χρόνος παράδοσης εξαρτάται από τον παραγωγό και τη γεωγραφική θέση.
+              Η πλατφόρμα δεν ευθύνεται για καθυστερήσεις που οφείλονται σε τρίτους
+              μεταφορείς ή ανωτέρα βία.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">5. Επιστροφές και Ακυρώσεις</h2>
+            <p>
+              Λόγω της φύσης των προϊόντων (φρέσκα τρόφιμα), οι επιστροφές γίνονται
+              αποδεκτές μόνο σε περιπτώσεις ελαττωματικού ή λανθασμένου προϊόντος.
+              Η αίτηση επιστροφής πρέπει να υποβληθεί εντός 24 ωρών από την παράδοση.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">6. Υποχρεώσεις Παραγωγών</h2>
+            <p>
+              Οι παραγωγοί ευθύνονται για την ακρίβεια των πληροφοριών (τίτλος, περιγραφή,
+              τιμή, απόθεμα) και την ποιότητα των προϊόντων τους. Η πλατφόρμα ενεργεί ως
+              διαμεσολαβητής και δεν εγγυάται την ποιότητα μεμονωμένων προϊόντων.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">7. Πνευματική Ιδιοκτησία</h2>
+            <p>
+              Το περιεχόμενο της πλατφόρμας (λογότυπο, σχεδιασμός, κώδικας) ανήκει στο
+              Dixis. Απαγορεύεται η αντιγραφή ή αναπαραγωγή χωρίς γραπτή άδεια.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">8. Περιορισμός Ευθύνης</h2>
+            <p>
+              Η πλατφόρμα παρέχεται &quot;ως έχει&quot;. Δεν φέρουμε ευθύνη για ζημίες
+              που προκύπτουν από τη χρήση ή αδυναμία χρήσης της πλατφόρμας,
+              εκτός αν προβλέπεται διαφορετικά από τον νόμο.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">9. Τροποποιήσεις</h2>
+            <p>
+              Διατηρούμε το δικαίωμα τροποποίησης των όρων χρήσης. Σε περίπτωση ουσιωδών
+              αλλαγών, θα ενημερώσουμε τους χρήστες μέσω της πλατφόρμας ή μέσω email.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">10. Εφαρμοστέο Δίκαιο</h2>
+            <p>
+              Οι παρόντες όροι διέπονται από το ελληνικό δίκαιο. Για κάθε διαφορά
+              αρμόδια είναι τα δικαστήρια Αθηνών.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mt-6 mb-3">11. Επικοινωνία</h2>
+            <p>
+              Για ερωτήσεις σχετικά με τους όρους χρήσης, επικοινωνήστε μαζί μας στη
+              σελίδα{' '}
+              <Link href="/contact" className="text-emerald-700 hover:underline">
+                Επικοινωνία
+              </Link>.
+            </p>
+          </section>
+        </div>
+      </article>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Replace placeholder legal pages with comprehensive content in Greek
- **Terms of Service** (`/legal/terms`): 11 sections covering orders, payments, returns, producer obligations, IP, liability
- **Privacy Policy** (`/legal/privacy`): 11 sections covering GDPR, data collection, cookies, user rights, third-party providers

## What Changed
- `app/legal/terms/page.tsx`: From 1-sentence placeholder → full ToS (126 lines)
- `app/legal/privacy/page.tsx`: From 1-sentence placeholder → full privacy policy (156 lines)

## Test Plan
- [ ] Visit `/legal/terms` → full terms of service displayed in Greek
- [ ] Visit `/legal/privacy` → full privacy policy displayed in Greek
- [ ] Footer links ("Όροι Χρήσης", "Πολιτική Απορρήτου") resolve correctly
- [ ] Both pages have correct metadata (title, description)
- [ ] `npm run build` passes with 0 errors

Pass: LEGAL-PAGES-01