### PR TITLE
feat(cod): wire COD fee through shipping quote and checkout UI

### DIFF
--- a/frontend/src/components/checkout/PaymentMethodSelector.tsx
+++ b/frontend/src/components/checkout/PaymentMethodSelector.tsx
@@ -9,12 +9,14 @@ interface PaymentMethodSelectorProps {
   value: PaymentMethod
   onChange: (method: PaymentMethod) => void
   disabled?: boolean
+  codFee?: number
 }
 
 export default function PaymentMethodSelector({
   value,
   onChange,
   disabled = false,
+  codFee,
 }: PaymentMethodSelectorProps) {
   // Card payments gated by build-time env flag AND user authentication
   // Guest users can only use COD; logged-in users can use card
@@ -59,6 +61,11 @@ export default function PaymentMethodSelector({
         <div className="flex-1">
           <span className="font-medium">Αντικαταβολή</span>
           <p className="text-sm text-gray-500">Πληρωμή κατά την παράδοση</p>
+          {codFee != null && codFee > 0 && (
+            <p className="text-xs text-amber-600 mt-0.5" data-testid="cod-fee-note">
+              +{new Intl.NumberFormat('el-GR', { style: 'currency', currency: 'EUR' }).format(codFee)} χρέωση αντικαταβολής
+            </p>
+          )}
         </div>
       </label>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -897,11 +897,12 @@ class ApiClient {
     });
   }
 
-  // Pass ORDER-SHIPPING-SPLIT-01: Get per-producer shipping breakdown for cart
+  // Pass ORDER-SHIPPING-SPLIT-01 + COD-COMPLETE: Get per-producer shipping breakdown for cart
   async getCartShippingQuote(data: {
     postal_code: string;
     method: 'HOME' | 'COURIER' | 'PICKUP';
     items: { product_id: number; quantity: number }[];
+    payment_method?: 'COD' | 'CARD';
   }): Promise<{
     producers: {
       producer_id: number;
@@ -915,6 +916,8 @@ class ApiClient {
       weight_grams: number;
     }[];
     total_shipping: number;
+    cod_fee: number;
+    payment_method: string;
     quoted_at: string;
     currency: string;
     zone_name: string | null;


### PR DESCRIPTION
## Summary

Pass **COD-COMPLETE** PR1: Wire the COD fee through the full shipping quote → checkout display pipeline.

- **Backend**: `quoteCart` endpoint now accepts `payment_method` (COD/CARD), returns `cod_fee` and `payment_method` in response. COD fee is calculated once at the top level (not per-producer) using config `shipping.cod_fee_eur` (default €4.00)
- **Frontend api.ts**: `getCartShippingQuote` now accepts and passes `payment_method` parameter
- **Frontend checkout**: Passes selected payment method to shipping quote API, re-fetches when user toggles COD↔Card, displays COD fee as separate line item in order total
- **PaymentMethodSelector**: Shows COD fee note (+€4,00 χρέωση αντικαταβολής) under the COD option when fee is active

### What this does NOT include (next PR)
- Enabling `SHIPPING_ENABLE_COD=true` in production `.env` (separate deploy step)
- Admin "mark as paid" endpoint for COD orders

## AC Checklist
- [x] Backend returns `cod_fee` and `payment_method` in cart shipping quote response
- [x] COD fee applied once (not per-producer) to avoid double-charging
- [x] Frontend passes `payment_method` to shipping quote API
- [x] Shipping quote re-fetches when payment method changes
- [x] COD fee displayed as line item in checkout total
- [x] COD fee note shown in PaymentMethodSelector
- [x] PHP syntax check passes
- [x] TypeScript compiles clean
- [x] Next.js build succeeds
- [x] LOC: 49 insertions, 7 deletions (well under 300)

## Test plan
- [ ] Select COD in checkout → shipping quote includes `cod_fee` field
- [ ] Select Card → re-fetch shows `cod_fee: 0`
- [ ] Toggle COD↔Card → total updates dynamically
- [ ] PaymentMethodSelector shows fee note under COD option
- [ ] Order creation still works with both payment methods