### PR TITLE
docs: record PROD-STABILITY-02 pass

### DIFF
--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -1,6 +1,6 @@
 # AGENT-STATE — Dixis Canonical Entry Point
 
-**Updated**: 2026-02-11 (P3-DOCS-CLEANUP complete)
+**Updated**: 2026-02-11 (PROD-STABILITY-02 complete)
 
 > **This is THE entry point.** Read this first on every agent session. Single source of truth.
 
@@ -28,9 +28,9 @@ _(empty — pick from NEXT)_
 
 | Priority | Pass ID | Feature | Why |
 |----------|---------|---------|-----|
-| 1 | **OAUTH-GOOGLE-01** | Google OAuth login | Backend NOT ready (needs Socialite) |
-| 2 | **WISHLIST-01** | User wishlist feature | No implementation yet |
-| 3 | **AUDIT-BACKLOG-P2** | Error response standardization | 82 routes inconsistent |
+| 1 | **REORDER-01** | "Order Again" button | Core marketplace loop, repeat customers |
+| 2 | **OAUTH-GOOGLE-01** | Google OAuth login | Backend needs Socialite — verify first |
+| 3 | **UX-POLISH-01** | Empty states + loading skeletons | Professional feel |
 
 See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 
@@ -47,6 +47,8 @@ See `docs/PRODUCT/PRD-COVERAGE.md` for full mapping.
 
 ## Recently Done (last 10)
 
+- **PROD-STABILITY-02** — Infra hardening: nginx .bak cleanup, Prisma singleton caching in production, Neon connection pooling params (PR #2755, deployed 2026-02-11) ✅
+- **PROD-FIX-SPRINT-01** — 3 production fixes from E2E audit: cart toast feedback (PR #2749), legal pages content (PR #2751), producer dashboard redirect+auth (PR #2753). All deployed & verified (2026-02-11) ✅
 - **P3-DOCS-CLEANUP** — 13 env vars documented in .env.example, OPS/STATE.md synced, audit backlog cleared (2026-02-11) ✅
 - **ADMIN-BULK-STATUS-01** — Bulk order status update with checkboxes + toolbar (PR #2744, deployed 2026-02-11) ✅
 - **CLEANUP-SPRINT-01** — Codebase health: PrismaClient singleton (#2738), SQLite compat (#2739), docs sync (#2740), XSS fix (#2741), mock cleanup (#2743) ✅

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,11 +1,44 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-11 (P3-DOCS-CLEANUP)
+**Last Updated**: 2026-02-11 (PROD-STABILITY-02)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~600 lines (target ≤350). ⚠️ Over limit — archive next pass.
 >
 > **Key Docs**: [DEPLOY SOP](DEPLOY.md) | [STATE Archive](STATE-ARCHIVE/)
+
+---
+
+## 2026-02-11 — PROD-STABILITY-02: Infrastructure Hardening
+
+**Status**: ✅ DONE (PR #2755 merged & deployed)
+
+**What was done**:
+- Removed stale `dixis.gr.bak` from nginx `sites-enabled/` (was a duplicate server block)
+- Fixed PrismaClient singleton: now cached in ALL environments (was only dev)
+- Added production log config: errors-only to reduce noise
+- Added Neon connection pooling params to DATABASE_URL: `pgbouncer=true&connection_limit=5&pool_timeout=20&connect_timeout=15`
+
+**Result**: Zero Prisma "Connection Closed" errors after deploy (was 11+ per restart before).
+
+---
+
+## 2026-02-11 — PROD-FIX-SPRINT-01: Production E2E Audit Fixes
+
+**Status**: ✅ DONE (PRs #2749, #2751, #2753 — all merged & deployed)
+
+**What was done**:
+- **Cart UX (PR #2749)**: Added toast notification to product detail page `Add.tsx` (was only showing subtle `<p>` text), passed `imageUrl` from product pages to cart store
+- **Legal Pages (PR #2751)**: Replaced 1-sentence placeholder Terms & Privacy pages with comprehensive Greek legal content (11 sections each, GDPR-aware)
+- **Producer Dashboard (PR #2753)**: Created `/producer` index page with redirect to `/producer/dashboard` (was 404), replaced manual auth in analytics with `AuthGuard requireRole="producer"`
+
+**Deploy note**: Orphaned next-server process was serving stale cached 404 for `/producer`. Fixed by killing orphan, cleaning PM2, fresh start. PM2 saved.
+
+**Production verification**:
+- `/legal/terms` → 200 ✅
+- `/legal/privacy` → 200 ✅
+- `/producer` → 307 → `/producer/dashboard` ✅
+- All 15 critical routes verified via `curl` through nginx
 
 ---
 


### PR DESCRIPTION
## Summary
- Record PROD-STABILITY-02 in AGENT-STATE and OPS/STATE
- Update NEXT priorities (Reorder > OAuth > UX Polish)
- Document nginx cleanup, Prisma connection fix, Neon pooling params

## Test plan
- [x] Docs only — no code changes