### PR TITLE
feat: email notifications for producer approve/reject

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/AdminProducerController.php
+++ b/backend/app/Http/Controllers/Api/Admin/AdminProducerController.php
@@ -3,9 +3,12 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Mail\ProducerApproved;
+use App\Mail\ProducerRejected;
 use App\Models\Producer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
 
 class AdminProducerController extends Controller
 {
@@ -65,6 +68,11 @@ class AdminProducerController extends Controller
             'rejection_reason' => null,
         ]);
 
+        // PRODUCER-ONBOARD-01: Send approval notification email
+        if ($producer->email && config('notifications.email_enabled', false)) {
+            Mail::to($producer->email)->send(new ProducerApproved($producer));
+        }
+
         return response()->json([
             'message' => 'Producer approved successfully',
             'producer' => $producer->fresh(),
@@ -89,6 +97,11 @@ class AdminProducerController extends Controller
             'is_active' => false,
             'rejection_reason' => $request->input('rejection_reason'),
         ]);
+
+        // PRODUCER-ONBOARD-01: Send rejection notification email
+        if ($producer->email && config('notifications.email_enabled', false)) {
+            Mail::to($producer->email)->send(new ProducerRejected($producer->fresh()));
+        }
 
         return response()->json([
             'message' => 'Producer rejected',

--- a/backend/app/Mail/ProducerApproved.php
+++ b/backend/app/Mail/ProducerApproved.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Producer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * PRODUCER-ONBOARD-01: Notify producer when their application is approved
+ */
+class ProducerApproved extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public Producer $producer
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Η αίτησή σας εγκρίθηκε! - Dixis',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.producers.approved',
+            with: [
+                'producerName' => $this->producer->business_name ?: $this->producer->name,
+                'dashboardUrl' => config('app.frontend_url', 'https://dixis.gr') . '/producer/dashboard',
+            ],
+        );
+    }
+}

--- a/backend/app/Mail/ProducerRejected.php
+++ b/backend/app/Mail/ProducerRejected.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Producer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * PRODUCER-ONBOARD-01: Notify producer when their application is rejected
+ */
+class ProducerRejected extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public Producer $producer
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Ενημέρωση αίτησης - Dixis',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.producers.rejected',
+            with: [
+                'producerName' => $this->producer->business_name ?: $this->producer->name,
+                'rejectionReason' => $this->producer->rejection_reason,
+                'contactEmail' => 'info@dixis.gr',
+            ],
+        );
+    }
+}

--- a/backend/resources/views/emails/producers/approved.blade.php
+++ b/backend/resources/views/emails/producers/approved.blade.php
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="el">
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #1a1a1a;">
+
+<div style="text-align: center; margin-bottom: 30px;">
+    <h1 style="color: #16a34a; font-size: 24px; margin: 0;">Dixis</h1>
+</div>
+
+<h2 style="color: #166534;">Η αίτησή σας εγκρίθηκε!</h2>
+
+<p>Αγαπητέ/ή <strong>{{ $producerName }}</strong>,</p>
+
+<p>Με χαρά σας ενημερώνουμε ότι η αίτηση εγγραφής σας ως παραγωγός στο Dixis <strong>εγκρίθηκε</strong>.</p>
+
+<p>Μπορείτε τώρα να:</p>
+<ul>
+    <li>Προσθέσετε τα προϊόντα σας</li>
+    <li>Διαχειριστείτε τις παραγγελίες σας</li>
+    <li>Δείτε τα στατιστικά πωλήσεών σας</li>
+</ul>
+
+<div style="text-align: center; margin: 30px 0;">
+    <a href="{{ $dashboardUrl }}" style="background-color: #16a34a; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: bold;">
+        Μετάβαση στο Dashboard
+    </a>
+</div>
+
+<p style="color: #666; font-size: 14px;">
+    Αν έχετε ερωτήσεις, επικοινωνήστε μαζί μας στο
+    <a href="mailto:info@dixis.gr">info@dixis.gr</a>
+</p>
+
+<hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
+<p style="color: #999; font-size: 12px; text-align: center;">Dixis - Marketplace</p>
+
+</body>
+</html>

--- a/backend/resources/views/emails/producers/rejected.blade.php
+++ b/backend/resources/views/emails/producers/rejected.blade.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="el">
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #1a1a1a;">
+
+<div style="text-align: center; margin-bottom: 30px;">
+    <h1 style="color: #16a34a; font-size: 24px; margin: 0;">Dixis</h1>
+</div>
+
+<h2 style="color: #991b1b;">Ενημέρωση Αίτησης</h2>
+
+<p>Αγαπητέ/ή <strong>{{ $producerName }}</strong>,</p>
+
+<p>Δυστυχώς, η αίτηση εγγραφής σας ως παραγωγός στο Dixis δεν εγκρίθηκε.</p>
+
+@if($rejectionReason)
+<div style="background-color: #fef2f2; border: 1px solid #fecaca; border-radius: 6px; padding: 16px; margin: 20px 0;">
+    <strong>Λόγος:</strong>
+    <p style="margin: 8px 0 0;">{{ $rejectionReason }}</p>
+</div>
+@endif
+
+<p>
+    Αν πιστεύετε ότι υπήρξε κάποιο λάθος ή θέλετε περισσότερες πληροφορίες,
+    επικοινωνήστε μαζί μας στο
+    <a href="mailto:{{ $contactEmail }}">{{ $contactEmail }}</a>.
+</p>
+
+<hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
+<p style="color: #999; font-size: 12px; text-align: center;">Dixis - Marketplace</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

**PRODUCER-ONBOARD-01 — PR 5/5** (Final)

Email notifications when admin approves or rejects a producer application. Completes the producer onboarding feature.

## New Files

| File | Purpose |
|------|---------|
| `ProducerApproved.php` | Mailable: approval congratulations + dashboard link |
| `ProducerRejected.php` | Mailable: rejection notification + reason + contact info |
| `approved.blade.php` | Greek HTML email template |
| `rejected.blade.php` | Greek HTML email template |

## Modified

| File | Change |
|------|--------|
| `AdminProducerController.php` | Hook Mail::send after approve/reject |

## Guard

Emails only sent when `config('notifications.email_enabled')` is true. No emails in test/dev.

## Acceptance Criteria

- [ ] Approve → producer receives approval email
- [ ] Reject → producer receives rejection email with reason
- [ ] Emails in Greek, consistent with existing templates
- [ ] No emails when email_enabled=false
- [ ] PHP syntax check passes

## PRODUCER-ONBOARD-01 Complete!

All 5 PRs:
- [x] PR 1: Auto-create Producer on registration (#2760)
- [x] PR 2: Admin approve/reject endpoints (#2761)
- [x] PR 3: Frontend onboarding form (#2762)
- [x] PR 4: Wire admin to Laravel (#2763)
- [x] PR 5: Email notifications (this PR)