### PR TITLE
feat(admin): polish producer management page

### DIFF
--- a/frontend/src/app/api/admin/producers/[id]/route.ts
+++ b/frontend/src/app/api/admin/producers/[id]/route.ts
@@ -1,81 +1,12 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db/client'
-import { z } from 'zod'
 import { getRequestId, logWithId } from '@/lib/observability/request'
 import { requireAdmin } from '@/lib/auth/admin'
 
-const UpdateSchema = z.object({
-  name: z.string().min(2).optional(),
-  slug: z.string().min(2).optional(),
-  region: z.string().min(2).optional(),
-  category: z.string().min(2).optional(),
-  description: z.string().optional(),
-  email: z.string().email().optional().or(z.literal('').transform((): undefined => undefined)),
-  phone: z.string().optional(),
-  isActive: z.boolean().optional(),
-  toggleActive: z.boolean().optional() // convenience
-})
-
-export async function PATCH(
-  _req: Request,
-  ctx: { params: Promise<{ id: string }> }
-) {
-  const rid = getRequestId(_req.headers)
-
-  try {
-    await requireAdmin()
-  } catch {
-    return NextResponse.json({ error: 'Απαιτείται σύνδεση διαχειριστή' }, { status: 403 })
-  }
-
-  const params = await ctx.params
-  const id = params.id
-  const body = await _req.json().catch(() => ({}))
-  const parsed = UpdateSchema.safeParse(body)
-
-  if (!parsed.success) {
-    const res = NextResponse.json(
-      { error: 'Λάθος δεδομένα', issues: parsed.error.format() },
-      { status: 400 }
-    )
-    res.headers.set('x-request-id', rid)
-    logWithId(rid, `PATCH /api/admin/producers/${id} [validation error]`, { error: parsed.error.format() })
-    return res
-  }
-
-  const existing = await prisma.producer.findUnique({ where: { id } })
-  if (!existing) {
-    const res = NextResponse.json({ error: 'Δεν βρέθηκε' }, { status: 404 })
-    res.headers.set('x-request-id', rid)
-    logWithId(rid, `PATCH /api/admin/producers/${id} [not found]`)
-    return res
-  }
-
-  const isActive = parsed.data.toggleActive ? !existing.isActive : parsed.data.isActive
-
-  const item = await prisma.producer.update({
-    where: { id },
-    data: {
-      name: parsed.data.name,
-      slug: parsed.data.slug,
-      region: parsed.data.region,
-      category: parsed.data.category,
-      description: parsed.data.description,
-      email: parsed.data.email,
-      phone: parsed.data.phone,
-      isActive: typeof isActive === 'boolean' ? isActive : undefined
-    }
-  })
-
-  const res = NextResponse.json({ item })
-  res.headers.set('x-request-id', rid)
-  logWithId(rid, `PATCH /api/admin/producers/${id} [updated]`, {
-    toggleActive: parsed.data.toggleActive,
-    wasActive: existing.isActive,
-    nowActive: item.isActive
-  })
-  return res
-}
+/**
+ * ADMIN-PRODUCERS: PATCH removed — approve/reject go through Laravel SSOT
+ * DELETE kept for emergency admin use (Prisma-based, rarely used)
+ */
 
 export async function DELETE(
   _req: Request,

--- a/frontend/src/app/api/admin/producers/route.ts
+++ b/frontend/src/app/api/admin/producers/route.ts
@@ -45,18 +45,28 @@ export async function GET(req: NextRequest) {
     const json = await res.json()
     const producers = json?.data ?? []
 
-    // Map Laravel format to admin panel format
+    // Map Laravel status to frontend approval status
+    // Laravel: pending/active/inactive → Frontend: pending/approved/rejected
+    const mapStatus = (s: string): string => {
+      if (s === 'active') return 'approved'
+      if (s === 'inactive') return 'rejected'
+      return 'pending'
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const items = producers.map((p: any) => ({
       id: String(p.id),
-      name: p.name,
+      name: p.name || p.business_name || '',
       businessName: p.business_name || '',
       region: p.region || p.location || '',
-      status: p.status || 'pending',
+      approvalStatus: mapStatus(p.status || 'pending'),
       isActive: p.is_active !== false,
       rejectionReason: p.rejection_reason || null,
       email: p.email || p.user?.email || '',
       phone: p.phone || '',
+      description: p.description || '',
+      city: p.city || '',
+      taxId: p.tax_id || '',
       createdAt: p.created_at,
     }))
 


### PR DESCRIPTION
## Summary
- Fix `approvalStatus` field mismatch — proxy sent `status` but frontend read `approvalStatus`, breaking status badges
- Map Laravel statuses correctly: `active`→`approved`, `inactive`→`rejected`, `pending`→`pending`
- Add status filter dropdown (Σε αναμονή / Εγκεκριμένοι / Απορρίφθηκαν) — admin's primary workflow
- Add expandable detail row (email, phone, city, tax ID, description, rejection reason)
- Add pending count badge with pulse animation
- Convert all inline styles to Tailwind CSS
- Remove stale Prisma PATCH handler (approve/reject go through Laravel SSOT)
- Remove create modal (producers self-register via PRODUCER-ONBOARD-01)

## Test plan
- [ ] `/admin/producers` loads with correct status badges
- [ ] Filter by "Σε αναμονή" shows only pending producers
- [ ] Click row → expands to show detail (email, phone, etc.)
- [ ] Approve pending producer → badge turns green
- [ ] Reject pending producer → modal + reason → badge turns red
- [ ] `npm run build` passes