### PR TITLE
fix: operational audit — producer orders access + SEO improvements

### DIFF
--- a/frontend/src/app/account/orders/[orderId]/page.tsx
+++ b/frontend/src/app/account/orders/[orderId]/page.tsx
@@ -443,7 +443,7 @@ function OrderDetailsPage(): React.JSX.Element {
 
 export default function OrderDetailsPageWithAuth(): React.JSX.Element {
   return (
-    <AuthGuard requireAuth={true} requireRole="consumer">
+    <AuthGuard requireAuth={true}>
       <OrderDetailsPage />
     </AuthGuard>
   );

--- a/frontend/src/app/account/orders/page.tsx
+++ b/frontend/src/app/account/orders/page.tsx
@@ -148,7 +148,7 @@ function OrdersPage(): React.JSX.Element {
 
 export default function OrdersPageWithAuth(): React.JSX.Element {
   return (
-    <AuthGuard requireAuth={true} requireRole="consumer">
+    <AuthGuard requireAuth={true}>
       <OrdersPage />
     </AuthGuard>
   );

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -68,18 +68,18 @@ export const metadata: Metadata = {
     description: 'Ανακαλύψτε φρέσκα τοπικά προϊόντα απευθείας από Έλληνες παραγωγούς. Από το χωράφι στο τραπέζι σας.',
     images: [
       {
-        url: `${siteUrl}/logo.svg`,
-        width: 400,
-        height: 400,
-        alt: 'Dixis - Φρέσκα τοπικά προϊόντα',
+        url: `${siteUrl}/hero-lcp.png`,
+        width: 1200,
+        height: 630,
+        alt: 'Dixis - Φρέσκα τοπικά προϊόντα από Έλληνες παραγωγούς',
       },
     ],
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'Dixis | Φρέσκα τοπικά προϊόντα από Έλληνες παραγωγούς',
     description: 'Ανακαλύψτε φρέσκα τοπικά προϊόντα απευθείας από Έλληνες παραγωγούς.',
-    images: [`${siteUrl}/logo.svg`],
+    images: [`${siteUrl}/hero-lcp.png`],
   },
   alternates: {
     canonical: siteUrl,

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -51,6 +51,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'monthly',
       priority: 0.5,
     },
+    {
+      url: `${BASE_URL}/faq`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: `${BASE_URL}/producers/join`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
   ];
 
   // Dynamic product pages from Laravel API (single source of truth)


### PR DESCRIPTION
## Summary
- **P0 Fix**: Remove `requireRole="consumer"` from `/account/orders` AuthGuard — producers can shop (cart/checkout works) but couldn't view their purchase orders
- **P1 Fix**: Add `/faq` and `/producers/join` to `sitemap.xml` (missing from SEO crawl)
- **P2 Fix**: Switch `og:image` from SVG → PNG (`hero-lcp.png`) for Facebook/Twitter social sharing compatibility, upgrade Twitter card to `summary_large_image`

## Context
Found during Operational Depth Audit of live dixis.gr production site.

## Test plan
- [ ] Logged in as producer, navigate to `/account/orders` — should show order history (not redirect to dashboard)
- [ ] Check `/sitemap.xml` includes `/faq` and `/producers/join`
- [ ] Validate og:image with Facebook Sharing Debugger