### PR TITLE
fix(db): cache PrismaClient in production + Neon pooling

### DIFF
--- a/frontend/src/lib/db/client.ts
+++ b/frontend/src/lib/db/client.ts
@@ -4,6 +4,13 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === 'production' ? ['error'] : ['query', 'error', 'warn'],
+  });
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+// Cache singleton in ALL environments.
+// Production standalone server is long-lived (not serverless),
+// so reusing the client avoids connection churn with Neon.
+globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## Summary
- Cache PrismaClient singleton in production (was only cached in dev)
- Add `log: ['error']` config for production to reduce log noise
- Production DATABASE_URL updated with `pgbouncer=true&connection_limit=5&pool_timeout=20&connect_timeout=15` (SSH)

## Why
Neon serverless PostgreSQL connections close after idle timeout. The standalone server is long-lived (not serverless), so the singleton should always be cached. Previously, the `if (NODE_ENV !== 'production')` guard meant production never cached the client.

## Test plan
- [x] Typecheck passes
- [ ] CI build passes
- [ ] Deploy: verify no more "Connection Closed" errors in PM2 logs
- [ ] Verify all routes still work