### PR TITLE
feat: producer name clickable + profile page redesign

### DIFF
--- a/frontend/src/app/producers/[slug]/page.tsx
+++ b/frontend/src/app/producers/[slug]/page.tsx
@@ -111,7 +111,7 @@ export default async function ProducerProfilePage(
         </nav>
 
         {/* Producer Hero */}
-        <div className="bg-white rounded-xl border border-neutral-200 overflow-hidden mb-8">
+        <div className="bg-white rounded-xl border border-neutral-200 overflow-hidden mb-6">
           <div className="grid md:grid-cols-3 gap-0">
             {/* Image */}
             <div className="aspect-[4/3] md:aspect-auto bg-neutral-100 overflow-hidden">
@@ -132,38 +132,59 @@ export default async function ProducerProfilePage(
 
             {/* Info */}
             <div className="md:col-span-2 p-6 sm:p-8 flex flex-col justify-center">
-              <span className="text-xs font-semibold text-primary uppercase tracking-wider mb-1">
-                {producer.category}
-              </span>
-              <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
+              {producer.category && (
+                <span className="text-xs font-semibold text-primary uppercase tracking-wider mb-1">
+                  {producer.category}
+                </span>
+              )}
+              <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-3">
                 {producer.name}
               </h1>
-              <p className="text-sm text-gray-500 flex items-center gap-1 mb-4">
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-                {producer.region}
-              </p>
-              {producer.description && (
-                <p className="text-gray-700 leading-relaxed mb-4">{producer.description}</p>
+              {producer.region && (
+                <p className="text-sm text-gray-500 flex items-center gap-1.5 mb-4">
+                  <svg className="w-4 h-4 text-primary/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                  {producer.region}
+                </p>
               )}
-              <p className="text-sm text-gray-500">
+              <span className="inline-flex items-center gap-1.5 text-sm text-gray-600 bg-neutral-100 px-3 py-1 rounded-full w-fit">
+                <svg className="w-4 h-4 text-primary/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+                </svg>
                 {productCount} {productCount === 1 ? 'προϊόν' : 'προϊόντα'}
-              </p>
+              </span>
             </div>
           </div>
         </div>
 
+        {/* Story / Description section */}
+        {producer.description && (
+          <div className="bg-primary/5 rounded-xl border border-primary/10 p-6 sm:p-8 mb-8">
+            <h2 className="text-lg font-bold text-gray-900 mb-3 flex items-center gap-2">
+              <svg className="w-5 h-5 text-primary/70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z" />
+              </svg>
+              Η Ιστορία μας
+            </h2>
+            <p className="text-gray-700 leading-relaxed">{producer.description}</p>
+          </div>
+        )}
+
         {/* Products Section */}
         {productCount > 0 ? (
           <>
-            <h2 className="text-xl font-bold text-gray-900 mb-4">
-              Τα προϊόντα του παραγωγού
-            </h2>
+            <div className="flex items-center gap-3 mb-6">
+              <h2 className="text-xl font-bold text-gray-900">
+                Τα Προϊόντα μας
+              </h2>
+              <span className="text-xs font-semibold text-primary bg-primary/10 px-2.5 py-1 rounded-full">
+                {productCount}
+              </span>
+            </div>
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
               {producer.products.map((p) => {
-                // Pass FIX-MOBILE-CARDS-01: Resolve image from images[] array or image_url
                 const imageUrl = p.image_url || p.images?.[0]?.url || null;
                 const price = typeof p.price === 'string' ? parseFloat(p.price) : p.price;
                 return (
@@ -177,6 +198,7 @@ export default async function ProducerProfilePage(
                     priceCents={Math.round(price * 100)}
                     image={imageUrl}
                     stock={p.stock}
+                    hideProducerLink
                   />
                 );
               })}

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -15,11 +15,12 @@ type Props = {
   priceCents: number
   image?: string | null
   stock?: number | null
+  hideProducerLink?: boolean
 }
 
 const fmtEUR = new Intl.NumberFormat('el-GR', { style: 'currency', currency: 'EUR' })
 
-export function ProductCard({ id, title, producer, producerId, producerSlug, priceCents, image, stock }: Props) {
+export function ProductCard({ id, title, producer, producerId, producerSlug, priceCents, image, stock, hideProducerLink }: Props) {
   const price = typeof priceCents === 'number' ? fmtEUR.format(priceCents / 100) : '—'
   const hasImage = image && image.length > 0
   const productUrl = `/products/${id}`
@@ -29,7 +30,7 @@ export function ProductCard({ id, title, producer, producerId, producerSlug, pri
 
   return (
     <div data-testid="product-card" className="group flex flex-col h-full bg-white border border-neutral-200 rounded-xl overflow-hidden hover:shadow-card-hover hover:border-primary/20 transition-all duration-300">
-      {/* Clickable section - navigates to product page */}
+      {/* Image — navigates to product page */}
       <Link href={productUrl} className="flex flex-col touch-manipulation active:scale-[0.99]">
         <div data-testid="product-card-image" className="relative aspect-square sm:h-48 sm:aspect-auto w-full bg-neutral-100 overflow-hidden">
           {hasImage ? (
@@ -47,34 +48,29 @@ export function ProductCard({ id, title, producer, producerId, producerSlug, pri
             </div>
           )}
         </div>
-
-        {/* Pass FIX-MOBILE-CARDS-01: Reduced padding on mobile for better space usage */}
-        <div className="px-2.5 pt-3 pb-1.5 sm:px-4 sm:pt-4 sm:pb-2">
-          <span data-testid="product-card-producer" className="text-xs font-semibold text-primary uppercase tracking-wider truncate block">
-            {producer || 'Παραγωγός'}
-          </span>
-          <h3 data-testid="product-card-title" className="text-sm sm:text-base font-bold text-gray-900 line-clamp-2 mt-1 leading-tight">
-            {title}
-          </h3>
-        </div>
       </Link>
 
-      {/* Pass FIX-MOBILE-CARDS-01: Producer link */}
-      {producerUrl && (
-        <div className="px-2.5 sm:px-4 pb-1">
+      {/* Producer name + product title */}
+      <div className="px-2.5 pt-3 pb-1.5 sm:px-4 sm:pt-4 sm:pb-2">
+        {producerUrl && !hideProducerLink ? (
           <Link
             href={producerUrl}
             data-testid="product-card-producer-link"
-            className="inline-flex items-center gap-1 text-xs text-primary/70 hover:text-primary transition-colors"
-            onClick={(e) => e.stopPropagation()}
+            className="text-xs font-semibold text-primary uppercase tracking-wider truncate block hover:underline transition-colors"
           >
-            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-            </svg>
-            <span>Δες τον παραγωγό</span>
+            {producer || 'Παραγωγός'}
           </Link>
-        </div>
-      )}
+        ) : (
+          <span data-testid="product-card-producer" className="text-xs font-semibold text-primary uppercase tracking-wider truncate block">
+            {producer || 'Παραγωγός'}
+          </span>
+        )}
+        <Link href={productUrl} className="block mt-1">
+          <h3 data-testid="product-card-title" className="text-sm sm:text-base font-bold text-gray-900 line-clamp-2 leading-tight hover:text-primary/80 transition-colors">
+            {title}
+          </h3>
+        </Link>
+      </div>
 
       {/* Non-clickable section - price + add to cart button */}
       {/* Pass FIX-MOBILE-CARDS-01: Stack vertically on mobile, row on sm+ */}

--- a/frontend/src/components/marketing/FeaturedProducts.tsx
+++ b/frontend/src/components/marketing/FeaturedProducts.tsx
@@ -83,6 +83,7 @@ export default async function FeaturedProducts() {
                 title={product.name}
                 producer={product.producer?.name || null}
                 producerId={product.producer_id}
+                producerSlug={product.producer?.slug || null}
                 priceCents={Math.round(product.price * 100)}
                 image={product.image_url || null}
                 stock={product.stock}


### PR DESCRIPTION
## Summary
- **ProductCard**: Producer name is now a direct clickable link to the producer profile page — replaces the separate "Δες τον παραγωγό" link that the user had to discover
- **FeaturedProducts**: Added missing `producerSlug` prop so homepage cards use clean slug URLs instead of numeric IDs
- **Producer Profile Page**: Redesigned with story section (warm `bg-primary/5` background), product count badge, improved section heading with count pill, and `hideProducerLink` on own-page product cards

## Changes (3 files, +62/-43)
| File | Change |
|------|--------|
| `ProductCard.tsx` | Producer name = Link, removed "Δες τον παραγωγό", added `hideProducerLink` prop |
| `FeaturedProducts.tsx` | Added `producerSlug={product.producer?.slug}` |
| `producers/[slug]/page.tsx` | Story section, badges, `hideProducerLink` on own cards |

## Test plan
- [ ] Homepage: producer name on featured product cards is clickable → navigates to `/producers/{slug}`
- [ ] `/products` page: same behavior
- [ ] `/producers/{slug}`: improved layout with story section, no clickable producer name on own cards
- [ ] No "Δες τον παραγωγό" link visible anywhere
- [ ] TypeScript ✅, Build ✅