### PR TITLE
fix: prevent stray 0 rendering on thank-you page

### DIFF
--- a/frontend/src/app/(storefront)/thank-you/page.tsx
+++ b/frontend/src/app/(storefront)/thank-you/page.tsx
@@ -186,7 +186,7 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
                   </div>
                 )}
 {/* VAT only shown when implemented (currently not calculated by backend) */}
-                {order.vat && order.vat > 0 && (
+                {order.vat != null && order.vat > 0 && (
                   <div className="flex justify-between">
                     <span>ΦΠΑ (24%):</span>
                     <span>{fmt.format(order.vat)}</span>


### PR DESCRIPTION
## Summary
- Fix React rendering quirk where `0 && <jsx>` renders literal "0"
- VAT line on thank-you page showed stray "0" when tax_amount was 0
- Use `!= null &&` guard consistent with COD fee line

## Test plan
- [ ] Place COD order → thank-you page shows no stray "0"
- [ ] `npm run build` passes ✅