### PR TITLE
fix: email notification + shipping address on producer order detail

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -64,6 +64,7 @@ export interface CartResponse {
 
 export interface ShippingAddress {
   name?: string;
+  email?: string;
   phone?: string;
   line1?: string;
   line2?: string;
@@ -175,6 +176,7 @@ export interface ProducerOrderRaw {
   currency: string;
   created_at: string;
   updated_at: string;
+  shipping_address?: ShippingAddress;
   user?: {
     id: number;
     name: string;
@@ -197,6 +199,7 @@ export interface ProducerOrder {
   currency: string;
   created_at: string;
   updated_at: string;
+  shipping_address?: ShippingAddress;
   user?: {
     id: number;
     name: string;


### PR DESCRIPTION
## Summary
- **FIX-EMAIL-01**: Remove broken Prisma dependency from email notification route. Orders live in Laravel DB, not Prisma — the route always returned 404. Now receives order data directly from the page component (which has it from the Laravel API).
- **FIX-SHIPPING-01**: Add shipping address section to producer order detail page (was only on list page from PR #2839).
- **Type update**: Add `email` to `ShippingAddress` and `shipping_address` to `ProducerOrder` types.

## Root Cause (Email)
The `/api/producer/orders/[id]/status` route used `prisma.order.findUnique()` to look up customer email, but orders are owned by Laravel/PostgreSQL. Prisma's Order model uses `cuid` IDs while Laravel uses `bigint` auto-increment — completely different databases. The fix removes the Prisma lookup entirely and receives the needed data from the client, which already fetched it from the Laravel API.

## Changes (3 files, ~77 LOC)
| File | Change |
|------|--------|
| `frontend/src/app/api/producer/orders/[id]/status/route.ts` | Remove Prisma import + lookup, accept data from request body |
| `frontend/src/app/producer/orders/[id]/page.tsx` | Pass email/name/total to notification route, add shipping address section |
| `frontend/src/lib/api.ts` | Add `email` to ShippingAddress, add `shipping_address` to ProducerOrder types |

## Test plan
- [ ] Navigate to `/producer/orders/9` as Κτήμα Παπαδόπουλου
- [ ] Verify shipping address shows in amber box (name, address, city, postal code, phone)
- [ ] Click "Ξεκίνησε Επεξεργασία" — no more "Αποτυχία αποστολής email" error
- [ ] Email notification shows "sent" or "skipped (dry-run)" status
- [ ] TypeScript compiles cleanly
- [ ] Build succeeds