### PR TITLE
feat: auto-create Producer profile on producer registration

### DIFF
--- a/backend/app/Http/Controllers/Api/ProducerController.php
+++ b/backend/app/Http/Controllers/Api/ProducerController.php
@@ -176,13 +176,18 @@ class ProducerController extends Controller
             return response()->json(['message' => 'Unauthenticated'], 401);
         }
 
-        // Ensure user has a producer profile
+        // PRODUCER-ONBOARD-01: Return 200 with has_profile flag instead of 403
+        // This lets the frontend distinguish "no profile yet" from "unauthorized"
         if (! $user->producer) {
-            return response()->json(['message' => 'Producer profile not found'], 403);
+            return response()->json([
+                'producer' => null,
+                'has_profile' => false,
+            ]);
         }
 
         return response()->json([
             'producer' => new \App\Http\Resources\ProducerResource($user->producer),
+            'has_profile' => true,
         ]);
     }
 

--- a/backend/app/Models/Producer.php
+++ b/backend/app/Models/Producer.php
@@ -34,6 +34,7 @@ class Producer extends Model
         'status',
         'user_id',
         'is_active',
+        'rejection_reason',
     ];
 
     protected $casts = [

--- a/backend/database/migrations/2026_02_12_100000_add_rejection_reason_to_producers.php
+++ b/backend/database/migrations/2026_02_12_100000_add_rejection_reason_to_producers.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * PRODUCER-ONBOARD-01: Add rejection_reason for admin review workflow
+     */
+    public function up(): void
+    {
+        Schema::table('producers', function (Blueprint $table) {
+            $table->text('rejection_reason')->nullable()->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('producers', function (Blueprint $table) {
+            $table->dropColumn('rejection_reason');
+        });
+    }
+};


### PR DESCRIPTION
## Summary

**PRODUCER-ONBOARD-01 — PR 1/5**

Without producers, there is no marketplace. Currently, registering as a producer creates a User but **not** a Producer profile — so the producer dashboard is unreachable.

This PR fixes the core gap:
- **Auto-create Producer** when `role=producer` during registration (DB transaction)
- **Fix `/producer/me`** — returns `200 { producer: null, has_profile: false }` instead of `403` when no profile exists
- **Add `rejection_reason`** column to producers table (for admin approve/reject flow in PR 2)

## Changes

| File | Change |
|------|--------|
| `AuthController.php` | Wrap registration in `DB::transaction`, create Producer with `status=pending` |
| `ProducerController.php` | `me()` returns 200 + `has_profile` flag instead of 403 |
| `Producer.php` | Add `rejection_reason` to fillable |
| New migration | Add nullable `rejection_reason` text column |

## Acceptance Criteria

- [ ] `POST /api/v1/auth/register` with `role=producer` creates both User and Producer
- [ ] Producer has `status=pending`, `is_active=false`
- [ ] `GET /api/v1/producer/me` returns `{ producer: null, has_profile: false }` for users without profile
- [ ] `GET /api/v1/producer/me` returns `{ producer: {...}, has_profile: true }` for users with profile
- [ ] Migration adds `rejection_reason` column
- [ ] PHP syntax check passes (0 errors)

## Test Plan

- [ ] Register new producer → verify both user and producer records created
- [ ] Check producer record has status=pending, is_active=false
- [ ] Call /producer/me without profile → verify 200 response
- [ ] Call /producer/me with profile → verify producer data returned
- [ ] Run migration on production after merge

## Deploy Note

After merge, run on production:
```bash
ssh dixis-prod
cd /var/www/dixis/current
php artisan migrate
```