### PR TITLE
feat(cod): admin confirm COD payment endpoint + UI button

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -357,6 +357,9 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:60,1'); // 60 requests per minute (Pass 61)
         Route::patch('{order}/status', [App\Http\Controllers\Api\Admin\AdminOrderController::class, 'updateStatus'])
             ->middleware('throttle:60,1'); // 60 status updates per minute
+        // Pass COD-COMPLETE: Admin confirm COD payment received
+        Route::patch('{order}/payment/confirm', [App\Http\Controllers\Api\Admin\AdminOrderController::class, 'confirmPayment'])
+            ->middleware('throttle:30,1'); // 30 payment confirms per minute
     });
 
     // Admin Shipping (read-only rate tables interface)

--- a/frontend/src/app/admin/orders/[id]/OrderStatusQuickActions.tsx
+++ b/frontend/src/app/admin/orders/[id]/OrderStatusQuickActions.tsx
@@ -6,6 +6,8 @@ import { useToast } from '@/contexts/ToastContext'
 interface Props {
   orderId: string
   currentStatus: string
+  paymentMethod?: string | null
+  paymentStatus?: string | null
 }
 
 const statusLabels: Record<string, string> = {
@@ -17,10 +19,33 @@ const statusLabels: Record<string, string> = {
   CANCELLED: 'Ακυρώθηκε'
 }
 
-export function OrderStatusQuickActions({ orderId, currentStatus }: Props) {
-  const { showError } = useToast()
+export function OrderStatusQuickActions({ orderId, currentStatus, paymentMethod, paymentStatus }: Props) {
+  const { showError, showSuccess } = useToast()
   const [loading, setLoading] = useState(false)
   const [status, setStatus] = useState(currentStatus)
+  const [paidConfirmed, setPaidConfirmed] = useState(
+    (paymentStatus || '').toLowerCase() === 'completed'
+  )
+
+  // Pass COD-COMPLETE: Confirm COD payment
+  const handleConfirmPayment = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/admin/orders/${orderId}/payment-confirm`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+      if (!res.ok) throw new Error('Payment confirm failed')
+      setPaidConfirmed(true)
+      showSuccess('Η πληρωμή επιβεβαιώθηκε')
+      window.location.reload()
+    } catch (e) {
+      console.error('Payment confirm error:', e)
+      showError('Σφάλμα κατά την επιβεβαίωση πληρωμής')
+    } finally {
+      setLoading(false)
+    }
+  }
 
   const handleStatusChange = async (newStatus: string) => {
     setLoading(true)
@@ -49,8 +74,11 @@ export function OrderStatusQuickActions({ orderId, currentStatus }: Props) {
 
   const showPacking = ['PENDING', 'PAID'].includes(status.toUpperCase())
   const showShipped = status.toUpperCase() === 'PACKING'
+  // Pass COD-COMPLETE: Show confirm payment for COD orders with pending payment
+  const isCod = (paymentMethod || '').toUpperCase() === 'COD'
+  const showConfirmPayment = isCod && !paidConfirmed
 
-  if (!showPacking && !showShipped) {
+  if (!showPacking && !showShipped && !showConfirmPayment) {
     return null
   }
 
@@ -58,6 +86,21 @@ export function OrderStatusQuickActions({ orderId, currentStatus }: Props) {
     <div className="mb-6 pb-6 border-b border-gray-200">
       <p className="text-sm text-gray-600 mb-3">Γρήγορες ενέργειες:</p>
       <div className="space-y-2">
+        {showConfirmPayment && (
+          <button
+            onClick={handleConfirmPayment}
+            disabled={loading}
+            data-testid="qa-confirm-payment"
+            className="w-full px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Επιβεβαίωση...' : 'Επιβεβαίωση Πληρωμής (Αντικαταβολή)'}
+          </button>
+        )}
+        {paidConfirmed && isCod && (
+          <div className="px-4 py-2 bg-green-50 border border-green-200 rounded-lg text-green-800 text-sm font-medium text-center">
+            Η πληρωμή έχει επιβεβαιωθεί
+          </div>
+        )}
         {showPacking && (
           <button
             onClick={() => handleStatusChange('PACKING')}

--- a/frontend/src/app/admin/orders/[id]/page.tsx
+++ b/frontend/src/app/admin/orders/[id]/page.tsx
@@ -17,6 +17,7 @@ type Order = {
   total: number;
   email?: string | null;
   paymentStatus?: string;
+  paymentMethod?: string | null;
   paymentRef?: string | null;
   status?: string;
 };
@@ -57,7 +58,12 @@ export default function AdminOrderDetail({
         <div className="mt-4 text-sm">
           {/* PR-FIX-01: Wire orphaned OrderStatusQuickActions */}
           {data.status && (
-            <OrderStatusQuickActions orderId={data.id} currentStatus={data.status} />
+            <OrderStatusQuickActions
+              orderId={data.id}
+              currentStatus={data.status}
+              paymentMethod={data.paymentMethod ?? (data.codFee != null && Number(data.codFee) > 0 ? 'COD' : null)}
+              paymentStatus={data.paymentStatus}
+            />
           )}
 
           {/* ADMIN-SHIPPING-UI-01: Shipping Label Manager */}

--- a/frontend/src/app/api/admin/orders/[id]/payment-confirm/route.ts
+++ b/frontend/src/app/api/admin/orders/[id]/payment-confirm/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+/**
+ * Pass COD-COMPLETE: Confirm COD payment received.
+ * POST /api/admin/orders/:id/payment-confirm
+ *
+ * Proxies to Laravel: PATCH /api/v1/admin/orders/:id/payment/confirm
+ */
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    // Get auth token
+    const cookieStore = await cookies();
+    const token = cookieStore.get('auth_token')?.value
+      || req.headers.get('authorization')?.replace('Bearer ', '');
+
+    if (!token) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    // Extract numeric Laravel order ID from "A-123" format
+    const rawId = params.id;
+    const laravelId = rawId.startsWith('A-') ? rawId.slice(2) : rawId;
+
+    const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+    const laravelRes = await fetch(
+      `${apiBase}/admin/orders/${laravelId}/payment/confirm`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    const data = await laravelRes.json();
+
+    if (!laravelRes.ok) {
+      return NextResponse.json(
+        { error: data.error || 'confirm_fail' },
+        { status: laravelRes.status }
+      );
+    }
+
+    return NextResponse.json({ ok: true, orderId: rawId });
+  } catch (error: unknown) {
+    console.error('[admin] payment confirm error:', error);
+    return NextResponse.json(
+      { error: (error as Error)?.message || 'confirm_fail' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Pass **COD-COMPLETE** PR2: Admin can confirm receipt of cash-on-delivery payments.

- **Backend**: New `PATCH /api/v1/admin/orders/{order}/payment/confirm` endpoint on `AdminOrderController`. Guards: only COD orders, only pending payments. Sets `payment_status=completed` and logs reference.
- **Frontend proxy**: Next.js API route at `/api/admin/orders/[id]/payment-confirm` proxies to Laravel with auth token.
- **Admin UI**: "Επιβεβαίωση Πληρωμής (Αντικαταβολή)" button in `OrderStatusQuickActions` — amber colored, appears for COD orders with pending payment. Shows green confirmation badge after success.
- **Order detail page**: Passes `paymentMethod` and `paymentStatus` props to quick actions. Uses `codFee > 0` as fallback COD detection for Prisma-based orders.

## AC Checklist
- [x] Backend endpoint with admin auth, COD-only guard, idempotency
- [x] Frontend proxy route to Laravel
- [x] Confirm button in admin order detail
- [x] Success confirmation UI (green badge)
- [x] PHP syntax clean
- [x] TypeScript compiles clean
- [x] Next.js build passes
- [x] LOC: 157 insertions (under 300)

## Test plan
- [ ] Open COD order in admin → see amber "Επιβεβαίωση Πληρωμής" button
- [ ] Click confirm → payment_status changes to completed, green badge shown
- [ ] Re-confirm → 422 "already confirmed" error
- [ ] Card order → no confirm button shown
- [ ] Non-admin → 403 unauthorized