### PR TITLE
UX-QUICK-WINS-01: Hellenize UI, improve error pages, add FAQ

### DIFF
--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -1,6 +1,6 @@
 # AGENT-STATE — Dixis Canonical Entry Point
 
-**Updated**: 2026-02-12 (L6-I18N-UNIFY deployed)
+**Updated**: 2026-02-12 (UX-QUICK-WINS-01 deployed)
 
 > **This is THE entry point.** Read this first on every agent session. Single source of truth.
 
@@ -66,6 +66,7 @@ _(Architecture audit complete — all items FIXED, WONTFIX, or DEFER. See ARCH-A
 
 ## Recently Done (last 10)
 
+- **UX-QUICK-WINS-01** — Hellenize all English UI strings (HomeClient filters/cards, contact, waitlist, order-lookup, footer). Rewrite 404/500 error pages with proper layout + CTAs. New `/faq` page (Greek accordion). (deployed 2026-02-12) ✅
 - **L6-I18N-UNIFY** — Remove next-intl, unify on LocaleContext. Delete deprecated CheckoutClient.tsx (561 LOC). Architecture audit 100% resolved. (deployed 2026-02-12) ✅
 - **H1-ORDER-MODEL Phase 2** — Proxy admin order detail/summary to Laravel API. Remaining: status+bulk routes still use Prisma Order (email/audit coupling) (deployed 2026-02-12) ✅
 - **H1-ORDER-MODEL Phase 1** — Delete CheckoutOrder model (never populated in prod), 8 dead routes/pages, orderStore.ts. Stub admin detail/summary. Remaining: Prisma Order (Phase 2) (deployed 2026-02-12) ✅

--- a/docs/OPS/STATE.md
+++ b/docs/OPS/STATE.md
@@ -1,11 +1,29 @@
 # OPS STATE
 
-**Last Updated**: 2026-02-12 (L6-I18N-UNIFY)
+**Last Updated**: 2026-02-12 (UX-QUICK-WINS-01)
 
 > **Archive Policy**: Keep last ~10 passes (~2 days). Older entries auto-archived to `STATE-ARCHIVE/`.
 > **Current size**: ~600 lines (target ≤350). ⚠️ Over limit — archive next pass.
 >
 > **Key Docs**: [DEPLOY SOP](DEPLOY.md) | [STATE Archive](STATE-ARCHIVE/)
+
+---
+
+## 2026-02-12 — UX-QUICK-WINS-01: Hellenize UI + Error Pages + FAQ
+
+**Status**: ✅ DONE (deployed)
+
+**What was done**:
+- Hellenized ALL English strings in HomeClient.tsx (30+ strings: filters, sort, organic, cards, buttons, tooltips)
+- Fixed "Email" placeholder in contact, waitlist, order-lookup pages → "Διεύθυνση email"
+- Fixed "Made with Cyprus Green" in footer → "Με ελληνικό πάθος"
+- Rewrote `not-found.tsx` — large 404, descriptive text, two CTA buttons (home + products)
+- Rewrote `error.tsx` — warning icon, retry button via `reset()`, home CTA
+- Created `/faq` page — 4 sections (Orders, Products, Account, Producers), 11 Q&As, accordion UI
+- Added FAQ link in footer under Υποστήριξη section
+
+**Files changed**: 8 (1 new, 7 modified)
+**Production**: Deployed, healthz 200
 
 ---
 

--- a/frontend/src/app/HomeClient.tsx
+++ b/frontend/src/app/HomeClient.tsx
@@ -317,13 +317,13 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                   {filters.search && (
                     <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center space-x-1">
                       {searchState.isGreek && (
-                        <span className="text-xs text-green-600 font-medium" title="Greek text detected">ΕΛ</span>
+                        <span className="text-xs text-green-600 font-medium" title="Ελληνικό κείμενο">ΕΛ</span>
                       )}
                       {searchState.isLatin && (
-                        <span className="text-xs text-blue-600 font-medium" title="Latin text detected (will be transliterated)">EN</span>
+                        <span className="text-xs text-blue-600 font-medium" title="Λατινικό κείμενο (θα μεταγραφεί)">EN</span>
                       )}
                       {searchState.variants.length > 1 && (
-                        <span className="text-xs text-purple-600 font-medium" title={`${searchState.variants.length} search variants`}>+{searchState.variants.length - 1}</span>
+                        <span className="text-xs text-purple-600 font-medium" title={`${searchState.variants.length} παραλλαγές αναζήτησης`}>+{searchState.variants.length - 1}</span>
                       )}
                     </div>
                   )}
@@ -331,8 +331,8 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                 {/* Search hints for Greek normalization */}
                 {filters.search && searchState.variants.length > 1 && (
                   <div className="mt-2 text-xs text-gray-600">
-                    <span className="font-medium">Searching for:</span> {searchState.variants.slice(0, 3).join(', ')}
-                    {searchState.variants.length > 3 && ` +${searchState.variants.length - 3} more variants`}
+                    <span className="font-medium">Αναζήτηση για:</span> {searchState.variants.slice(0, 3).join(', ')}
+                    {searchState.variants.length > 3 && ` +${searchState.variants.length - 3} ακόμη παραλλαγές`}
                   </div>
                 )}
               </div>
@@ -344,7 +344,7 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
                   </svg>
-                  Filters
+                  Φίλτρα
                   {hasActiveFilters && (
                     <span className="bg-green-500 text-white text-xs px-2 py-1 rounded-full">
                       {Object.values(filters).filter(v => v && v !== 'created_at' && v !== 'desc').length}
@@ -356,7 +356,7 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                     onClick={clearAllFilters}
                     className="px-4 py-2 text-gray-600 hover:text-gray-800"
                   >
-                    Clear All
+                    Καθαρισμός
                   </button>
                 )}
               </div>
@@ -368,13 +368,13 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                   {/* Category Filter */}
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Category</label>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">Κατηγορία</label>
                     <select
                       value={filters.category}
                       onChange={(e) => updateFilter('category', e.target.value)}
                       className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
                     >
-                      <option value="">All Categories</option>
+                      <option value="">Όλες οι κατηγορίες</option>
                       {categories.map((category) => (
                         <option key={category} value={category}>
                           {category}
@@ -385,13 +385,13 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
 
                   {/* Producer Filter */}
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Producer</label>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">Παραγωγός</label>
                     <select
                       value={filters.producer}
                       onChange={(e) => updateFilter('producer', e.target.value)}
                       className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
                     >
-                      <option value="">All Producers</option>
+                      <option value="">Όλοι οι παραγωγοί</option>
                       {producers.map((producer) => (
                         <option key={producer.id} value={producer.id}>
                           {producer.name}
@@ -402,11 +402,11 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
 
                   {/* Price Range */}
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Price Range (€)</label>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">Εύρος τιμής (€)</label>
                     <div className="flex gap-2">
                       <input
                         type="number"
-                        placeholder="Min"
+                        placeholder="Ελάχ."
                         value={filters.minPrice}
                         onChange={(e) => updateFilter('minPrice', e.target.value)}
                         className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
@@ -414,7 +414,7 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                       <span className="self-center text-gray-500">-</span>
                       <input
                         type="number"
-                        placeholder="Max"
+                        placeholder="Μέγ."
                         value={filters.maxPrice}
                         onChange={(e) => updateFilter('maxPrice', e.target.value)}
                         className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
@@ -426,16 +426,16 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                   <div className="space-y-4">
                     {/* Sort Options */}
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Sort By</label>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Ταξινόμηση</label>
                       <div className="flex gap-2">
                         <select
                           value={filters.sort}
                           onChange={(e) => updateFilter('sort', e.target.value)}
                           className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
                         >
-                          <option value="created_at">Newest</option>
-                          <option value="name">Name</option>
-                          <option value="price">Price</option>
+                          <option value="created_at">Νεότερα</option>
+                          <option value="name">Όνομα</option>
+                          <option value="price">Τιμή</option>
                         </select>
                         <select
                           value={filters.dir}
@@ -450,15 +450,15 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
 
                     {/* Organic Filter */}
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Organic</label>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Βιολογικά</label>
                       <select
                         value={filters.organic === null ? '' : filters.organic.toString()}
                         onChange={(e) => updateFilter('organic', e.target.value === '' ? null : e.target.value === 'true')}
                         className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
                       >
-                        <option value="">All Products</option>
-                        <option value="true">Organic Only</option>
-                        <option value="false">Non-Organic</option>
+                        <option value="">Όλα τα προϊόντα</option>
+                        <option value="true">Μόνο βιολογικά</option>
+                        <option value="false">Μη βιολογικά</option>
                       </select>
                     </div>
                   </div>
@@ -470,10 +470,10 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
 
         {/* Content */}
         {loading ? (
-          <LoadingSpinner text="Loading fresh products..." />
+          <LoadingSpinner text="Φόρτωση προϊόντων..." />
         ) : error ? (
           <ErrorState
-            title="Unable to load products"
+            title="Αδυναμία φόρτωσης προϊόντων"
             message={error}
             onRetry={loadProducts}
           />
@@ -494,7 +494,7 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                   </h3>
                   
                   <p className="text-sm text-gray-600 mb-2">
-                    By {product.producer.name}
+                    Από {product.producer.name}
                   </p>
                   
                   <div className="flex items-center justify-between mb-4">
@@ -503,7 +503,7 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                     </span>
                     {product.stock !== null && (
                       <span className="text-sm text-gray-500">
-                        Stock: {product.stock}
+                        Απόθεμα: {product.stock}
                       </span>
                     )}
                   </div>
@@ -522,7 +522,7 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                         ))}
                         {product.categories.length > 2 && (
                           <span className="px-2 py-1 bg-gray-100 text-gray-600 text-xs rounded-full">
-                            +{product.categories.length - 2} more
+                            +{product.categories.length - 2} ακόμη
                           </span>
                         )}
                       </div>
@@ -535,20 +535,20 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                       data-testid="product-view-details"
                       className="relative z-10 flex-1 bg-gray-100 hover:bg-gray-200 text-gray-800 px-4 py-2 rounded-lg text-center text-sm font-medium"
                     >
-                      View Details
+                      Λεπτομέρειες
                     </Link>
                     <button
                       data-testid="add-to-cart"
                       onClick={() => handleAddToCart(product.id)}
                       disabled={product.stock === 0 || addingToCart.has(product.id)}
                       className="flex-1 bg-green-600 hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
-                      aria-label={`Add ${product.name} to cart`}
+                      aria-label={`Προσθήκη ${product.name} στο καλάθι`}
                     >
-                      {product.stock === 0 
-                        ? 'Out of Stock' 
-                        : addingToCart.has(product.id) 
-                          ? 'Adding...' 
-                          : 'Add to Cart'
+                      {product.stock === 0
+                        ? 'Εξαντλήθηκε'
+                        : addingToCart.has(product.id)
+                          ? 'Προσθήκη...'
+                          : 'Στο καλάθι'
                       }
                     </button>
                   </div>

--- a/frontend/src/app/contact/page.tsx
+++ b/frontend/src/app/contact/page.tsx
@@ -18,7 +18,7 @@ export default function ContactPage() {
       {state==="error" && <div className="p-3 rounded bg-red-100">Κάτι πήγε στραβά. Δοκίμασε ξανά.</div>}
       <form onSubmit={onSubmit} className="grid gap-3 mt-3">
         <input name="name" placeholder="Ονοματεπώνυμο" required minLength={2} className="border rounded p-2" />
-        <input name="email" type="email" placeholder="Email" required className="border rounded p-2" />
+        <input name="email" type="email" placeholder="Διεύθυνση email" required className="border rounded p-2" />
         <textarea name="message" placeholder="Μήνυμα" required minLength={10} className="border rounded p-2 h-40" />
         <input name="hp" className="hidden" tabIndex={-1} autoComplete="off" />
         <button disabled={state==="sending"} className="rounded bg-black text-white px-4 py-2">

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,9 +1,42 @@
 'use client';
-export default function Error({ error }: { error: Error & { digest?: string } }){
+
+import Link from 'next/link';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
   return (
-    <main>
-      <h1 className="text-2xl font-bold text-red-600">Κάτι πήγε στραβά</h1>
-      <p className="text-sm text-neutral-600 mt-2">Δοκιμάστε ξανά σε λίγο.</p>
+    <main className="container mx-auto px-4 py-16 flex flex-col items-center text-center">
+      <div className="w-16 h-16 rounded-full bg-red-100 flex items-center justify-center mb-4">
+        <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+        </svg>
+      </div>
+
+      <h1 className="text-2xl font-bold text-gray-900">Κάτι πήγε στραβά</h1>
+
+      <p className="text-gray-600 mt-2 max-w-md">
+        Προέκυψε ένα απρόσμενο σφάλμα. Δοκιμάστε ξανά ή επιστρέψτε στην αρχική.
+      </p>
+
+      <div className="flex flex-col sm:flex-row gap-3 mt-8">
+        <button
+          onClick={reset}
+          className="inline-flex items-center justify-center bg-green-600 hover:bg-green-700 text-white font-medium py-3 px-6 rounded-lg transition"
+        >
+          Δοκιμάστε ξανά
+        </button>
+        <Link
+          href="/"
+          className="inline-flex items-center justify-center border border-gray-300 hover:bg-gray-50 text-gray-700 font-medium py-3 px-6 rounded-lg transition"
+        >
+          Αρχική σελίδα
+        </Link>
+      </div>
     </main>
   );
 }

--- a/frontend/src/app/faq/page.tsx
+++ b/frontend/src/app/faq/page.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+interface FaqItem {
+  q: string;
+  a: string;
+}
+
+const sections: { title: string; items: FaqItem[] }[] = [
+  {
+    title: 'Παραγγελίες & Αποστολή',
+    items: [
+      {
+        q: 'Πώς μπορώ να κάνω μια παραγγελία;',
+        a: 'Επιλέξτε τα προϊόντα που θέλετε, προσθέστε τα στο καλάθι σας και προχωρήστε στο ταμείο. Μπορείτε να πληρώσετε με κάρτα ή αντικαταβολή.',
+      },
+      {
+        q: 'Ποιοι είναι οι τρόποι πληρωμής;',
+        a: 'Δεχόμαστε πιστωτικές/χρεωστικές κάρτες μέσω Stripe και αντικαταβολή (με επιπλέον χρέωση 4€).',
+      },
+      {
+        q: 'Πόσο κοστίζουν τα μεταφορικά;',
+        a: 'Τα μεταφορικά υπολογίζονται αυτόματα με βάση τον ταχυδρομικό κώδικα και το βάρος. Κάθε παραγωγός μπορεί να προσφέρει δωρεάν αποστολή πάνω από ένα ελάχιστο ποσό.',
+      },
+      {
+        q: 'Πώς μπορώ να παρακολουθήσω την παραγγελία μου;',
+        a: 'Μετά την ολοκλήρωση της παραγγελίας, θα λάβετε email επιβεβαίωσης με σύνδεσμο παρακολούθησης. Μπορείτε επίσης να χρησιμοποιήσετε την αναζήτηση παραγγελίας.',
+      },
+    ],
+  },
+  {
+    title: 'Προϊόντα & Ποιότητα',
+    items: [
+      {
+        q: 'Τα προϊόντα είναι φρέσκα;',
+        a: 'Ναι! Τα προϊόντα μας προέρχονται απευθείας από Έλληνες παραγωγούς και αποστέλλονται κατά παραγγελία για μέγιστη φρεσκάδα.',
+      },
+      {
+        q: 'Υπάρχουν βιολογικά προϊόντα;',
+        a: 'Πολλοί παραγωγοί μας προσφέρουν βιολογικά προϊόντα. Μπορείτε να φιλτράρετε τα προϊόντα ανά βιολογικά στη σελίδα αναζήτησης.',
+      },
+      {
+        q: 'Μπορώ να επιστρέψω ένα προϊόν;',
+        a: 'Αν λάβατε ελαττωματικό ή κατεστραμμένο προϊόν, επικοινωνήστε μαζί μας μέσω της σελίδας επικοινωνίας εντός 48 ωρών και θα βρούμε λύση.',
+      },
+    ],
+  },
+  {
+    title: 'Λογαριασμός & Ασφάλεια',
+    items: [
+      {
+        q: 'Πώς δημιουργώ λογαριασμό;',
+        a: 'Πατήστε "Εγγραφή" στο μενού και συμπληρώστε τα στοιχεία σας. Η εγγραφή είναι δωρεάν.',
+      },
+      {
+        q: 'Τα στοιχεία μου είναι ασφαλή;',
+        a: 'Απολύτως. Χρησιμοποιούμε κρυπτογράφηση SSL σε όλες τις συναλλαγές. Οι πληρωμές γίνονται μέσω Stripe, χωρίς να αποθηκεύουμε στοιχεία καρτών.',
+      },
+    ],
+  },
+  {
+    title: 'Για Παραγωγούς',
+    items: [
+      {
+        q: 'Πώς μπορώ να γίνω παραγωγός στο Dixis;',
+        a: 'Επισκεφθείτε τη σελίδα εγγραφής παραγωγού, συμπληρώστε τη φόρμα ενδιαφέροντος και η ομάδα μας θα επικοινωνήσει μαζί σας.',
+      },
+      {
+        q: 'Υπάρχει κόστος εγγραφής;',
+        a: 'Η εγγραφή ως παραγωγός είναι δωρεάν. Χρεώνουμε μόνο μια μικρή προμήθεια ανά πώληση.',
+      },
+    ],
+  },
+];
+
+function AccordionItem({ item }: { item: FaqItem }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border-b border-gray-200">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between py-4 text-left hover:text-green-700 transition-colors"
+        aria-expanded={open}
+      >
+        <span className="font-medium text-gray-900 pr-4">{item.q}</span>
+        <svg
+          className={`w-5 h-5 flex-shrink-0 text-gray-500 transition-transform ${open ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <div className="pb-4 text-gray-600 leading-relaxed">
+          {item.a}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function FaqPage() {
+  return (
+    <main className="container mx-auto px-4 py-8 max-w-3xl">
+      <h1 className="text-3xl font-bold mb-2">Συχνές Ερωτήσεις</h1>
+      <p className="text-gray-600 mb-8">
+        Βρείτε απαντήσεις στα πιο συνηθισμένα ερωτήματα σχετικά με το Dixis.
+      </p>
+
+      {sections.map((section) => (
+        <section key={section.title} className="mb-8">
+          <h2 className="text-xl font-semibold text-gray-900 mb-3">
+            {section.title}
+          </h2>
+          <div className="bg-white rounded-lg border border-gray-200 divide-y-0 px-4">
+            {section.items.map((item) => (
+              <AccordionItem key={item.q} item={item} />
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <div className="mt-8 p-6 bg-green-50 rounded-lg text-center">
+        <p className="text-gray-700 mb-3">
+          Δεν βρήκατε αυτό που ψάχνατε;
+        </p>
+        <Link
+          href="/contact"
+          className="inline-flex items-center justify-center bg-green-600 hover:bg-green-700 text-white font-medium py-2 px-6 rounded-lg transition"
+        >
+          Επικοινωνήστε μαζί μας
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,8 +1,30 @@
-export default function NotFound(){
+import Link from 'next/link';
+
+export default function NotFound() {
   return (
-    <main>
-      <h1 className="text-2xl font-bold">Η σελίδα δεν βρέθηκε</h1>
-      <p className="text-sm text-neutral-600 mt-2">Επιστρέψτε στην <a className="underline" href="/">αρχική</a> ή δείτε τα <a className="underline" href="/products">προϊόντα</a>.</p>
+    <main className="container mx-auto px-4 py-16 flex flex-col items-center text-center">
+      <p className="text-7xl font-bold text-gray-200 select-none">404</p>
+
+      <h1 className="text-2xl font-bold mt-4">Η σελίδα δεν βρέθηκε</h1>
+
+      <p className="text-gray-600 mt-2 max-w-md">
+        Η σελίδα που αναζητάτε δεν υπάρχει ή έχει μετακινηθεί.
+      </p>
+
+      <div className="flex flex-col sm:flex-row gap-3 mt-8">
+        <Link
+          href="/"
+          className="inline-flex items-center justify-center bg-green-600 hover:bg-green-700 text-white font-medium py-3 px-6 rounded-lg transition"
+        >
+          Αρχική σελίδα
+        </Link>
+        <Link
+          href="/products"
+          className="inline-flex items-center justify-center border border-gray-300 hover:bg-gray-50 text-gray-700 font-medium py-3 px-6 rounded-lg transition"
+        >
+          Δείτε τα προϊόντα
+        </Link>
+      </div>
     </main>
   );
 }

--- a/frontend/src/app/orders/lookup/page.tsx
+++ b/frontend/src/app/orders/lookup/page.tsx
@@ -186,7 +186,7 @@ function OrderLookupContent() {
                   } catch {}
                 }
               }}
-              placeholder="Email"
+              placeholder="Διεύθυνση email"
               ref={emailRef}
               type="email"
               className="border border-gray-300 px-3 py-2 rounded-lg w-full focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"

--- a/frontend/src/app/producers/waitlist/page.tsx
+++ b/frontend/src/app/producers/waitlist/page.tsx
@@ -35,7 +35,7 @@ export default function WaitlistPage(){
           <input name="phone" placeholder="Τηλέφωνο *" className="h-10 px-3 border rounded-md" required />
         </div>
         <div className="grid sm:grid-cols-2 gap-3">
-          <input type="email" name="email" placeholder="Email" className="h-10 px-3 border rounded-md" />
+          <input type="email" name="email" placeholder="Διεύθυνση email" className="h-10 px-3 border rounded-md" />
           <input name="region" placeholder="Περιοχή (π.χ. Λήμνος)" className="h-10 px-3 border rounded-md" />
         </div>
         <input name="products" placeholder="Τι προϊόντα έχεις (π.χ. μέλι, λάδι…)" className="h-10 px-3 border rounded-md" />

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -54,6 +54,9 @@ export default function Footer() {
           <div>
             <h4 className="font-semibold text-neutral-900 mb-3 sm:mb-4">Υποστήριξη</h4>
             <nav className="flex flex-col gap-1">
+              <Link href="/faq" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
+                Συχνές Ερωτήσεις
+              </Link>
               <Link href="/contact" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
                 Επικοινωνία / Σχόλια
               </Link>
@@ -91,7 +94,7 @@ export default function Footer() {
                 </button>
               ))}
             </div>
-            <span className="text-xs text-neutral-400">Made with Cyprus Green</span>
+            <span className="text-xs text-neutral-400">Με ελληνικό πάθος</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Translate 30+ English strings in HomeClient.tsx to Greek (filters, sort, organic, product cards, buttons, tooltips, loading/error states)
- Fix "Email" placeholder leak in 3 forms (contact, waitlist, order-lookup) → "Διεύθυνση email"
- Fix "Made with Cyprus Green" in footer → "Με ελληνικό πάθος"
- Rewrite `not-found.tsx` with large 404 visual, descriptive text, two CTA buttons (home + products)
- Rewrite `error.tsx` with warning icon, `reset()` retry button, home CTA
- Create `/faq` page with 4 sections (Παραγγελίες, Προϊόντα, Λογαριασμός, Παραγωγοί), 11 Q&As, accordion UI
- Add FAQ link in footer under Υποστήριξη section

## Test plan
- [ ] Visit `/products` → all filter labels, buttons, cards in Greek
- [ ] Visit `/contact` → email placeholder in Greek
- [ ] Visit `/producers/waitlist` → email placeholder in Greek
- [ ] Visit `/orders/lookup` → email placeholder in Greek
- [ ] Visit `/nonexistent-page` → styled 404 with navigation CTAs
- [ ] Visit `/faq` → 4 sections, accordions expand/collapse
- [ ] Footer shows FAQ link and Greek tagline
- [ ] `npm run build` passes