### PR TITLE
docs: update DoD — Stripe E2E payment verified

### DIFF
--- a/docs/DOD-LAUNCH-READINESS.md
+++ b/docs/DOD-LAUNCH-READINESS.md
@@ -98,22 +98,25 @@ All 4 Greek zones tested and return correct costs:
 | E2E order test (Card) | ✅ Tested | — | Consumer card order #7 created. Stripe Checkout Session opened with correct amount (€10.80). Stripe Link integration working. |
 | COD fee in backend total | ✅ Fixed | — | PR #2807: Backend now calculates COD fee server-side (4€) and includes it in order total. Order #8 verified: total=22.70€ (subtotal 15.80 + shipping 2.90 + COD 4.00). |
 | Producer cannot place orders | ⚠️ By Design | Low | OrderPolicy blocks producers (role=producer). Only guests, consumers, admins can checkout. |
-| Login page i18n | ⚠️ English | Medium | `/auth/login` shows English UI ("Sign in to your account", "Email address", "Password"). Should be Greek. |
-| Navbar i18n (logged in) | ⚠️ English | Medium | Navbar shows "Products", "Our Producers" in English when logged in. User dropdown: "My Orders", "Logout" in English. |
+| ~~Login page i18n~~ | ✅ Fixed | — | PR #2809: Removed browser language auto-detect. Default is now Greek for all visitors. |
+| ~~Navbar i18n (logged in)~~ | ✅ Fixed | — | PR #2809: Same root cause — browser `en` overriding default `el` locale. |
 | E2E registration | ✅ Tested | — | Consumer "Test User Dixis" (e2etest2026@dixis.gr) registered on production. Greek form, redirect to homepage. |
 | E2E waitlist | ✅ Tested | — | Producer waitlist form submitted successfully. "Ελήφθη! Θα σε καλέσουμε σύντομα." confirmed. |
 | Waitlist infra fix | ✅ Fixed | — | Added `/api/ops/` nginx route + `ADMIN_EMAIL` env var on production. Was returning 404/500. |
+| E2E card payment (full) | ✅ Tested | — | Order #9: Stripe Elements PaymentIntent confirmed with test card (pm_card_visa). PI `pi_3T0JQrQ9Xukpkfmb1FfNRit3` succeeded. Order total €6.40 (3.50 + 2.90 shipping). Thank-you page verified. |
+| Webhook gap | ⚠️ Known | Low | Webhook handles `checkout.session.completed` but not `payment_intent.succeeded`. Elements flow uses frontend confirm endpoint instead. Works correctly for launch. |
 
 ---
 
 ## P2 — Future Improvements
 
 - ~~Fix COD fee bug~~ → ✅ FIXED (PR #2807, Order #8 verified)
+- ~~Complete Stripe test payment~~ → ✅ DONE (Order #9, PI confirmed, thank-you page verified)
+- ~~Fix login page i18n~~ → ✅ FIXED (PR #2809, deployed + verified on production)
 - Dedicated OG image (1200x630 with product photos)
 - `/about` page with company story
 - Categories API endpoint in Laravel
 - Switch Stripe to live keys for real payments
-- **Fix login page i18n** — `/auth/login` shows English; navbar + user dropdown English when logged in
 - Multi-language support (currently Greek-only, correct for launch)
 - Producer product image upload improvements
 
@@ -138,6 +141,17 @@ All 4 Greek zones tested and return correct costs:
 - Stripe Checkout Session created with Stripe Link integration
 - Payment not completed (test mode, would charge test card)
 
+### Card Order #9 ✅ (Full Payment Completed)
+- **Authenticated consumer** (Test User Dixis, e2etest2026@dixis.gr)
+- Items: 1x Ντομάτες Βιολογικές = 3,50€
+- Shipping: 2,90€ (Αττική zone, ΤΚ 10671)
+- **Total: 6,40€** — correct in Stripe Elements + DB
+- PaymentIntent `pi_3T0JQrQ9Xukpkfmb1FfNRit3` confirmed with `pm_card_visa`
+- PI status: **succeeded** ✅
+- Order status: **confirmed**, payment_status: **paid** ✅
+- Thank-you page: Order #9 displayed correctly with all Greek text ✅
+- Tracking link present ✅
+
 ### ~~BUG: COD Fee Not Persisted~~ → ✅ FIXED (PR #2807)
 **Resolution**: Added `cod_fee` column to orders table. Backend `CheckoutService` now
 calculates COD fee server-side using `config('shipping.cod_fee_eur')` when `payment_method=COD`.
@@ -151,7 +165,7 @@ Fee is included in order total. Verified with Order #8:
 
 1. ~~Place a test COD order~~ → ✅ DONE (Order #6)
 2. ~~Place a test Card order~~ → ✅ DONE (Order #7, Stripe redirect works)
-3. **Complete a Stripe test payment** → use test card 4242 4242 4242 4242 → verify webhook fires → order confirmed
+3. ~~Complete a Stripe test payment~~ → ✅ DONE (Order #9, PaymentIntent confirmed, €6.40 paid, thank-you page verified)
 4. ~~Register as new customer~~ → ✅ DONE (Consumer "Test User Dixis", e2etest2026@dixis.gr, registered + login verified)
 5. ~~Apply as producer~~ → ✅ DONE (Waitlist form submitted, "Ελήφθη!" confirmed. Required nginx route + ADMIN_EMAIL fix.)
 6. **Switch Stripe to live keys** when ready for real payments
@@ -163,4 +177,5 @@ _Audit completed 2026-02-13 by agent. All automated checks passed._
 _E2E order tests completed 2026-02-13. COD + Card orders verified on production._
 _COD fee bug fixed 2026-02-13. PR #2807 + #2808 deployed. Order #8 verified correct totals._
 _E2E registration + waitlist tests completed 2026-02-13. Waitlist infra fix deployed (nginx route + ADMIN_EMAIL)._
-_i18n bug discovered 2026-02-13: Login page + navbar + user dropdown show English instead of Greek._
+_i18n bug fixed 2026-02-13: PR #2809 — removed browser language auto-detect, default to Greek. Verified on production._
+_Stripe E2E payment completed 2026-02-13: Order #9, PI pi_3T0JQrQ9Xukpkfmb1FfNRit3 succeeded (€6.40). Thank-you page verified._


### PR DESCRIPTION
## Summary
- Stripe E2E payment test completed on production (Order #9)
- PaymentIntent `pi_3T0JQrQ9Xukpkfmb1FfNRit3` confirmed with test card (€6.40)
- Thank-you page verified with correct Greek text and order details
- i18n fix (PR #2809) documented as resolved
- Webhook gap noted (Elements flow uses frontend confirm, not webhook)

## Test plan
- [x] Order #9 visible in production DB with status=confirmed, payment_status=paid
- [x] Thank-you page displays correct order summary
- [x] All manual testing items now checked off except "Switch Stripe to live keys"