### PR TITLE
refactor: wire admin producers to Laravel SSOT

### DIFF
--- a/frontend/src/app/api/admin/producers/[id]/approve/route.ts
+++ b/frontend/src/app/api/admin/producers/[id]/approve/route.ts
@@ -1,82 +1,66 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@/lib/db/client'
-import { requireAdmin, AdminError } from '@/lib/auth/admin'
-import { logAdminAction, createApprovalContext } from '@/lib/audit/logger'
+import { requireAdmin } from '@/lib/auth/admin'
+import { getLaravelInternalUrl } from '@/env'
+import { cookies } from 'next/headers'
 
 /**
- * POST /api/admin/producers/[id]/approve
- * Approves a producer (sets approvalStatus to 'approved')
+ * PRODUCER-ONBOARD-01: Approve producer — proxy to Laravel SSOT
+ * Replaces previous Prisma-based approve with Laravel admin endpoint
  */
+
+async function getAuthToken(req: NextRequest): Promise<string | null> {
+  const cookieStore = await cookies()
+  return cookieStore.get('auth_token')?.value
+    || cookieStore.get('dixis_session')?.value
+    || req.headers.get('authorization')?.replace('Bearer ', '')
+    || null
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    // Get admin context for audit logging
-    const admin = await requireAdmin()
-    const { id: producerId } = await params
+    await requireAdmin()
+  } catch {
+    return NextResponse.json({ error: 'Απαιτείται σύνδεση διαχειριστή' }, { status: 403 })
+  }
 
-    if (!producerId) {
-      return NextResponse.json({ error: 'Invalid producer ID' }, { status: 400 })
+  const { id: producerId } = await params
+
+  if (!producerId) {
+    return NextResponse.json({ error: 'Invalid producer ID' }, { status: 400 })
+  }
+
+  try {
+    const token = await getAuthToken(request)
+    const laravelBase = getLaravelInternalUrl()
+    const url = `${laravelBase}/admin/producers/${producerId}/approve`
+
+    const headers: Record<string, string> = {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    }
+    if (token) headers['Authorization'] = `Bearer ${token}`
+
+    const res = await fetch(url, { method: 'PATCH', headers, cache: 'no-store' })
+
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({}))
+      return NextResponse.json(
+        { error: errorData.message || 'Σφάλμα έγκρισης παραγωγού' },
+        { status: res.status }
+      )
     }
 
-    // Fetch existing producer for audit log (oldValue)
-    const existingProducer = await prisma.producer.findUnique({
-      where: { id: producerId },
-      select: { id: true, name: true, approvalStatus: true, isActive: true }
-    })
-
-    if (!existingProducer) {
-      return NextResponse.json({ error: 'Ο παραγωγός δεν βρέθηκε' }, { status: 404 })
-    }
-
-    // Update producer
-    const producer = await prisma.producer.update({
-      where: { id: producerId },
-      data: {
-        approvalStatus: 'approved',
-        isActive: true,
-        rejectionReason: null
-      },
-      select: {
-        id: true,
-        name: true,
-        approvalStatus: true,
-        isActive: true
-      }
-    })
-
-    // Audit log
-    await logAdminAction({
-      admin,
-      action: 'PRODUCER_APPROVE',
-      entityType: 'producer',
-      entityId: producerId,
-      ...createApprovalContext(existingProducer)
-    })
-
+    const data = await res.json()
     return NextResponse.json({
       success: true,
-      message: 'Ο παραγωγός εγκρίθηκε επιτυχώς',
-      producer
+      message: data.message || 'Ο παραγωγός εγκρίθηκε επιτυχώς',
+      producer: data.producer,
     })
-
-  } catch (error: unknown) {
-    console.error('Producer approval error:', error)
-
-    // Handle AdminError
-    if (error instanceof AdminError) {
-      if (error.code === 'NOT_AUTHENTICATED') {
-        return NextResponse.json({ error: 'Απαιτείται σύνδεση' }, { status: 401 })
-      }
-      return NextResponse.json({ error: 'Απαιτείται σύνδεση διαχειριστή' }, { status: 403 })
-    }
-
-    // Handle Prisma errors
-    if ((error as any)?.code === 'P2025') {
-      return NextResponse.json({ error: 'Ο παραγωγός δεν βρέθηκε' }, { status: 404 })
-    }
-
+  } catch (error) {
+    console.error('[Admin] Producer approve proxy error:', error)
     return NextResponse.json({ error: 'Σφάλμα διακομιστή' }, { status: 500 })
   }
 }

--- a/frontend/src/app/api/admin/producers/[id]/reject/route.ts
+++ b/frontend/src/app/api/admin/producers/[id]/reject/route.ts
@@ -1,98 +1,81 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@/lib/db/client'
-import { requireAdmin, AdminError } from '@/lib/auth/admin'
-import { logAdminAction, createRejectionContext } from '@/lib/audit/logger'
-import { z } from 'zod'
-
-const RejectSchema = z.object({
-  rejectionReason: z.string().min(5, 'Ο λόγος απόρριψης πρέπει να έχει τουλάχιστον 5 χαρακτήρες')
-})
+import { requireAdmin } from '@/lib/auth/admin'
+import { getLaravelInternalUrl } from '@/env'
+import { cookies } from 'next/headers'
 
 /**
- * POST /api/admin/producers/[id]/reject
- * Rejects a producer (sets approvalStatus to 'rejected')
+ * PRODUCER-ONBOARD-01: Reject producer — proxy to Laravel SSOT
+ * Replaces previous Prisma-based reject with Laravel admin endpoint
  */
+
+async function getAuthToken(req: NextRequest): Promise<string | null> {
+  const cookieStore = await cookies()
+  return cookieStore.get('auth_token')?.value
+    || cookieStore.get('dixis_session')?.value
+    || req.headers.get('authorization')?.replace('Bearer ', '')
+    || null
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    // Get admin context for audit logging
-    const admin = await requireAdmin()
-    const { id: producerId } = await params
+    await requireAdmin()
+  } catch {
+    return NextResponse.json({ error: 'Απαιτείται σύνδεση διαχειριστή' }, { status: 403 })
+  }
 
-    if (!producerId) {
-      return NextResponse.json({ error: 'Invalid producer ID' }, { status: 400 })
+  const { id: producerId } = await params
+
+  if (!producerId) {
+    return NextResponse.json({ error: 'Invalid producer ID' }, { status: 400 })
+  }
+
+  const body = await request.json().catch(() => ({}))
+  const rejectionReason = body.rejectionReason || body.rejection_reason
+
+  if (!rejectionReason || typeof rejectionReason !== 'string' || rejectionReason.length < 5) {
+    return NextResponse.json(
+      { error: 'Ο λόγος απόρριψης πρέπει να έχει τουλάχιστον 5 χαρακτήρες' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const token = await getAuthToken(request)
+    const laravelBase = getLaravelInternalUrl()
+    const url = `${laravelBase}/admin/producers/${producerId}/reject`
+
+    const headers: Record<string, string> = {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
     }
+    if (token) headers['Authorization'] = `Bearer ${token}`
 
-    const body = await request.json().catch(() => ({}))
-    const parsed = RejectSchema.safeParse(body)
+    const res = await fetch(url, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ rejection_reason: rejectionReason }),
+      cache: 'no-store',
+    })
 
-    if (!parsed.success) {
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({}))
       return NextResponse.json(
-        { error: parsed.error.errors[0]?.message || 'Λάθος δεδομένα' },
-        { status: 400 }
+        { error: errorData.message || 'Σφάλμα απόρριψης παραγωγού' },
+        { status: res.status }
       )
     }
 
-    // Fetch existing producer for audit log (oldValue)
-    const existingProducer = await prisma.producer.findUnique({
-      where: { id: producerId },
-      select: { id: true, name: true, approvalStatus: true, isActive: true }
-    })
-
-    if (!existingProducer) {
-      return NextResponse.json({ error: 'Ο παραγωγός δεν βρέθηκε' }, { status: 404 })
-    }
-
-    // Update producer
-    const producer = await prisma.producer.update({
-      where: { id: producerId },
-      data: {
-        approvalStatus: 'rejected',
-        isActive: false,
-        rejectionReason: parsed.data.rejectionReason
-      },
-      select: {
-        id: true,
-        name: true,
-        approvalStatus: true,
-        isActive: true,
-        rejectionReason: true
-      }
-    })
-
-    // Audit log with rejection reason
-    await logAdminAction({
-      admin,
-      action: 'PRODUCER_REJECT',
-      entityType: 'producer',
-      entityId: producerId,
-      ...createRejectionContext(existingProducer, parsed.data.rejectionReason)
-    })
-
+    const data = await res.json()
     return NextResponse.json({
       success: true,
-      message: 'Ο παραγωγός απορρίφθηκε',
-      producer
+      message: data.message || 'Ο παραγωγός απορρίφθηκε',
+      producer: data.producer,
     })
-
-  } catch (error: unknown) {
-    console.error('Producer rejection error:', error)
-
-    // Handle AdminError
-    if (error instanceof AdminError) {
-      if (error.code === 'NOT_AUTHENTICATED') {
-        return NextResponse.json({ error: 'Απαιτείται σύνδεση' }, { status: 401 })
-      }
-      return NextResponse.json({ error: 'Απαιτείται σύνδεση διαχειριστή' }, { status: 403 })
-    }
-
-    // Handle Prisma errors
-    if ((error as any)?.code === 'P2025') {
-      return NextResponse.json({ error: 'Ο παραγωγός δεν βρέθηκε' }, { status: 404 })
-    }
-
+  } catch (error) {
+    console.error('[Admin] Producer reject proxy error:', error)
     return NextResponse.json({ error: 'Σφάλμα διακομιστή' }, { status: 500 })
   }
 }

--- a/frontend/src/app/api/admin/producers/route.ts
+++ b/frontend/src/app/api/admin/producers/route.ts
@@ -1,35 +1,22 @@
-import { NextResponse } from 'next/server'
-import { z } from 'zod'
-import { getRequestId, logWithId } from '@/lib/observability/request'
+import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth/admin'
 import { getLaravelInternalUrl } from '@/env'
 import { cookies } from 'next/headers'
 
 /**
- * Phase 5.2: Admin producer routes now proxy to Laravel (SSOT).
- * Admin authentication still uses Prisma AdminUser table.
- * Producer CRUD goes to Laravel so producers appear on the storefront.
+ * PRODUCER-ONBOARD-01: Admin producer list — proxy to Laravel SSOT
+ * Replaces previous public-endpoint proxy with admin-authenticated endpoint
  */
 
-const CreateSchema = z.object({
-  name: z.string().min(2),
-  slug: z.string().min(2),
-  region: z.string().min(2),
-  category: z.string().min(2),
-  description: z.string().optional(),
-  email: z.string().email().optional().or(z.literal('').transform((): undefined => undefined)),
-  phone: z.string().optional(),
-  isActive: z.boolean().optional()
-})
-
-async function getSessionToken(): Promise<string | null> {
+async function getAuthToken(req: NextRequest): Promise<string | null> {
   const cookieStore = await cookies()
-  return cookieStore.get('dixis_session')?.value ?? null
+  return cookieStore.get('auth_token')?.value
+    || cookieStore.get('dixis_session')?.value
+    || req.headers.get('authorization')?.replace('Bearer ', '')
+    || null
 }
 
-export async function GET(req: Request) {
-  const rid = getRequestId(req.headers)
-
+export async function GET(req: NextRequest) {
   try {
     await requireAdmin()
   } catch {
@@ -37,143 +24,45 @@ export async function GET(req: Request) {
   }
 
   const { searchParams } = new URL(req.url)
-  const q = searchParams.get('q') || ''
-  const active = searchParams.get('active') || ''
-  const sort = searchParams.get('sort') || 'name-asc'
+  const status = searchParams.get('status') || 'all'
 
   try {
-    // Proxy to Laravel public producers endpoint
+    const token = await getAuthToken(req)
     const laravelBase = getLaravelInternalUrl()
-    const url = new URL(`${laravelBase}/public/producers`)
-    if (q) url.searchParams.set('search', q)
+    const url = new URL(`${laravelBase}/admin/producers`)
+    url.searchParams.set('status', status)
     url.searchParams.set('per_page', '100')
 
-    const res = await fetch(url.toString(), {
-      headers: { 'Accept': 'application/json' },
-      cache: 'no-store',
-    })
+    const headers: Record<string, string> = { 'Accept': 'application/json' }
+    if (token) headers['Authorization'] = `Bearer ${token}`
+
+    const res = await fetch(url.toString(), { headers, cache: 'no-store' })
 
     if (!res.ok) {
-      console.error('[Admin] Laravel producers fetch failed:', res.status)
       return NextResponse.json({ error: 'Σφάλμα ανάκτησης παραγωγών' }, { status: res.status })
     }
 
     const json = await res.json()
     const producers = json?.data ?? []
 
-    // Map Laravel format to admin panel format and apply filters
+    // Map Laravel format to admin panel format
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let items = producers.map((p: any) => ({
+    const items = producers.map((p: any) => ({
       id: String(p.id),
       name: p.name,
-      region: p.location || p.region || '',
-      category: p.category || '',
+      businessName: p.business_name || '',
+      region: p.region || p.location || '',
+      status: p.status || 'pending',
       isActive: p.is_active !== false,
-      approvalStatus: p.approval_status || 'approved',
       rejectionReason: p.rejection_reason || null,
+      email: p.email || p.user?.email || '',
+      phone: p.phone || '',
+      createdAt: p.created_at,
     }))
 
-    // Apply active filter
-    if (active === 'only') {
-      items = items.filter((p: { isActive: boolean }) => p.isActive)
-    }
-
-    // Apply sort
-    if (sort === 'name-desc') {
-      items.sort((a: { name: string }, b: { name: string }) => b.name.localeCompare(a.name, 'el'))
-    } else {
-      items.sort((a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name, 'el'))
-    }
-
-    const response = NextResponse.json({ items })
-    response.headers.set('x-request-id', rid)
-    logWithId(rid, 'GET /api/admin/producers [laravel-proxy]', { count: items.length, q, active, sort })
-    return response
+    return NextResponse.json({ items, total: json.total || items.length })
   } catch (error) {
     console.error('[Admin] Producers proxy error:', error)
     return NextResponse.json({ error: 'Σφάλμα διακομιστή' }, { status: 500 })
-  }
-}
-
-export async function POST(req: Request) {
-  const rid = getRequestId(req.headers)
-
-  try {
-    await requireAdmin()
-  } catch {
-    return NextResponse.json({ error: 'Απαιτείται σύνδεση διαχειριστή' }, { status: 403 })
-  }
-
-  const data = await req.json().catch(() => ({}))
-  const parsed = CreateSchema.safeParse(data)
-
-  if (!parsed.success) {
-    const res = NextResponse.json(
-      { error: 'Λάθος δεδομένα', issues: parsed.error.format() },
-      { status: 400 }
-    )
-    res.headers.set('x-request-id', rid)
-    logWithId(rid, 'POST /api/admin/producers [validation error]', { error: parsed.error.format() })
-    return res
-  }
-
-  try {
-    const sessionToken = await getSessionToken()
-    const laravelBase = getLaravelInternalUrl()
-    const url = new URL(`${laravelBase}/producers`)
-
-    // Map to Laravel format
-    const laravelPayload = {
-      name: parsed.data.name,
-      slug: parsed.data.slug,
-      location: parsed.data.region,
-      description: parsed.data.description || null,
-      email: parsed.data.email || null,
-      phone: parsed.data.phone || null,
-      is_active: parsed.data.isActive ?? true,
-    }
-
-    const headers: Record<string, string> = {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-    }
-    if (sessionToken) {
-      headers['Authorization'] = `Bearer ${sessionToken}`
-    }
-
-    const response = await fetch(url.toString(), {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(laravelPayload),
-    })
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}))
-      console.error('[Admin] Laravel producer create failed:', response.status, errorData)
-      return NextResponse.json(
-        { error: errorData.message || 'Σφάλμα δημιουργίας παραγωγού' },
-        { status: response.status }
-      )
-    }
-
-    const result = await response.json()
-    const producer = result.data || result
-
-    const item = {
-      id: String(producer.id),
-      name: producer.name,
-      slug: producer.slug,
-      region: producer.location || parsed.data.region,
-      category: parsed.data.category,
-      isActive: producer.is_active !== false,
-    }
-
-    const res = NextResponse.json({ item }, { status: 201 })
-    res.headers.set('x-request-id', rid)
-    logWithId(rid, 'POST /api/admin/producers [created via laravel]', { id: item.id, name: item.name })
-    return res
-  } catch (error) {
-    console.error('[Admin] Producer create proxy error:', error)
-    return NextResponse.json({ error: 'Σφάλμα δημιουργίας παραγωγού' }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary

**PRODUCER-ONBOARD-01 — PR 4/5**

Rewires the admin producer management proxy routes from Prisma to Laravel. Previously, approve/reject used Prisma directly (hitting SQLite in CI, PostgreSQL in prod). Now they proxy to the new Laravel admin endpoints from PR 2.

## Changes

| File | Before | After |
|------|--------|-------|
| `api/admin/producers/route.ts` | Proxy to public `/producers` | Proxy to `admin/producers` with auth |
| `[id]/approve/route.ts` | Prisma update | PATCH to Laravel `admin/producers/{id}/approve` |
| `[id]/reject/route.ts` | Prisma update | PATCH to Laravel `admin/producers/{id}/reject` |

## Key Improvements

- **Prisma removed**: No more direct DB access from Next.js for producer operations
- **Laravel SSOT**: All producer state managed by Laravel
- **Auth forwarded**: `auth_token` cookie forwarded to Laravel for admin verification
- **Net reduction**: -270 lines, +126 lines (simpler code)

## Acceptance Criteria

- [ ] Admin can list producers with status filter
- [ ] Admin can approve a pending producer
- [ ] Admin can reject with reason
- [ ] Non-admin gets 403
- [ ] TypeScript compiles (0 errors)