### PR TITLE
fix(css): wrap base styles in @layer base for Tailwind v4

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -27,8 +27,10 @@
 }
 
 /* =============================================================================
-   BASE STYLES
+   BASE STYLES — wrapped in @layer base so Tailwind utilities can override
    ============================================================================= */
+
+@layer base {
 
 * {
   box-sizing: border-box;
@@ -91,6 +93,8 @@ a {
 a:hover {
   color: var(--brand-primary-light);
 }
+
+} /* end @layer base */
 
 /* =============================================================================
    BUTTONS


### PR DESCRIPTION
## Summary
- Wraps global element styles (`a`, `p`, `h1-h3`, `*`) in `@layer base {}` so Tailwind v4 utility classes can override them
- Fixes invisible hero CTA button ("Δείτε τα Προϊόντα") — was green text on green background because `a { color: var(--brand-primary) }` overrode `text-white`
- Fixes all link-based components where `text-white` or `text-primary-foreground` was being ignored

## Root Cause
In Tailwind v4, styles outside `@layer` have higher specificity than utility classes. The global `a { color: ... }` rule was winning over `text-white` on `<a>` elements used as buttons.

## Test Plan
- [ ] Verify hero CTA "Δείτε τα Προϊόντα" shows white text on green button
- [ ] Verify cart badge still visible (green circle, white number)
- [ ] Verify product card links and breadcrumb links still styled correctly
- [ ] Verify no visual regressions on /products, /cart, /checkout pages