### PR TITLE
feat: admin endpoints to approve/reject producers

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/AdminProducerController.php
+++ b/backend/app/Http/Controllers/Api/Admin/AdminProducerController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Producer;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AdminProducerController extends Controller
+{
+    /**
+     * PRODUCER-ONBOARD-01: List producers with optional status filter
+     *
+     * Query params:
+     * - status: pending|active|inactive|all (default: all)
+     * - page: int (default 1)
+     * - per_page: int (default 20, max 100)
+     */
+    public function index(Request $request): JsonResponse
+    {
+        if (! $request->user() || $request->user()->role !== 'admin') {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $request->validate([
+            'status' => 'nullable|string|in:pending,active,inactive,all',
+            'page' => 'nullable|integer|min:1',
+            'per_page' => 'nullable|integer|min:1|max:100',
+        ]);
+
+        $status = $request->query('status', 'all');
+        $perPage = $request->query('per_page', 20);
+
+        $query = Producer::with('user:id,name,email,created_at')
+            ->orderBy('created_at', 'desc');
+
+        if ($status !== 'all') {
+            $query->where('status', $status);
+        }
+
+        $producers = $query->paginate($perPage);
+
+        return response()->json([
+            'data' => $producers->items(),
+            'current_page' => $producers->currentPage(),
+            'per_page' => $producers->perPage(),
+            'total' => $producers->total(),
+            'last_page' => $producers->lastPage(),
+        ]);
+    }
+
+    /**
+     * PRODUCER-ONBOARD-01: Approve a pending producer
+     */
+    public function approve(Request $request, Producer $producer): JsonResponse
+    {
+        if (! $request->user() || $request->user()->role !== 'admin') {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $producer->update([
+            'status' => 'active',
+            'is_active' => true,
+            'rejection_reason' => null,
+        ]);
+
+        return response()->json([
+            'message' => 'Producer approved successfully',
+            'producer' => $producer->fresh(),
+        ]);
+    }
+
+    /**
+     * PRODUCER-ONBOARD-01: Reject a producer application
+     */
+    public function reject(Request $request, Producer $producer): JsonResponse
+    {
+        if (! $request->user() || $request->user()->role !== 'admin') {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $request->validate([
+            'rejection_reason' => 'required|string|max:1000',
+        ]);
+
+        $producer->update([
+            'status' => 'inactive',
+            'is_active' => false,
+            'rejection_reason' => $request->input('rejection_reason'),
+        ]);
+
+        return response()->json([
+            'message' => 'Producer rejected',
+            'producer' => $producer->fresh(),
+        ]);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -369,6 +369,16 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:30,1'); // 30 simulations per minute
     });
 
+    // PRODUCER-ONBOARD-01: Admin Producer Management
+    Route::middleware('auth:sanctum')->prefix('admin/producers')->group(function () {
+        Route::get('/', [App\Http\Controllers\Api\Admin\AdminProducerController::class, 'index'])
+            ->middleware('throttle:60,1');
+        Route::patch('{producer}/approve', [App\Http\Controllers\Api\Admin\AdminProducerController::class, 'approve'])
+            ->middleware('throttle:30,1');
+        Route::patch('{producer}/reject', [App\Http\Controllers\Api\Admin\AdminProducerController::class, 'reject'])
+            ->middleware('throttle:30,1');
+    });
+
 });
 
 // Pass 51: Card payment checkout (authenticated)


### PR DESCRIPTION
## Summary

**PRODUCER-ONBOARD-01 — PR 2/5**

Admin endpoints to review, approve, and reject producer applications. Required for the admin approval workflow — after a producer registers (PR 1), admin needs API to manage them.

## New Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| `GET` | `/api/v1/admin/producers` | List producers (filter by status) |
| `PATCH` | `/api/v1/admin/producers/{id}/approve` | Approve producer → active |
| `PATCH` | `/api/v1/admin/producers/{id}/reject` | Reject producer (reason required) |

## Changes

| File | Change |
|------|--------|
| `AdminProducerController.php` (new) | index(), approve(), reject() with admin role check |
| `routes/api.php` | 3 new routes under `admin/producers` prefix |

## Acceptance Criteria

- [ ] `GET /admin/producers?status=pending` returns only pending producers
- [ ] `PATCH /admin/producers/{id}/approve` sets status=active, is_active=true
- [ ] `PATCH /admin/producers/{id}/reject` requires rejection_reason, sets status=inactive
- [ ] All endpoints require admin role (403 for non-admin)
- [ ] PHP syntax check passes

## Test Plan

- [ ] List all producers → verify pagination
- [ ] Filter by status=pending → verify only pending shown
- [ ] Approve producer → verify status changed to active
- [ ] Reject without reason → verify 422 validation error
- [ ] Reject with reason → verify status=inactive + reason saved
- [ ] Non-admin request → verify 403