### PR TITLE
fix: product image fallback + cart i18n (PROD-IMAGE-FIX-01)

### DIFF
--- a/frontend/src/app/(storefront)/cart/page.tsx
+++ b/frontend/src/app/(storefront)/cart/page.tsx
@@ -76,7 +76,7 @@ export default function CartPage() {
                 <span className="text-gray-600">Υποσύνολο</span>
                 <span className="text-lg font-bold" data-testid="total">Σύνολο: {fmt.format(totalCents / 100)}</span>
               </div>
-              <p className="text-xs text-gray-500 mt-2">Οι τελικές χρεώσεις (μεταφορικά/ΦΠΑ) υπολογίζονται στο checkout.</p>
+              <p className="text-xs text-gray-500 mt-2">Οι τελικές χρεώσεις (μεταφορικά/ΦΠΑ) υπολογίζονται κατά την ολοκλήρωση.</p>
               <button onClick={clear} className="mt-2 w-full inline-flex justify-center border border-red-300 text-red-600 px-4 py-2 rounded-lg hover:bg-red-50">
                 Καθαρισμός
               </button>
@@ -85,7 +85,7 @@ export default function CartPage() {
                 className="mt-4 w-full inline-flex justify-center bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700"
                 data-testid="go-checkout"
               >
-                Συνέχεια στο checkout
+                Ολοκλήρωση παραγγελίας
               </button>
               <Link href="/products" className="mt-2 w-full inline-flex justify-center border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50">
                 Συνέχεια αγορών

--- a/frontend/src/app/(storefront)/products/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/page.tsx
@@ -49,7 +49,7 @@ async function getProductById(id: string) {
       stock: raw.stock,
       isActive: raw.is_active !== false,
       category: raw.category,
-      imageUrl: raw.image_url,
+      imageUrl: raw.image_url || raw.images?.[0]?.url || null,
       producer: raw.producer ? { name: raw.producer.name } : null,
       // Pass HOTFIX-MP-CHECKOUT-GUARD-01: Include producer_id for multi-producer cart detection
       producerId: raw.producer_id || raw.producer?.id || null,

--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -76,7 +76,7 @@ async function getData(search?: string): Promise<{ items: ApiItem[]; total: numb
       producerId: p.producer?.id || null,
       producerName: p.producer?.name || null,
       priceCents: Math.round(parseFloat(p.price) * 100),
-      imageUrl: p.image_url,
+      imageUrl: p.image_url || p.images?.[0]?.url || null,
       categorySlug: p.category || null,
       stock: typeof p.stock === 'number' ? p.stock : null,
     }));


### PR DESCRIPTION
## Summary

- **Image fallback**: Products with `id≥10` have `image_url: null` but images in `images[]` array. Added fallback `p.image_url || p.images?.[0]?.url || null` on both listing and detail pages.
- **Cart i18n**: Replaced mixed Greek/English text ("Συνέχεια στο checkout", "υπολογίζονται στο checkout") with full Greek ("Ολοκλήρωση παραγγελίας", "υπολογίζονται κατά την ολοκλήρωση").

## Files changed (4 LOC)

| File | Change |
|------|--------|
| `products/page.tsx` | Image URL fallback in listing mapper |
| `products/[id]/page.tsx` | Image URL fallback in detail mapper |
| `cart/page.tsx` | Greek i18n for checkout button + disclaimer |

## Test plan

- [ ] Products listing: all product cards show images (no broken img placeholders)
- [ ] Product detail: image renders for products with id≥10
- [ ] Cart page: button says "Ολοκλήρωση παραγγελίας" (no English)
- [ ] Cart page: disclaimer says "κατά την ολοκλήρωση" (no English)
- [ ] `npm run build` passes