### PR TITLE
fix: enable Sanctum SPA mode for cookie-based auth (2A backend)

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -16,6 +16,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->trustProxies(at: '*');
 
         $middleware->api(prepend: [
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             \Illuminate\Http\Middleware\HandleCors::class,
         ]);
 

--- a/backend/config/sanctum.php
+++ b/backend/config/sanctum.php
@@ -17,9 +17,8 @@ return [
 
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
-        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8001,::1',
+        'localhost,localhost:3000,localhost:3001,127.0.0.1,127.0.0.1:8001,::1,dixis.gr,www.dixis.gr',
         Sanctum::currentApplicationUrlWithPort(),
-        // Sanctum::currentRequestHost(),
     ))),
 
     /*


### PR DESCRIPTION
## Summary
Strategic Fix 2A (Phase 1/2) — Auth token migration from localStorage to HttpOnly cookies.

- Add `EnsureFrontendRequestsAreStateful` middleware to API stack in `bootstrap/app.php`
- Add `Auth::login($user)` in login + register to create session cookies alongside API tokens
- Invalidate session on logout (session + CSRF token regeneration)
- Add `localhost:3001`, `dixis.gr`, `www.dixis.gr` to Sanctum stateful domains

**Dual-mode**: Both Bearer tokens and session cookies work simultaneously. Sanctum checks session first, falls back to Bearer — no breaking changes for existing clients.

## Files Changed (3 files, ~18 LOC)
- `backend/bootstrap/app.php` — Add stateful middleware
- `backend/app/Http/Controllers/Api/AuthController.php` — Auth::login + session logout
- `backend/config/sanctum.php` — Add domains to stateful list

## Test Plan
- [ ] Existing Bearer token auth still works (no regression)
- [ ] Login response now sets `dixis_session` + `XSRF-TOKEN` cookies
- [ ] Logout invalidates both token and session
- [ ] Backend tests pass (`php artisan test`)
- [ ] Frontend PR (2A part 2) will add CSRF cookie fetch + XSRF header

## References
- Strategic Fix: `docs/AGENT/STRATEGIC-FIXES.md` item 2A
- Depends on: Nothing (self-contained backend change)
- Blocks: PR 2 (Frontend CSRF + Cookie Auth)