### PR TITLE
feat: add Privacy Policy & Terms of Service pages

### DIFF
--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Πολιτική Απορρήτου | Dixis',
+  description: 'Πολιτική απορρήτου και προστασία προσωπικών δεδομένων του dixis.gr.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="container mx-auto max-w-3xl px-4 py-12">
+      <h1 className="text-3xl font-bold mb-2">Πολιτική Απορρήτου</h1>
+      <p className="text-sm text-gray-500 mb-8">Τελευταία ενημέρωση: Φεβρουάριος 2026</p>
+
+      <div className="prose prose-gray max-w-none space-y-8">
+        <section>
+          <h2 className="text-xl font-semibold mb-3">1. Ποιοι είμαστε</h2>
+          <p className="text-gray-700 leading-relaxed">
+            Η πλατφόρμα <strong>Dixis</strong> (dixis.gr) είναι μια ηλεκτρονική αγορά
+            τοπικών Ελλήνων παραγωγών. Υπεύθυνος επεξεργασίας δεδομένων είναι η εταιρεία
+            που διαχειρίζεται το dixis.gr, με έδρα στην Ελλάδα.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">2. Δεδομένα που συλλέγουμε</h2>
+          <p className="text-gray-700 leading-relaxed mb-3">Κατά τη χρήση του dixis.gr ενδέχεται να συλλέγουμε:</p>
+          <ul className="list-disc pl-6 text-gray-700 space-y-1">
+            <li><strong>Στοιχεία εγγραφής:</strong> Ονοματεπώνυμο, email, τηλέφωνο</li>
+            <li><strong>Στοιχεία παραγγελίας:</strong> Διεύθυνση αποστολής, ταχυδρομικός κώδικας</li>
+            <li><strong>Στοιχεία πληρωμής:</strong> Τα δεδομένα πληρωμής διαχειρίζονται αποκλειστικά από τον πάροχο πληρωμών (Viva Wallet) — δεν αποθηκεύουμε αριθμούς καρτών</li>
+            <li><strong>Τεχνικά δεδομένα:</strong> Διεύθυνση IP, τύπος browser, cookies λειτουργικότητας</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">3. Σκοπός επεξεργασίας</h2>
+          <ul className="list-disc pl-6 text-gray-700 space-y-1">
+            <li>Εκτέλεση και παράδοση παραγγελιών</li>
+            <li>Επικοινωνία σχετικά με παραγγελίες (email ενημερώσεις)</li>
+            <li>Βελτίωση της λειτουργίας της πλατφόρμας</li>
+            <li>Συμμόρφωση με νομικές υποχρεώσεις (φορολογικά παραστατικά)</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">4. Νομική βάση</h2>
+          <p className="text-gray-700 leading-relaxed">
+            Η επεξεργασία βασίζεται στην εκτέλεση σύμβασης (παραγγελίες), στη συγκατάθεσή σας
+            (newsletter, cookies) και στα έννομα συμφέροντά μας (ασφάλεια πλατφόρμας),
+            σύμφωνα με τον GDPR (ΕΕ 2016/679).
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">5. Κοινοποίηση δεδομένων</h2>
+          <p className="text-gray-700 leading-relaxed mb-3">Τα δεδομένα σας μπορεί να κοινοποιηθούν σε:</p>
+          <ul className="list-disc pl-6 text-gray-700 space-y-1">
+            <li><strong>Παραγωγούς:</strong> Όνομα και διεύθυνση αποστολής για εκτέλεση παραγγελίας</li>
+            <li><strong>Πάροχο πληρωμών:</strong> Viva Wallet για ασφαλείς συναλλαγές</li>
+            <li><strong>Μεταφορικές εταιρείες:</strong> Διεύθυνση αποστολής για παράδοση</li>
+          </ul>
+          <p className="text-gray-700 leading-relaxed mt-3">
+            Δεν πωλούμε ή κοινοποιούμε τα δεδομένα σας σε τρίτους για διαφημιστικούς σκοπούς.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">6. Cookies</h2>
+          <p className="text-gray-700 leading-relaxed">
+            Χρησιμοποιούμε μόνο απαραίτητα cookies λειτουργικότητας (session, authentication).
+            Δεν χρησιμοποιούμε cookies παρακολούθησης ή διαφήμισης.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">7. Τα δικαιώματά σας</h2>
+          <p className="text-gray-700 leading-relaxed mb-3">Σύμφωνα με τον GDPR, έχετε δικαίωμα:</p>
+          <ul className="list-disc pl-6 text-gray-700 space-y-1">
+            <li>Πρόσβασης στα δεδομένα σας</li>
+            <li>Διόρθωσης ανακριβών δεδομένων</li>
+            <li>Διαγραφής (δικαίωμα στη λήθη)</li>
+            <li>Περιορισμού της επεξεργασίας</li>
+            <li>Φορητότητας δεδομένων</li>
+            <li>Ανάκλησης συγκατάθεσης</li>
+          </ul>
+          <p className="text-gray-700 leading-relaxed mt-3">
+            Για άσκηση των δικαιωμάτων σας, επικοινωνήστε μαζί μας στο{' '}
+            <a href="mailto:privacy@dixis.gr" className="text-green-600 hover:text-green-700 underline">
+              privacy@dixis.gr
+            </a>
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">8. Ασφάλεια</h2>
+          <p className="text-gray-700 leading-relaxed">
+            Εφαρμόζουμε κατάλληλα τεχνικά και οργανωτικά μέτρα ασφάλειας,
+            συμπεριλαμβανομένης κρυπτογράφησης SSL/TLS και ασφαλούς αποθήκευσης κωδικών.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">9. Επικοινωνία</h2>
+          <p className="text-gray-700 leading-relaxed">
+            Για ερωτήσεις σχετικά με την προστασία δεδομένων:{' '}
+            <a href="mailto:privacy@dixis.gr" className="text-green-600 hover:text-green-700 underline">
+              privacy@dixis.gr
+            </a>
+          </p>
+          <p className="text-gray-700 leading-relaxed mt-2">
+            Εποπτική αρχή: Αρχή Προστασίας Δεδομένων Προσωπικού Χαρακτήρα (
+            <a href="https://www.dpa.gr" target="_blank" rel="noopener noreferrer" className="text-green-600 hover:text-green-700 underline">
+              www.dpa.gr
+            </a>)
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -1,0 +1,121 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Όροι Χρήσης | Dixis',
+  description: 'Όροι και προϋποθέσεις χρήσης της πλατφόρμας dixis.gr.',
+};
+
+export default function TermsPage() {
+  return (
+    <main className="container mx-auto max-w-3xl px-4 py-12">
+      <h1 className="text-3xl font-bold mb-2">Όροι Χρήσης</h1>
+      <p className="text-sm text-gray-500 mb-8">Τελευταία ενημέρωση: Φεβρουάριος 2026</p>
+
+      <div className="prose prose-gray max-w-none space-y-8">
+        <section>
+          <h2 className="text-xl font-semibold mb-3">1. Γενικά</h2>
+          <p className="text-gray-700 leading-relaxed">
+            Οι παρόντες όροι χρήσης ρυθμίζουν τη σχέση μεταξύ του χρήστη και της πλατφόρμας
+            <strong> Dixis</strong> (dixis.gr). Χρησιμοποιώντας το dixis.gr, αποδέχεστε
+            τους παρόντες όρους στο σύνολό τους.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">2. Περιγραφή υπηρεσίας</h2>
+          <p className="text-gray-700 leading-relaxed">
+            Το Dixis είναι ηλεκτρονική αγορά (marketplace) που συνδέει τοπικούς Έλληνες
+            παραγωγούς με καταναλωτές. Η πλατφόρμα διευκολύνει τις συναλλαγές αλλά δεν
+            αποτελεί η ίδια πωλητή των προϊόντων.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">3. Εγγραφή χρήστη</h2>
+          <ul className="list-disc pl-6 text-gray-700 space-y-1">
+            <li>Η εγγραφή απαιτεί έγκυρο email και κωδικό πρόσβασης</li>
+            <li>Είστε υπεύθυνοι για τη διατήρηση της εμπιστευτικότητας του λογαριασμού σας</li>
+            <li>Πρέπει να είστε τουλάχιστον 18 ετών για να πραγματοποιήσετε αγορές</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">4. Παραγγελίες & Πληρωμές</h2>
+          <ul className="list-disc pl-6 text-gray-700 space-y-1">
+            <li>Οι τιμές εμφανίζονται σε Ευρώ (€) και περιλαμβάνουν ΦΠΑ όπου ισχύει</li>
+            <li>Η παραγγελία επιβεβαιώνεται με email μετά την ολοκλήρωση της πληρωμής</li>
+            <li>Αποδεκτοί τρόποι πληρωμής: Πιστωτική/χρεωστική κάρτα μέσω Viva Wallet, αντικαταβολή</li>
+            <li>Η αντικαταβολή επιβαρύνεται με κόστος 2,00 €</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">5. Αποστολή & Παράδοση</h2>
+          <ul className="list-disc pl-6 text-gray-700 space-y-1">
+            <li>Η αποστολή γίνεται εντός 1-2 εργάσιμων ημερών από την επιβεβαίωση</li>
+            <li>Τα μεταφορικά υπολογίζονται βάσει βάρους, περιοχής και αριθμού παραγωγών</li>
+            <li>Δωρεάν αποστολή για παραγγελίες άνω των 30 € ανά παραγωγό</li>
+            <li>Η παράδοση γίνεται στη διεύθυνση που δηλώνετε κατά την παραγγελία</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">6. Επιστροφές & Ακυρώσεις</h2>
+          <ul className="list-disc pl-6 text-gray-700 space-y-1">
+            <li>Δικαίωμα υπαναχώρησης εντός 14 ημερών σύμφωνα με την ελληνική νομοθεσία</li>
+            <li>Λόγω φύσης (φρέσκα τρόφιμα), ορισμένα προϊόντα εξαιρούνται από επιστροφή</li>
+            <li>Σε περίπτωση ελαττωματικού προϊόντος, επικοινωνήστε μαζί μας εντός 48 ωρών</li>
+            <li>Η επιστροφή χρημάτων γίνεται στον ίδιο τρόπο πληρωμής εντός 5 εργάσιμων</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">7. Ευθύνη πλατφόρμας</h2>
+          <p className="text-gray-700 leading-relaxed">
+            Το Dixis λειτουργεί ως διαμεσολαβητής μεταξύ παραγωγών και καταναλωτών.
+            Κάθε παραγωγός είναι υπεύθυνος για την ποιότητα, τη σήμανση και την ασφάλεια
+            των προϊόντων του. Το Dixis δεν φέρει ευθύνη για ελαττωματικά προϊόντα, αλλά
+            διαμεσολαβεί για την επίλυση κάθε προβλήματος.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">8. Για παραγωγούς</h2>
+          <ul className="list-disc pl-6 text-gray-700 space-y-1">
+            <li>Η εγγραφή ως παραγωγός υπόκειται σε έγκριση</li>
+            <li>Ο παραγωγός είναι υπεύθυνος για την ακρίβεια των πληροφοριών προϊόντων</li>
+            <li>Η τιμολόγηση καθορίζεται από τον παραγωγό</li>
+            <li>Το Dixis παρακρατεί προμήθεια ανά πώληση σύμφωνα με τη σύμβαση συνεργασίας</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">9. Πνευματική ιδιοκτησία</h2>
+          <p className="text-gray-700 leading-relaxed">
+            Το σύνολο του περιεχομένου του dixis.gr (λογότυπο, σχεδιασμός, κώδικας)
+            προστατεύεται από τη νομοθεσία περί πνευματικής ιδιοκτησίας.
+            Απαγορεύεται η αναπαραγωγή χωρίς γραπτή άδεια.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">10. Εφαρμοστέο δίκαιο</h2>
+          <p className="text-gray-700 leading-relaxed">
+            Οι παρόντες όροι διέπονται από το ελληνικό δίκαιο. Αρμόδια δικαστήρια
+            για τυχόν διαφορές ορίζονται τα δικαστήρια Αθηνών.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">11. Επικοινωνία</h2>
+          <p className="text-gray-700 leading-relaxed">
+            Για ερωτήσεις σχετικά με τους όρους χρήσης:{' '}
+            <a href="mailto:info@dixis.gr" className="text-green-600 hover:text-green-700 underline">
+              info@dixis.gr
+            </a>
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -60,10 +60,10 @@ export default function Footer() {
               <Link href="/contact" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
                 Επικοινωνία / Σχόλια
               </Link>
-              <Link href="/legal/terms" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
+              <Link href="/terms" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
                 Όροι Χρήσης
               </Link>
-              <Link href="/legal/privacy" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
+              <Link href="/privacy" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
                 Πολιτική Απορρήτου
               </Link>
             </nav>


### PR DESCRIPTION
## Summary
- Add `/privacy` page — GDPR-compliant Greek privacy policy
- Add `/terms` page — Greek terms of service for marketplace
- Fix footer links from `/legal/privacy` → `/privacy`, `/legal/terms` → `/terms`

These are legal requirements for e-commerce in Greece/EU.

## Test plan
- [ ] `/privacy` renders Greek privacy policy
- [ ] `/terms` renders Greek terms of service  
- [ ] Footer links navigate to correct pages (no more 404)