### PR TITLE
fix: add CSRF cookie fetch + XSRF header for Sanctum SPA auth (2A frontend)

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -92,18 +92,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       }
 
-      // Normal auth flow
+      // Normal auth flow — try profile fetch regardless of localStorage token.
+      // Strategic Fix 2A: session cookie may authenticate even without stored token.
       apiClient.refreshToken();
-      const token = apiClient.getToken();
 
-      if (token) {
-        try {
-          const userData = await apiClient.getProfile();
-          setUser(userData);
-        } catch {
-          // Clear invalid token
-          apiClient.setToken(null);
-        }
+      try {
+        const userData = await apiClient.getProfile();
+        setUser(userData);
+      } catch {
+        // Not authenticated via cookie or token — clear any stale token
+        apiClient.setToken(null);
       }
 
       setLoading(false);


### PR DESCRIPTION
## Summary
Strategic Fix 2A (Phase 2/2) — Frontend support for cookie-based authentication.

- Add `fetchCsrfCookie()` method to fetch `XSRF-TOKEN` from `/sanctum/csrf-cookie`
- Add `getXsrfToken()` helper to read XSRF cookie and send as `X-XSRF-TOKEN` header
- Call `fetchCsrfCookie()` before `login()` and `register()` API calls
- Add XSRF header to all API requests via `getHeaders()`
- Simplify `AuthContext.initAuth()` to always attempt profile fetch (session cookie may authenticate without localStorage token)

**Dual-mode**: Both Bearer token and XSRF session cookie are sent on every request. Sanctum authenticates via session first, Bearer fallback. No breaking changes.

## Files Changed (2 files, ~56 LOC)
- `frontend/src/lib/api.ts` — CSRF fetch + XSRF header methods
- `frontend/src/contexts/AuthContext.tsx` — Simplified initAuth for cookie auth

## Test Plan
- [ ] TypeScript: `npx tsc --noEmit` — 0 errors
- [ ] Build: `npm run build` — clean pass
- [ ] Login still works with existing Bearer tokens (backward compat)
- [ ] After login, browser has `dixis_session` + `XSRF-TOKEN` cookies
- [ ] New tab restores session from cookie (no localStorage needed)
- [ ] E2E tests pass (MSW mocks unaffected)

## References
- Strategic Fix: `docs/AGENT/STRATEGIC-FIXES.md` item 2A
- Depends on: PR #2867 (Backend Sanctum SPA mode)
- Next: PR 3 — Remove localStorage token storage (future, after production validation)