### PR TITLE
fix: harden cart sync + align SEO test with Greek manifest

### DIFF
--- a/frontend/src/lib/cart.ts
+++ b/frontend/src/lib/cart.ts
@@ -79,10 +79,12 @@ export const useCart = create<State>()(
       },
       getItemsForSync: () => {
         const items = get().items
-        return Object.values(items).map(item => ({
-          product_id: parseInt(item.id, 10),
-          quantity: item.qty,
-        }))
+        return Object.values(items)
+          .filter(item => item.id && !isNaN(parseInt(item.id, 10)) && item.qty > 0)
+          .map(item => ({
+            product_id: parseInt(item.id, 10),
+            quantity: item.qty,
+          }))
       },
     }),
     { name: 'dixis:cart:v1' }

--- a/frontend/tests/e2e/seo-basics.spec.ts
+++ b/frontend/tests/e2e/seo-basics.spec.ts
@@ -193,7 +193,7 @@ test.describe('SEO Basics Implementation', () => {
       const content = await page.textContent('body');
       const manifest = JSON.parse(content!);
       
-      expect(manifest.name).toBe('Project Dixis - Local Producer Marketplace');
+      expect(manifest.name).toBe('Dixis — Φρέσκα τοπικά προϊόντα');
       expect(manifest.short_name).toBe('Dixis');
       expect(manifest.display).toBe('standalone');
       expect(manifest.theme_color).toBe('#16a34a');


### PR DESCRIPTION
## Summary
- **Cart sync hardening**: Filter invalid product IDs (NaN, empty string) in `getItemsForSync()` to prevent 422 validation errors when syncing cart on login. The Laravel CartController requires `product_id` to be a valid integer — items with demo/invalid IDs were slipping through.
- **SEO test alignment**: Update E2E manifest name assertion from English `"Project Dixis - Local Producer Marketplace"` to Greek `"Dixis — Φρέσκα τοπικά προϊόντα"` to match the current PWA manifest.

## Files changed (2 files, +7/-5 lines)
- `frontend/src/lib/cart.ts` — Add `.filter()` before `.map()` in `getItemsForSync()`
- `frontend/tests/e2e/seo-basics.spec.ts` — Fix manifest name assertion

## Test plan
- [ ] Login with items in cart → no 422 errors in console
- [ ] Cart with demo/invalid product IDs → filtered out during sync
- [ ] `npm run build` passes
- [ ] E2E seo-basics test passes with updated manifest name