### PR TITLE
ux: producer pages loading spinners + mobile card layout

### DIFF
--- a/frontend/src/app/producer/dashboard/page.tsx
+++ b/frontend/src/app/producer/dashboard/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { apiClient, ProducerStats, Product } from '@/lib/api';
 import AuthGuard from '@/components/AuthGuard';
+import LoadingSpinner from '@/components/LoadingSpinner';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTranslations } from '@/contexts/LocaleContext';
 import { formatCurrency } from '@/env';
@@ -128,7 +129,7 @@ export default function ProducerDashboard() {
 
         {loading ? (
           <div className="flex justify-center py-12">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600"></div>
+            <LoadingSpinner />
           </div>
         ) : error ? (
           <div className="text-center py-12">
@@ -200,7 +201,44 @@ export default function ProducerDashboard() {
                     </button>
                   </div>
                 ) : (
-                  <div className="overflow-x-auto -mx-6">
+                  <>
+                  {/* Mobile card layout */}
+                  <div className="md:hidden space-y-3">
+                    {topProducts.slice(0, 5).map((product) => (
+                      <div key={product.id} className="flex items-center gap-3 p-3 border rounded-lg">
+                        <div className="flex-shrink-0 h-12 w-12">
+                          {product.images.length > 0 ? (
+                            <img
+                              className="h-12 w-12 rounded-lg object-cover"
+                              src={product.images[0].image_path}
+                              alt={product.images[0].alt_text || product.name}
+                            />
+                          ) : (
+                            <div className="h-12 w-12 rounded-lg bg-gray-200 flex items-center justify-center">
+                              <span className="text-xs text-gray-400">{t('producerDashboard.noImage')}</span>
+                            </div>
+                          )}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-gray-900 truncate">{product.name}</p>
+                          <p className="text-sm text-gray-600">
+                            {formatCurrency(parseFloat(product.price || product.current_price))} / {product.unit}
+                          </p>
+                          <div className="flex items-center gap-2 mt-1">
+                            <span className="text-xs text-gray-500">
+                              {product.stock !== null ? `${product.stock} ${product.unit}(s)` : t('producerDashboard.inStock')}
+                            </span>
+                            <span className="inline-flex px-1.5 py-0.5 text-xs font-semibold rounded-full bg-green-100 text-green-800">
+                              {t('producerDashboard.active')}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* Desktop table layout */}
+                  <div className="hidden md:block overflow-x-auto -mx-6">
                     <table className="min-w-full divide-y divide-gray-200">
                       <thead className="bg-gray-50">
                         <tr>
@@ -272,6 +310,7 @@ export default function ProducerDashboard() {
                       </tbody>
                     </table>
                   </div>
+                  </>
                 )}
               </div>
             </div>

--- a/frontend/src/app/producer/onboarding/page.tsx
+++ b/frontend/src/app/producer/onboarding/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { apiClient } from '@/lib/api';
+import LoadingSpinner from '@/components/LoadingSpinner';
 
 interface ProducerProfile {
   id: number;
@@ -87,7 +88,7 @@ export default function ProducerOnboardingPage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600" />
+        <LoadingSpinner />
       </div>
     );
   }

--- a/frontend/src/app/producer/orders/[id]/page.tsx
+++ b/frontend/src/app/producer/orders/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { apiClient, ProducerOrder } from '@/lib/api';
 import AuthGuard from '@/components/AuthGuard';
+import LoadingSpinner from '@/components/LoadingSpinner';
 import { formatCurrency } from '@/env';
 
 type OrderStatus = 'pending' | 'confirmed' | 'processing' | 'shipped' | 'delivered' | 'cancelled';
@@ -190,7 +191,7 @@ export default function ProducerOrderDetailsPage() {
 
           {loading ? (
             <div className="flex justify-center py-12">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600"></div>
+              <LoadingSpinner />
             </div>
           ) : error ? (
             <div className="text-center py-12">

--- a/frontend/src/app/producer/orders/page.tsx
+++ b/frontend/src/app/producer/orders/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { apiClient, ProducerOrder } from '@/lib/api';
 import AuthGuard from '@/components/AuthGuard';
+import LoadingSpinner from '@/components/LoadingSpinner';
 import { formatCurrency } from '@/env';
 import { useTranslations } from '@/contexts/LocaleContext';
 
@@ -243,7 +244,7 @@ export default function ProducerOrdersPage() {
           {/* Loading State */}
           {loading ? (
             <div className="flex justify-center py-12">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600"></div>
+              <LoadingSpinner />
             </div>
           ) : error ? (
             /* Error State */

--- a/frontend/src/components/AuthGuard.tsx
+++ b/frontend/src/components/AuthGuard.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
+import LoadingSpinner from '@/components/LoadingSpinner';
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -43,12 +44,7 @@ export default function AuthGuard({
 
   // Show loading state while checking auth
   if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex flex-col justify-center items-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
-        <p className="mt-4 text-gray-600">Loading...</p>
-      </div>
-    );
+    return <LoadingSpinner size="lg" fullScreen />;
   }
 
   // If auth is required but user is not authenticated, don't render children


### PR DESCRIPTION
## Summary
- **AuthGuard loading → `<LoadingSpinner size="lg" fullScreen />`** — highest impact change, affects ALL producer + account pages (10+ pages) via single component
- **Producer dashboard/orders/onboarding**: inline `animate-spin` divs → `<LoadingSpinner />` (4 files)
- **Dashboard products table**: new mobile card layout (`md:hidden`) showing product image, name, price, stock, and status vertically — replaces horizontal-scroll table on small screens

## Impact
- 5 files changed, 49 insertions, 11 deletions (net +38 LOC)
- Consistent loading UX across all producer and authenticated pages
- `data-testid="loading-spinner"` preserved via LoadingSpinner component (E2E compatibility)
- Products table now usable on mobile without horizontal scrolling

## Test plan
- [ ] `npx tsc --noEmit` — 0 errors ✅
- [ ] `npm run build` — succeeds ✅
- [ ] AuthGuard: fullscreen spinner on all protected pages
- [ ] Producer dashboard: loading spinner + mobile cards at <768px
- [ ] Producer orders list: loading spinner visible
- [ ] Producer order detail: loading spinner visible
- [ ] Producer onboarding: loading spinner visible

Generated-by: Claude Code