### PR TITLE
security: close public orders data leak + protect endpoints

### DIFF
--- a/frontend/src/app/(storefront)/thank-you/page.tsx
+++ b/frontend/src/app/(storefront)/thank-you/page.tsx
@@ -29,7 +29,8 @@ interface Order {
 }
 
 export default function ThankYouPage({ searchParams }: { searchParams?: Record<string, string | undefined> }) {
-  const orderId = searchParams?.id || ''
+  // SECURITY FIX: Use token (UUID) instead of sequential ID for order lookup
+  const orderToken = searchParams?.token || searchParams?.id || ''
   const [order, setOrder] = useState<Order | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -37,7 +38,7 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
   const fmt = new Intl.NumberFormat('el-GR', { style: 'currency', currency: 'EUR' })
 
   useEffect(() => {
-    if (!orderId) {
+    if (!orderToken) {
       setError('Δεν βρέθηκε κωδικός παραγγελίας')
       setLoading(false)
       return
@@ -45,9 +46,8 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
 
     async function fetchOrder() {
       try {
-        // Pass 54: Fetch from Laravel API (single source of truth)
-        // This ensures we get the same order data as /account/orders
-        const laravelOrder = await apiClient.getPublicOrder(orderId)
+        // SECURITY FIX: Fetch by UUID token instead of sequential ID
+        const laravelOrder = await apiClient.getOrderByToken(orderToken)
 
         // Transform Laravel order format to thank-you page format
         const orderItems = laravelOrder.items || laravelOrder.order_items || []
@@ -90,7 +90,7 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
     }
 
     fetchOrder()
-  }, [orderId])
+  }, [orderToken])
 
   if (loading) {
     return (

--- a/frontend/src/app/(storefront)/viva-return/page.tsx
+++ b/frontend/src/app/(storefront)/viva-return/page.tsx
@@ -32,7 +32,7 @@ function VivaReturnContent() {
           setMessage('Η πληρωμή ολοκληρώθηκε!')
           // Redirect to thank-you after brief delay
           setTimeout(() => {
-            router.push(`/thank-you?id=${data.orderId}`)
+            router.push(`/thank-you?token=${data.orderToken || data.orderId}`)
           }, 1500)
         } else {
           setStatus('error')

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -664,31 +664,16 @@ class ApiClient {
     return this.request<Order>(`orders/${id}`);
   }
 
-  // Public orders endpoints (consumer-facing)
-  async getPublicOrders(params?: {
-    page?: number;
-    per_page?: number;
-    status?: string;
-  }): Promise<{ data: Order[] }> {
-    const searchParams = new URLSearchParams();
+  // SECURITY FIX: Removed getPublicOrders() — was exposing ALL orders without auth.
+  // Orders list is now only available via authenticated getOrders() endpoint.
 
-    if (params) {
-      Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
-          searchParams.append(key, value.toString());
-        }
-      });
-    }
-
-    const queryString = searchParams.toString();
-    const endpoint = `public/orders${queryString ? `?${queryString}` : ''}`;
-
-    return this.request<{ data: Order[] }>(endpoint);
-  }
-
-  async getPublicOrder(id: number | string): Promise<Order> {
-    // API returns { data: Order }, must unwrap
-    const response = await this.request<{ data: Order }>(`public/orders/${id}`);
+  /**
+   * SECURITY FIX: Get order by UUID public token (not guessable sequential ID).
+   * Used by thank-you page and email confirmation links.
+   * Replaces the old getPublicOrder(id) which used sequential IDs.
+   */
+  async getOrderByToken(token: string): Promise<Order> {
+    const response = await this.request<{ data: Order }>(`public/orders/by-token/${token}`);
     return response.data;
   }
 

--- a/frontend/src/lib/email.ts
+++ b/frontend/src/lib/email.ts
@@ -10,6 +10,7 @@
 
 export interface OrderEmailData {
   id: string
+  public_token?: string // SECURITY FIX: UUID token for thank-you/tracking links
   total: number
   subtotal: number
   shipping: number
@@ -370,9 +371,9 @@ function renderOrderConfirmationHTML(order: OrderEmailData): string {
         Μπορείτε να δείτε τα στοιχεία της παραγγελίας σας στο:
       </p>
       <p style="margin: 0;">
-        <a href="https://dixis.gr/thank-you?id=${order.id}"
+        <a href="https://dixis.gr/thank-you?token=${order.public_token || order.id}"
            style="color: #059669; text-decoration: none; font-weight: bold; font-size: 14px;">
-          https://dixis.gr/thank-you?id=${order.id}
+          https://dixis.gr/thank-you?token=${order.public_token || order.id}
         </a>
       </p>
     </div>


### PR DESCRIPTION
## Summary

**CRITICAL SECURITY FIX** — The `GET /api/v1/public/orders` endpoint exposed ALL orders without authentication. Anyone could enumerate sequential order IDs and view order details, amounts, payment status, and public tokens.

### Changes
- 🔴 **Remove public order listing** — `GET /api/v1/public/orders` (data leak)
- 🔴 **Remove public order by ID** — `GET /api/v1/public/orders/{id}` (guessable sequential IDs)
- ✅ **Add token-based order lookup** — `GET /api/v1/public/orders/by-token/{token}` (UUID v4, not guessable)
- 🟠 **Protect commission-preview** — Added `auth:sanctum` middleware
- ✅ **Thank-you page uses token** — `?token=UUID` instead of `?id=123`
- ✅ **Checkout redirects use public_token** from order response
- ✅ **Email links use public_token** for thank-you URLs
- 🧹 **Remove dead code** — `getPublicOrders()`, `getPublicOrder()` from API client

### What stays public
- `POST /api/v1/public/orders` — order creation (guest checkout)
- `GET /api/v1/public/orders/track/{token}` — order tracking by UUID
- `GET /api/v1/public/orders/by-token/{token}` — full order details by UUID

### Test plan
- [ ] Create COD order → verify redirect uses `?token=UUID`
- [ ] Thank-you page loads correctly with token param
- [ ] `GET /api/v1/public/orders` returns 404 (removed)
- [ ] `GET /api/v1/public/orders/1` returns 404 (removed)
- [ ] `GET /api/v1/public/orders/by-token/{valid-uuid}` returns order
- [ ] Commission-preview returns 401 without auth
- [ ] Email confirmation links use token-based URLs