### PR TITLE
docs: update AGENT-STATE + audit after DEAD-CODE-CLEANUP

### DIFF
--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -1,6 +1,6 @@
 # AGENT-STATE — Dixis Canonical Entry Point
 
-**Updated**: 2026-02-12 (AUTH-FIX-CRITICAL deployed)
+**Updated**: 2026-02-12 (DEAD-CODE-CLEANUP deployed)
 
 > **This is THE entry point.** Read this first on every agent session. Single source of truth.
 
@@ -41,8 +41,8 @@
 
 _(empty — pick from NEXT)_
 
-> **AUTH-FIX-CRITICAL DONE** — PR #2783 merged, deployed 2026-02-12
-> Security audit + fix: 4 admin endpoints secured, 2 production blocks added
+> **DEAD-CODE-CLEANUP DONE** — PR #2786 merged, deployed 2026-02-12
+> Deleted 42 files (3,058 LOC): 16 components, 6 libs, 5 API routes, 8 legacy/dev pages, 3 redirect stubs
 
 ---
 
@@ -50,12 +50,12 @@ _(empty — pick from NEXT)_
 
 | # | Pass ID | What | Why | Scope |
 |---|---------|------|-----|-------|
-| 1 | **DEAD-CODE-CLEANUP** | Delete 17 dead components, 10 dead libs, 11 orphan routes | Tech debt | ~200 LOC deletions |
-| 2 | **ORDER-CONSOLIDATE** | Remove 4/5 duplicate tracking APIs + legacy checkout flow | Architecture | ~300 LOC deletions |
-| 3 | **CSP-FIX** | Remove localhost from CSP, fix hardcoded URLs | Security | ~20 LOC |
+| 1 | **ORDER-CONSOLIDATE** | Remove duplicate tracking APIs + duplicate tracking page | Architecture | ~200 LOC deletions |
+| 2 | **CSP-FIX** | Remove localhost from CSP, fix hardcoded URLs | Security | ~20 LOC |
+| 3 | **PRISMA-IMPORT-UNIFY** | Consolidate 3 import paths to single `@/lib/db/client` | Tech debt | ~30 LOC |
 | 4 | **PROD-CDN-FIX** | Fix 400/MIME errors on production static assets | Reliability | Server/nginx |
 
-**Note**: Priorities updated from architecture audit (`docs/PRODUCT/ARCH-AUDIT-2026-02-12.md`). Focus on cleanup before new features.
+**Note**: DEAD-CODE-CLEANUP done (PR #2786). Priorities from `docs/PRODUCT/ARCH-AUDIT-2026-02-12.md`.
 
 ---
 
@@ -72,6 +72,7 @@ _(empty — pick from NEXT)_
 
 ## Recently Done (last 10)
 
+- **DEAD-CODE-CLEANUP** — Delete 42 dead files (3,058 LOC): 16 components, 6 libs, 5 API routes, 8 legacy/dev pages, 3 redirect stubs (PR #2786, deployed 2026-02-12) ✅
 - **AUTH-FIX-CRITICAL** — Add requireAdmin() to 4 unprotected admin endpoints + production blocks on /api/ops/status and /dev-check (PR #2783, deployed 2026-02-12) ✅
 - **ARCH-AUDIT** — Full architecture audit: 82 API routes, 14 Prisma models, ~200 frontend files. Found CRITICAL auth holes, dead code, duplicate systems. Report: `docs/PRODUCT/ARCH-AUDIT-2026-02-12.md` (2026-02-12) ✅
 - **ADMIN-PRODUCTS-TAILWIND** — Convert admin products page from inline styles to Tailwind (PR #2780, deployed 2026-02-12) ✅

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,11 +1,27 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-12 (AUTH-FIX-CRITICAL)
+**Last Updated**: 2026-02-12 (DEAD-CODE-CLEANUP)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~600 lines (target ≤350). ⚠️ Over limit — archive next pass.
 >
 > **Key Docs**: [DEPLOY SOP](DEPLOY.md) | [STATE Archive](STATE-ARCHIVE/)
+
+---
+
+## 2026-02-12 — DEAD-CODE-CLEANUP: Delete 42 Dead Files
+
+**Status**: ✅ DONE (PR #2786, deployed)
+
+**What was done**:
+- Verified each file with parallel scan agents (zero importers confirmed)
+- Deleted 16 dead components, 6 dead libs, 5 orphan API routes, 8 legacy/dev pages, 3 redirect stubs
+- Total: 42 files, 3,058 LOC removed
+- Build passes, all deleted routes return 404 in production
+- Updated ARCH-AUDIT doc to mark L1/L2/L3/H4/H6/M5/L9 as FIXED
+
+**Files deleted**: 42 (pure deletions, zero code changes)
+**Production**: Deployed, healthz 200, deleted routes verified 404
 
 ---
 

--- a/docs/PRODUCT/ARCH-AUDIT-2026-02-12.md
+++ b/docs/PRODUCT/ARCH-AUDIT-2026-02-12.md
@@ -17,12 +17,12 @@
 
 | # | Finding | File(s) | Status |
 |---|---------|---------|--------|
-| C1 | `/api/admin/orders/export` — ZERO auth, exposes all orders as CSV | `api/admin/orders/export/route.ts` | OPEN |
-| C2 | `/api/admin/orders/facets` — ZERO auth, exposes order aggregation | `api/admin/orders/facets/route.ts` | OPEN |
-| C3 | `/api/ops/status` — ZERO auth, exposes hostname, PID, memory, DB latency, git commit | `api/ops/status/route.ts` | OPEN |
-| C4 | `/dev-check` page — ZERO auth, exposes env config and API base URL | `app/dev-check/page.tsx` | OPEN |
-| C5 | `/api/admin/orders/summary` — weak auth (`adminEnabled()` checks env var only, no user identity) | `api/admin/orders/summary/route.ts` | OPEN |
-| C6 | `/api/admin/orders/[id]` GET — same weak `adminEnabled()` guard | `api/admin/orders/[id]/route.ts` | OPEN |
+| C1 | `/api/admin/orders/export` — ZERO auth, exposes all orders as CSV | `api/admin/orders/export/route.ts` | FIXED PR #2783 |
+| C2 | `/api/admin/orders/facets` — ZERO auth, exposes order aggregation | `api/admin/orders/facets/route.ts` | FIXED PR #2783 |
+| C3 | `/api/ops/status` — ZERO auth, exposes hostname, PID, memory, DB latency, git commit | `api/ops/status/route.ts` | FIXED PR #2783 |
+| C4 | `/dev-check` page — ZERO auth, exposes env config and API base URL | `app/dev-check/page.tsx` | FIXED PR #2783 |
+| C5 | `/api/admin/orders/summary` — weak auth (`adminEnabled()` checks env var only, no user identity) | `api/admin/orders/summary/route.ts` | FIXED PR #2783 |
+| C6 | `/api/admin/orders/[id]` GET — same weak `adminEnabled()` guard | `api/admin/orders/[id]/route.ts` | FIXED PR #2783 |
 
 **Fix**: Add `requireAdmin()` to C1/C2/C5/C6. Block C3/C4 in production (`DIXIS_ENV=production` → 404).
 
@@ -35,9 +35,9 @@
 | H1 | Triple order model confusion | `prisma.Order` (intents, status, tracking) ≠ `prisma.CheckoutOrder` (admin summary, lookup) ≠ Laravel orders (admin list, payment). Admin sees different data per endpoint. | OPEN |
 | H2 | 5 duplicate order tracking APIs | `/api/track/[token]`, `/api/orders/track/[token]`, `/api/orders/track`, `/api/orders/public/[token]`, `/api/public/track/[token]` — three different response shapes | OPEN |
 | H3 | 2 duplicate tracking pages | `/track/[token]` (uses Laravel API, correct) vs `/orders/track/[token]` (uses Prisma directly, stale) | OPEN |
-| H4 | Legacy checkout flow still live | `/checkout/flow`, `/checkout/payment`, `/checkout/payment/success`, `/checkout/payment/failure`, `/checkout/confirmation` — inline styles, localStorage state. Real checkout is `/(storefront)/checkout` | OPEN |
+| H4 | Legacy checkout flow still live | `/checkout/flow`, `/checkout/payment`, `/checkout/payment/success`, `/checkout/payment/failure`, `/checkout/confirmation` — inline styles, localStorage state. Real checkout is `/(storefront)/checkout` | FIXED PR #2786 |
 | H5 | CSP hardcodes localhost | `src/lib/csp.ts:7` — `http://localhost:3200` in production CSP connect-src | OPEN |
-| H6 | `/api/order-intents` — ZERO auth | Creates draft orders in Prisma without any authentication | OPEN |
+| H6 | `/api/order-intents` — ZERO auth | Creates draft orders in Prisma without any authentication | FIXED PR #2786 (deleted) |
 
 ---
 
@@ -49,7 +49,7 @@
 | M2 | Producer DELETE via Prisma doesn't sync Laravel | `api/admin/producers/[id]/route.ts` DELETE removes from Prisma only — ghost data in Laravel | OPEN |
 | M3 | Category CRUD in both systems | Prisma `api/categories/[id]` can update categories independently of Laravel Category model | OPEN |
 | M4 | Inconsistent Laravel URL resolution | Some routes use `getLaravelInternalUrl()`, others use `process.env.NEXT_PUBLIC_API_BASE_URL` | OPEN |
-| M5 | Dev/test pages accessible in production | `/dev/notifications`, `/dev/brand`, `/dev/quote-demo`, `/test-error`, `/products-demo` — no auth | OPEN |
+| M5 | Dev/test pages accessible in production | `/dev/notifications`, `/dev/brand`, `/dev/quote-demo`, `/test-error`, `/products-demo` — no auth | FIXED PR #2786 (deleted) |
 
 ---
 
@@ -57,15 +57,15 @@
 
 | # | Finding | Count | Status |
 |---|---------|-------|--------|
-| L1 | Dead components (never imported) | 17+ files | OPEN |
-| L2 | Dead lib files (never imported) | 10+ files | OPEN |
-| L3 | Dead API routes (no frontend callers) | 11 routes | OPEN |
+| L1 | Dead components (never imported) | 17+ files | FIXED PR #2786 (16 deleted) |
+| L2 | Dead lib files (never imported) | 10+ files | FIXED PR #2786 (6 deleted, 5 alive) |
+| L3 | Dead API routes (no frontend callers) | 11 routes | FIXED PR #2786 (5 deleted, 2 kept for E2E) |
 | L4 | 3 Prisma import paths for same singleton | `@/lib/db/client` (canonical), `@/lib/prisma` (9 files), `@/server/db/prisma` (4 files) | OPEN |
 | L5 | 2 rate-limiting implementations | `rate-limit.ts` (class-based) vs `rateLimit.ts` (token-bucket) | OPEN |
 | L6 | 2 i18n systems coexist | next-intl `getTranslations()` vs custom `LocaleContext` `useTranslations()` | OPEN |
 | L7 | 50+ console.log in production code | Including `console.log('Starting login process...', { email })` in auth/login | OPEN |
 | L8 | 8+ files still using inline styles | After Tailwind conversions: track/page, checkout/flow, checkout/payment, products-demo, dev/brand, admin/shipping-test, my/error, global-error | OPEN |
-| L9 | Redirect stub pages | `/login`→`/auth/login`, `/register`→`/auth/register`, `/product/[id]`→`/products/[id]` | OPEN |
+| L9 | Redirect stub pages | `/login`→`/auth/login`, `/register`→`/auth/register`, `/product/[id]`→`/products/[id]` | FIXED PR #2786 (deleted) |
 | L10 | Duplicate consumer order pages | `/orders` and `/account/orders` serve same audience with different implementations | OPEN |
 | L11 | `@/lib/prismaSafe` deprecated shim | 0 callers, can be deleted | OPEN |
 


### PR DESCRIPTION
## Summary

- Mark 10 audit items as FIXED in `docs/PRODUCT/ARCH-AUDIT-2026-02-12.md`
- Add DEAD-CODE-CLEANUP to Recently Done in AGENT-STATE
- Update NEXT priorities (ORDER-CONSOLIDATE is next)
- Add deployment record in OPS/STATE

## Test plan

- [ ] Docs-only change, no code impact