### PR TITLE
fix: resolve producer ID for flat profile routes (500 error)

### DIFF
--- a/backend/app/Http/Requests/UpdateProducerRequest.php
+++ b/backend/app/Http/Requests/UpdateProducerRequest.php
@@ -21,7 +21,11 @@ class UpdateProducerRequest extends FormRequest
      */
     public function rules(): array
     {
-        $producerId = $this->route('producer') ? $this->route('producer')->id ?? $this->route('producer') : null;
+        // Fix: For flat routes like PATCH /v1/producer/profile (no {producer} param),
+        // resolve producer ID from the authenticated user instead of route binding.
+        $producerId = $this->route('producer')
+            ? ($this->route('producer')->id ?? $this->route('producer'))
+            : ($this->user()?->producer?->id);
 
         return [
             'name' => 'sometimes|required|string|max:255',


### PR DESCRIPTION
## Summary
- Fixed 500 error when saving producer settings via PATCH `/v1/producer/profile`
- Root cause: `UpdateProducerRequest` used `$this->route('producer')` for slug uniqueness validation, but flat routes (no `{producer}` param) returned `null`, causing PostgreSQL `invalid input syntax for type bigint: ""`
- Fix: Falls back to `$this->user()?->producer?->id` when no route binding is present

## Test plan
- [x] Verified PATCH `/api/v1/producer/profile` returns 200 OK on production (was 500)
- [x] Producer settings save works end-to-end on dixis.gr
- [ ] Existing admin producer update routes still work (they use `{producer}` route binding)