### PR TITLE
feat(seed): hellenize seed data — Greek producers, products, categories

### DIFF
--- a/backend/database/seeders/CategorySeeder.php
+++ b/backend/database/seeders/CategorySeeder.php
@@ -13,30 +13,31 @@ class CategorySeeder extends Seeder
      */
     public function run(): void
     {
+        // Greek-first category names (slug stays English for URLs)
         $categories = [
-            'Fruits',
-            'Vegetables',
-            'Herbs & Spices',
-            'Grains & Cereals',
-            'Dairy Products',
-            'Olive Oil & Olives',
-            'Wine & Beverages',
-            'Honey & Preserves',
+            'fruits' => 'Φρούτα',
+            'vegetables' => 'Λαχανικά',
+            'herbs-spices' => 'Βότανα & Μπαχαρικά',
+            'grains-cereals' => 'Δημητριακά & Όσπρια',
+            'dairy-products' => 'Γαλακτοκομικά',
+            'olive-oil-olives' => 'Ελαιόλαδο & Ελιές',
+            'wine-beverages' => 'Κρασιά & Ποτά',
+            'honey-preserves' => 'Μέλι & Κονσέρβες',
             // Phase 3: Categories needed by Greek storefront products
-            'Legumes',
-            'Pasta & Trahanas',
-            'Flours & Bakery',
-            'Nuts & Dried Fruits',
-            'Sweets & Preserves',
-            'Sauces & Pickles',
+            'legumes' => 'Όσπρια',
+            'pasta-trahanas' => 'Ζυμαρικά & Τραχανάς',
+            'flours-bakery' => 'Αλεύρια & Αρτοποιία',
+            'nuts-dried-fruits' => 'Ξηροί Καρποί',
+            'sweets-preserves' => 'Γλυκά & Μαρμελάδες',
+            'sauces-pickles' => 'Σάλτσες & Τουρσιά',
         ];
 
-        foreach ($categories as $categoryName) {
+        foreach ($categories as $slug => $greekName) {
             Category::firstOrCreate([
-                'slug' => Str::slug($categoryName),
+                'slug' => $slug,
             ], [
-                'name' => $categoryName,
-                'slug' => Str::slug($categoryName),
+                'name' => $greekName,
+                'slug' => $slug,
             ]);
         }
     }

--- a/backend/database/seeders/GreekProductSeeder.php
+++ b/backend/database/seeders/GreekProductSeeder.php
@@ -23,16 +23,16 @@ class GreekProductSeeder extends Seeder
 
         $malisUser = User::firstOrCreate(
             ['email' => 'malis@dixis.gr'],
-            ['name' => 'Malis Garden', 'password' => bcrypt('demo-seed-2026')]
+            ['name' => 'Κήπος Μάλη', 'password' => bcrypt('demo-seed-2026')]
         );
         $malis = Producer::firstOrCreate(
             ['slug' => 'malis-garden'],
             [
                 'user_id' => $malisUser->id,
-                'name' => 'Malis Garden',
-                'business_name' => 'Malis Garden',
-                'description' => 'Παραδοσιακό βιολογικό αγρόκτημα με ελαιόλαδο και κονσέρβες',
-                'location' => 'Attica',
+                'name' => 'Κήπος Μάλη',
+                'business_name' => 'Κήπος Μάλη',
+                'description' => 'Παραδοσιακό βιολογικό αγρόκτημα με ελαιόλαδο και κονσέρβες στην Αττική.',
+                'location' => 'Αττική',
                 'phone' => '+30 210 0000001',
                 'email' => 'malis@dixis.gr',
                 'status' => 'active',
@@ -42,17 +42,17 @@ class GreekProductSeeder extends Seeder
 
         $lemnosUser = User::firstOrCreate(
             ['email' => 'lemnos@dixis.gr'],
-            ['name' => 'Lemnos Honey Co', 'password' => bcrypt('demo-seed-2026')]
+            ['name' => 'Μελισσοκομία Λήμνου', 'password' => bcrypt('demo-seed-2026')]
         );
         $lemnos = Producer::firstOrCreate(
             ['slug' => 'lemnos-honey-co'],
             [
                 'user_id' => $lemnosUser->id,
-                'name' => 'Lemnos Honey Co',
-                'business_name' => 'Lemnos Honey Co',
-                'description' => 'Οικογενειακή μελισσοκομία με premium θυμαρίσιο μέλι',
-                'location' => 'Lemnos',
-                'phone' => '+30 210 0000002',
+                'name' => 'Μελισσοκομία Λήμνου',
+                'business_name' => 'Μελισσοκομία Λήμνου',
+                'description' => 'Οικογενειακή μελισσοκομία τρίτης γενιάς με premium θυμαρίσιο μέλι από τη Λήμνο.',
+                'location' => 'Λήμνος',
+                'phone' => '+30 254 0000002',
                 'email' => 'lemnos@dixis.gr',
                 'status' => 'active',
                 'is_active' => true,
@@ -73,7 +73,7 @@ class GreekProductSeeder extends Seeder
                 'data' => [
                     'name' => 'Εξαιρετικό Παρθένο Ελαιόλαδο 1L',
                     'slug' => 'exairetiko-partheno-elaiolado-1l',
-                    'description' => 'Extra virgin olive oil from organic olives',
+                    'description' => 'Εξαιρετικό παρθένο ελαιόλαδο από βιολογικές ελιές της Αττικής. Χαμηλή οξύτητα, πλούσιο άρωμα.',
                     'price' => 10.90,
                     'unit' => 'bottle',
                     'stock' => 45,
@@ -88,7 +88,7 @@ class GreekProductSeeder extends Seeder
                 'data' => [
                     'name' => 'Γλυκό Κουταλιού Σύκο 380g',
                     'slug' => 'glyko-koutaliou-syko-380g',
-                    'description' => 'Traditional fig spoon sweet',
+                    'description' => 'Παραδοσιακό γλυκό κουταλιού σύκο, φτιαγμένο με τον παλιό τρόπο από φρέσκα σύκα.',
                     'price' => 4.50,
                     'unit' => 'jar',
                     'stock' => 30,
@@ -103,7 +103,7 @@ class GreekProductSeeder extends Seeder
                 'data' => [
                     'name' => 'Φέτα ΠΟΠ Μυτιλήνης 400g',
                     'slug' => 'feta-pop-mytilinis',
-                    'description' => 'Authentic PDO feta cheese from Mytilini',
+                    'description' => 'Αυθεντική φέτα ΠΟΠ Μυτιλήνης από γάλα ελευθέρας βοσκής. Κρεμώδης και αρωματική.',
                     'price' => 6.50,
                     'unit' => 'pack',
                     'stock' => 25,
@@ -118,7 +118,7 @@ class GreekProductSeeder extends Seeder
                 'data' => [
                     'name' => 'Πορτοκάλια Βιολογικά 5kg',
                     'slug' => 'portokalia-viologika',
-                    'description' => 'Organic oranges from Argolida',
+                    'description' => 'Βιολογικά πορτοκάλια Αργολίδας, γεμάτα χυμό. Ιδανικά για φρέσκο χυμό και κατανάλωση.',
                     'price' => 8.90,
                     'unit' => 'box',
                     'stock' => 60,
@@ -133,7 +133,7 @@ class GreekProductSeeder extends Seeder
                 'data' => [
                     'name' => 'Πατάτες Νάξου 3kg',
                     'slug' => 'patates-naxou',
-                    'description' => 'Famous potatoes from Naxos island',
+                    'description' => 'Οι φημισμένες πατάτες Νάξου ΠΓΕ. Τραγανές, αρωματικές, ιδανικές για τηγάνισμα και φούρνο.',
                     'price' => 4.90,
                     'unit' => 'bag',
                     'stock' => 100,
@@ -148,7 +148,7 @@ class GreekProductSeeder extends Seeder
                 'data' => [
                     'name' => 'Τραχανάς Σπιτικός 500g',
                     'slug' => 'trachanas-spitikos',
-                    'description' => 'Traditional homemade trahanas',
+                    'description' => 'Σπιτικός τραχανάς φτιαγμένος με παραδοσιακή συνταγή από ξινόγαλο και σιτάρι.',
                     'price' => 5.50,
                     'unit' => 'pack',
                     'stock' => 40,
@@ -165,7 +165,7 @@ class GreekProductSeeder extends Seeder
                 'data' => [
                     'name' => 'Θυμαρίσιο Μέλι 450g',
                     'slug' => 'thymarisio-meli-450g',
-                    'description' => 'Premium thyme honey from Lemnos island',
+                    'description' => 'Premium θυμαρίσιο μέλι από τη Λήμνο. Πυκνό, αρωματικό, με χαρακτηριστική χρυσή απόχρωση.',
                     'price' => 7.90,
                     'unit' => 'jar',
                     'stock' => 50,
@@ -180,7 +180,7 @@ class GreekProductSeeder extends Seeder
                 'data' => [
                     'name' => 'Τσίπουρο Παραδοσιακό 700ml',
                     'slug' => 'tsipouro-paradosiako',
-                    'description' => 'Traditional Greek tsipouro spirit',
+                    'description' => 'Παραδοσιακό τσίπουρο χωρίς γλυκάνισο, απόσταξη σε χάλκινο καζάνι. Ήπια γεύση, καθαρό άρωμα.',
                     'price' => 12.90,
                     'unit' => 'bottle',
                     'stock' => 20,
@@ -195,7 +195,7 @@ class GreekProductSeeder extends Seeder
                 'data' => [
                     'name' => 'Ρίγανη Βουνού 100g',
                     'slug' => 'rigani-vounou',
-                    'description' => 'Wild mountain oregano from Epirus',
+                    'description' => 'Άγρια ρίγανη βουνού από την Ήπειρο. Αρωματική, ξηραμένη στον ήλιο με τον παραδοσιακό τρόπο.',
                     'price' => 3.50,
                     'unit' => 'pack',
                     'stock' => 80,
@@ -210,7 +210,7 @@ class GreekProductSeeder extends Seeder
                 'data' => [
                     'name' => 'Κρασί Λήμνου Ερυθρό 750ml',
                     'slug' => 'krasi-limnou-erythro',
-                    'description' => 'Red wine from Lemnos vineyards',
+                    'description' => 'Ερυθρό κρασί από τους αμπελώνες της Λήμνου. Ξηρό, με νότες μαύρων φρούτων και μπαχαρικών.',
                     'price' => 9.90,
                     'unit' => 'bottle',
                     'stock' => 30,

--- a/backend/database/seeders/ProducerSeeder.php
+++ b/backend/database/seeders/ProducerSeeder.php
@@ -15,27 +15,27 @@ class ProducerSeeder extends Seeder
      */
     public function run(): void
     {
-        // Producer 1: Green Farm Co. (linked to producer@example.com)
+        // Παραγωγός 1: Κτήμα Παπαδόπουλου (linked to producer@example.com)
         $producerUser = User::where('email', 'producer@example.com')->first();
 
         if ($producerUser) {
             $this->createProducerIfNotExists($producerUser->id, [
-                'name' => 'Green Farm Co.',
-                'slug' => 'green-farm-co',
-                'business_name' => 'Green Farm Company Ltd',
-                'description' => 'Organic vegetables and fruits from local farms',
-                'location' => 'Athens, Greece',
-                'phone' => '+30 210 1234567',
-                'email' => 'info@greenfarm.gr',
-                'website' => 'https://greenfarm.gr',
+                'name' => 'Κτήμα Παπαδόπουλου',
+                'slug' => 'ktima-papadopoulou',
+                'business_name' => 'Κτήμα Παπαδόπουλου Ο.Ε.',
+                'description' => 'Βιολογικά λαχανικά και φρούτα από οικογενειακό αγρόκτημα στη Μεσσηνία. Καλλιεργούμε με σεβασμό στη γη από το 1985.',
+                'location' => 'Καλαμάτα, Μεσσηνία',
+                'phone' => '+30 272 1012345',
+                'email' => 'info@ktimapapadopoulou.gr',
+                'website' => 'https://ktimapapadopoulou.gr',
             ]);
         }
 
-        // Producer 2: Cretan Honey (create user if needed)
+        // Παραγωγός 2: Μελισσοκομία Κρήτης
         $honeyUser = User::firstOrCreate(
             ['email' => 'producer2@example.com'],
             [
-                'name' => 'Cretan Honey Producer',
+                'name' => 'Νίκος Στεφανάκης',
                 'email' => 'producer2@example.com',
                 'role' => 'producer',
                 'password' => bcrypt('password'),
@@ -44,21 +44,21 @@ class ProducerSeeder extends Seeder
         );
 
         $this->createProducerIfNotExists($honeyUser->id, [
-            'name' => 'Cretan Honey',
-            'slug' => 'cretan-honey',
-            'business_name' => 'Cretan Honey Producers Co-op',
-            'description' => 'Traditional honey and bee products from Crete',
-            'location' => 'Heraklion, Crete',
+            'name' => 'Μελισσοκομία Κρήτης',
+            'slug' => 'melissokomia-kritis',
+            'business_name' => 'Μελισσοκομία Κρήτης — Στεφανάκης',
+            'description' => 'Παραδοσιακή μελισσοκομία τρίτης γενιάς στα βουνά της Κρήτης. Θυμαρίσιο μέλι, ελαιόλαδο και προϊόντα κυψέλης.',
+            'location' => 'Ηράκλειο, Κρήτη',
             'phone' => '+30 281 0987654',
-            'email' => 'info@cretanhoney.gr',
-            'website' => 'https://cretanhoney.gr',
+            'email' => 'info@melissakritis.gr',
+            'website' => 'https://melissakritis.gr',
         ]);
 
-        // Producer 3: Mount Olympus Dairy (create user if needed)
+        // Παραγωγός 3: Γαλακτοκομικά Ολύμπου
         $dairyUser = User::firstOrCreate(
             ['email' => 'producer3@example.com'],
             [
-                'name' => 'Olympus Dairy Producer',
+                'name' => 'Γιώργος Τσιμπούκης',
                 'email' => 'producer3@example.com',
                 'role' => 'producer',
                 'password' => bcrypt('password'),
@@ -67,14 +67,14 @@ class ProducerSeeder extends Seeder
         );
 
         $this->createProducerIfNotExists($dairyUser->id, [
-            'name' => 'Mount Olympus Dairy',
-            'slug' => 'mount-olympus-dairy',
-            'business_name' => 'Mount Olympus Dairy Products SA',
-            'description' => 'Traditional Greek dairy products and cheeses',
-            'location' => 'Larissa, Thessaly',
+            'name' => 'Γαλακτοκομικά Ολύμπου',
+            'slug' => 'galaktokomika-olympou',
+            'business_name' => 'Γαλακτοκομικά Ολύμπου Α.Ε.',
+            'description' => 'Παραδοσιακά γαλακτοκομικά προϊόντα από τους πρόποδες του Ολύμπου. Φέτα ΠΟΠ, γιαούρτι και τυριά με γάλα ελευθέρας βοσκής.',
+            'location' => 'Λάρισα, Θεσσαλία',
             'phone' => '+30 241 0567890',
-            'email' => 'info@olympusdairy.gr',
-            'website' => 'https://olympusdairy.gr',
+            'email' => 'info@galaktokomika-olympou.gr',
+            'website' => 'https://galaktokomika-olympou.gr',
         ]);
     }
 

--- a/backend/database/seeders/ProductSeeder.php
+++ b/backend/database/seeders/ProductSeeder.php
@@ -35,19 +35,19 @@ class ProductSeeder extends Seeder
         $honey = Category::where('slug', 'honey-preserves')->first();
 
         // Get producers by slug for explicit assignment, with fallbacks
-        $greenFarm = $producers->firstWhere('slug', 'green-farm-co') ?? $producers->first();
-        $cretanHoney = $producers->firstWhere('slug', 'cretan-honey') ?? $producers->skip(1)->first() ?? $greenFarm;
-        $olympusDairy = $producers->firstWhere('slug', 'mount-olympus-dairy') ?? $producers->skip(2)->first() ?? $greenFarm;
+        $ktima = $producers->firstWhere('slug', 'ktima-papadopoulou') ?? $producers->firstWhere('slug', 'green-farm-co') ?? $producers->first();
+        $melissa = $producers->firstWhere('slug', 'melissokomia-kritis') ?? $producers->firstWhere('slug', 'cretan-honey') ?? $producers->skip(1)->first() ?? $ktima;
+        $galakto = $producers->firstWhere('slug', 'galaktokomika-olympou') ?? $producers->firstWhere('slug', 'mount-olympus-dairy') ?? $producers->skip(2)->first() ?? $ktima;
 
         // Create products distributed across producers
         $productsData = [
-            // GREEN FARM CO. products (vegetables, herbs)
+            // ΚΤΗΜΑ ΠΑΠΑΔΟΠΟΥΛΟΥ — λαχανικά, βότανα, φρούτα
             [
                 'product_data' => [
-                    'producer_id' => $greenFarm->id,
-                    'name' => 'Organic Tomatoes',
-                    'slug' => 'organic-tomatoes',
-                    'description' => 'Fresh organic tomatoes grown without pesticides',
+                    'producer_id' => $ktima->id,
+                    'name' => 'Ντομάτες Βιολογικές',
+                    'slug' => 'ntomates-viologikes',
+                    'description' => 'Φρέσκες βιολογικές ντομάτες από το κτήμα μας στη Μεσσηνία. Καλλιεργούνται χωρίς φυτοφάρμακα με παραδοσιακές μεθόδους.',
                     'price' => 3.50,
                     'weight_per_unit' => 1.000,
                     'unit' => 'kg',
@@ -66,13 +66,13 @@ class ProductSeeder extends Seeder
             ],
             [
                 'product_data' => [
-                    'producer_id' => $greenFarm->id,
-                    'name' => 'Fresh Lettuce',
-                    'slug' => 'fresh-lettuce',
-                    'description' => 'Crispy fresh lettuce perfect for salads',
+                    'producer_id' => $ktima->id,
+                    'name' => 'Μαρούλι Φρέσκο',
+                    'slug' => 'marouli-fresko',
+                    'description' => 'Τραγανό φρέσκο μαρούλι, ιδανικό για σαλάτες. Μαζεύεται κάθε πρωί από τον κήπο μας.',
                     'price' => 2.25,
                     'weight_per_unit' => 0.300,
-                    'unit' => 'piece',
+                    'unit' => 'τεμάχιο',
                     'stock' => 50,
                     'category' => 'Vegetables',
                     'is_organic' => false,
@@ -87,14 +87,14 @@ class ProductSeeder extends Seeder
             ],
             [
                 'product_data' => [
-                    'producer_id' => $greenFarm->id,
-                    'name' => 'Greek Oregano',
-                    'slug' => 'greek-oregano',
-                    'description' => 'Aromatic Greek oregano, dried and packaged',
-                    'price' => 5.50,
-                    'weight_per_unit' => 0.050,
-                    'unit' => 'packet',
-                    'stock' => 30,
+                    'producer_id' => $ktima->id,
+                    'name' => 'Ρίγανη Βουνού 100g',
+                    'slug' => 'rigani-vounou-100g',
+                    'description' => 'Αρωματική ελληνική ρίγανη βουνού, αποξηραμένη με τον παραδοσιακό τρόπο. Ιδανική για σαλάτες και ψητά.',
+                    'price' => 3.50,
+                    'weight_per_unit' => 0.100,
+                    'unit' => 'συσκευασία',
+                    'stock' => 80,
                     'category' => 'Herbs',
                     'is_organic' => true,
                     'image_url' => 'https://images.unsplash.com/photo-1629978452215-6ab392d7abb9',
@@ -106,16 +106,16 @@ class ProductSeeder extends Seeder
                     ['url' => 'https://images.unsplash.com/photo-1629978452215-6ab392d7abb9', 'is_primary' => true, 'sort_order' => 0],
                 ],
             ],
-            // CRETAN HONEY products (oil, honey)
+            // ΜΕΛΙΣΣΟΚΟΜΙΑ ΚΡΗΤΗΣ — ελαιόλαδο, μέλι
             [
                 'product_data' => [
-                    'producer_id' => $cretanHoney->id,
-                    'name' => 'Extra Virgin Olive Oil',
-                    'slug' => 'extra-virgin-olive-oil',
-                    'description' => 'Premium Greek olive oil from Crete',
+                    'producer_id' => $melissa->id,
+                    'name' => 'Εξαιρετικό Παρθένο Ελαιόλαδο 500ml',
+                    'slug' => 'exairetiko-partheno-elaiolado-500ml',
+                    'description' => 'Premium ελαιόλαδο εξαιρετικό παρθένο από βιολογικούς ελαιώνες της Κρήτης. Χαμηλή οξύτητα, πλούσια γεύση.',
                     'price' => 12.00,
                     'weight_per_unit' => 0.500,
-                    'unit' => 'bottle',
+                    'unit' => 'φιάλη',
                     'stock' => 25,
                     'category' => 'Oil',
                     'is_organic' => true,
@@ -131,13 +131,13 @@ class ProductSeeder extends Seeder
             ],
             [
                 'product_data' => [
-                    'producer_id' => $cretanHoney->id,
-                    'name' => 'Cretan Thyme Honey',
-                    'slug' => 'cretan-thyme-honey',
-                    'description' => 'Pure thyme honey from the mountains of Crete',
+                    'producer_id' => $melissa->id,
+                    'name' => 'Θυμαρίσιο Μέλι Κρήτης 450g',
+                    'slug' => 'thymarisio-meli-kritis-450g',
+                    'description' => 'Αγνό θυμαρίσιο μέλι από τα βουνά της Κρήτης. Συλλέγεται χειροποίητα από τα μελίσσια μας σε υψόμετρο 800μ.',
                     'price' => 15.00,
-                    'weight_per_unit' => 0.500,
-                    'unit' => 'jar',
+                    'weight_per_unit' => 0.450,
+                    'unit' => 'βάζο',
                     'stock' => 40,
                     'category' => 'Honey',
                     'is_organic' => true,
@@ -150,13 +150,13 @@ class ProductSeeder extends Seeder
                     ['url' => 'https://images.unsplash.com/photo-1587049352846-4a222e784d38', 'is_primary' => true, 'sort_order' => 0],
                 ],
             ],
-            // MOUNT OLYMPUS DAIRY products (fruits, dairy)
+            // ΓΑΛΑΚΤΟΚΟΜΙΚΑ ΟΛΥΜΠΟΥ — φρούτα, γαλακτοκομικά
             [
                 'product_data' => [
-                    'producer_id' => $olympusDairy->id,
-                    'name' => 'Fresh Apples',
-                    'slug' => 'fresh-apples',
-                    'description' => 'Crispy red apples from local orchards',
+                    'producer_id' => $galakto->id,
+                    'name' => 'Μήλα Ζαγοράς Πηλίου',
+                    'slug' => 'mila-zagoras-piliou',
+                    'description' => 'Τραγανά μήλα ΠΟΠ Ζαγοράς Πηλίου. Φυσική γλυκύτητα και τραγανή υφή, ιδανικά για κατανάλωση και μαγειρική.',
                     'price' => 4.00,
                     'weight_per_unit' => 1.000,
                     'unit' => 'kg',
@@ -174,13 +174,13 @@ class ProductSeeder extends Seeder
             ],
             [
                 'product_data' => [
-                    'producer_id' => $olympusDairy->id,
-                    'name' => 'Greek Feta Cheese',
-                    'slug' => 'greek-feta-cheese',
-                    'description' => 'Traditional PDO feta cheese from Thessaly',
+                    'producer_id' => $galakto->id,
+                    'name' => 'Φέτα ΠΟΠ Θεσσαλίας 400g',
+                    'slug' => 'feta-pop-thessalias-400g',
+                    'description' => 'Αυθεντική φέτα ΠΟΠ από γάλα ελευθέρας βοσκής στους πρόποδες του Ολύμπου. Κρεμώδης υφή, πλούσια γεύση.',
                     'price' => 8.50,
                     'weight_per_unit' => 0.400,
-                    'unit' => 'piece',
+                    'unit' => 'συσκευασία',
                     'stock' => 60,
                     'category' => 'Dairy',
                     'is_organic' => false,


### PR DESCRIPTION
## Summary
- **ProducerSeeder**: 3 producers → Greek names & descriptions (Κτήμα Παπαδόπουλου, Μελισσοκομία Κρήτης, Γαλακτοκομικά Ολύμπου)
- **ProductSeeder**: 7 products → Greek names & rich descriptions (Ντομάτες Βιολογικές, Θυμαρίσιο Μέλι, Φέτα ΠΟΠ, etc.)
- **CategorySeeder**: 14 categories → Greek names (Φρούτα, Λαχανικά, Ελαιόλαδο & Ελιές, etc.)
- **GreekProductSeeder**: Updated 10 product descriptions + 2 producer names to Greek

## Why
The site looked like an English demo despite having a fully Greek UI. Real Greek marketplace needs Greek product and producer data.

## Test plan
- [ ] `php -l` passes on all 4 files
- [ ] `php artisan migrate:fresh --seed` succeeds (local)
- [ ] Products display with Greek names on storefront