### PR TITLE
fix: bridge brand colors to Tailwind v4 theme — invisible bg-primary

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -18,6 +18,10 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-primary: var(--brand-primary);
+  --color-primary-light: var(--brand-primary-light);
+  --color-primary-pale: var(--brand-primary-pale);
+  --color-primary-foreground: var(--brand-primary-foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }


### PR DESCRIPTION
## Summary
- **Critical bug**: `bg-primary` Tailwind class resolved to `rgba(0,0,0,0)` (transparent) — cart badge invisible, Header/Footer/CTA buttons unstyled
- **Root cause**: Tailwind v4 uses `@theme inline` for color definitions, not `tailwind.config.ts`. The `--color-primary` variable was never defined in the theme block.
- **Fix**: Bridge 4 brand color variables from `brand.css` into the `@theme inline` block in `globals.css`

## What was affected (21 usages across 10 files)
- `CartIcon.tsx` — badge background (invisible → green)
- `Header.tsx` — 8 primary-colored elements
- `Footer.tsx` — accent elements
- `button.tsx` — primary button variant
- `CTA.tsx` — call-to-action backgrounds
- `Hero.tsx`, `Trust.tsx`, `NotificationDropdown.tsx`, `card.tsx`, notifications page

## Change
```css
@theme inline {
  --color-background: var(--background);
  --color-foreground: var(--foreground);
+ --color-primary: var(--brand-primary);
+ --color-primary-light: var(--brand-primary-light);
+ --color-primary-pale: var(--brand-primary-pale);
+ --color-primary-foreground: var(--brand-primary-foreground);
  --font-sans: var(--font-geist-sans);
  --font-mono: var(--font-geist-mono);
}
```

## Test plan
- [ ] Cart badge shows green circle with item count
- [ ] Header primary-colored elements render correctly
- [ ] Primary buttons (CTA, forms) show green background
- [ ] `npm run build` passes