### PR TITLE
docs: consolidate VPS/SSH docs — fix root→deploy contradictions

### DIFF
--- a/docs/AGENT/SYSTEM/ssh-access.md
+++ b/docs/AGENT/SYSTEM/ssh-access.md
@@ -1,6 +1,6 @@
 # SSH Access - Canonical Configuration
 
-**Last Updated**: 2026-01-17 (Pass OPS-SSH-HYGIENE-01)
+**Last Updated**: 2026-02-14 (Security hardening: root login disabled)
 
 ## Quick Reference
 
@@ -8,9 +8,9 @@
 |------|-------|
 | **Canonical Alias** | `dixis-prod` |
 | **Host** | 147.93.126.235 |
-| **User** | root |
+| **User** | `deploy` |
 | **Key File** | `~/.ssh/dixis_prod_ed25519_20260115` |
-| **Key Fingerprint** | SHA256:MekIeM... |
+| **Root Login** | **DISABLED** (PermitRootLogin no) |
 
 ## Health Check Command
 
@@ -23,7 +23,7 @@ ssh dixis-prod 'echo SSH_OK && whoami && hostname && uptime'
 Expected output:
 ```
 SSH_OK
-root
+deploy
 srv709397
  HH:MM:SS up X days, ...
 ```
@@ -33,7 +33,7 @@ srv709397
 ```
 Host dixis-prod
   HostName 147.93.126.235
-  User root
+  User deploy
   Port 22
   IdentityFile ~/.ssh/dixis_prod_ed25519_20260115
   IdentitiesOnly yes
@@ -46,9 +46,10 @@ Host dixis-prod
 ## Rules
 
 1. **Always use alias**: `ssh dixis-prod` - never `ssh -i ... user@ip`
-2. **One canonical key**: Only `dixis_prod_ed25519_20260115` is authorized on server
-3. **IdentitiesOnly yes**: Prevents SSH agent from offering other keys
-4. **No password auth**: Key-only authentication enforced
+2. **User is `deploy`**: Root SSH is disabled. All operations use the `deploy` user.
+3. **One canonical key**: Only `dixis_prod_ed25519_20260115` is authorized on server
+4. **IdentitiesOnly yes**: Prevents SSH agent from offering other keys
+5. **No password auth**: Key-only authentication enforced
 
 ## Troubleshooting
 

--- a/docs/OPS/DEPLOY-FRONTEND.md
+++ b/docs/OPS/DEPLOY-FRONTEND.md
@@ -1,19 +1,22 @@
-# Frontend Deployment Guide (Legacy)
+# Frontend Deployment Guide (DEPRECATED)
 
-> **Superseded by**: [`docs/OPS/DEPLOY.md`](DEPLOY.md) and `scripts/prod-deploy-clean.sh`
-> This file is kept for historical reference only.
+> **⚠️ DEPRECATED** — Do NOT follow this guide. Use instead:
+> - **Automated**: `bash scripts/prod-deploy-clean.sh`
+> - **Manual**: [`docs/AGENT/SOPs/SOP-VPS-DEPLOY.md`](../AGENT/SOPs/SOP-VPS-DEPLOY.md)
+> - **SSH config**: [`docs/AGENT/SYSTEM/ssh-access.md`](../AGENT/SYSTEM/ssh-access.md)
+>
+> **Key change (2026-02-14)**: Root login DISABLED. User is now `deploy`. Use `ssh dixis-prod`.
 
-**Last Updated**: 2025-01-03
+**Last Updated**: 2026-02-14 (deprecated)
 
-## Quick Reference
+## Quick Reference (OUTDATED — see SOP-VPS-DEPLOY.md)
 
 ```bash
-# SSH to VPS
-ssh -i ~/.ssh/dixis_prod_ed25519 root@147.93.126.235
+# SSH to VPS (CURRENT — use alias)
+ssh dixis-prod
 
-# Run safe deploy
-cd /var/www/dixis/current/frontend
-./scripts/safe-frontend-deploy.sh
+# Old command (BROKEN — root login disabled):
+# ssh -i ~/.ssh/dixis_prod_ed25519 root@147.93.126.235
 ```
 
 ## Safe Deploy Script

--- a/docs/OPS/PROCESS-IMPROVEMENTS.md
+++ b/docs/OPS/PROCESS-IMPROVEMENTS.md
@@ -22,20 +22,23 @@
 ### Fix
 **Canonical SSH command** (enforced in all docs):
 ```bash
-ssh -i ~/.ssh/dixis_prod_ed25519 -o IdentitiesOnly=yes root@147.93.126.235
+ssh dixis-prod
 ```
 
-Or via SSH config (~/.ssh/config):
+> **UPDATE 2026-02-14**: Root login is now DISABLED. User is `deploy`.
+> See `docs/AGENT/SYSTEM/ssh-access.md` for canonical SSH config.
+
+SSH config (~/.ssh/config):
 ```
-Host dixis-vps
+Host dixis-prod
   HostName 147.93.126.235
-  User root
-  IdentityFile ~/.ssh/dixis_prod_ed25519
+  User deploy
+  IdentityFile ~/.ssh/dixis_prod_ed25519_20260115
   IdentitiesOnly yes
 ```
 
 ### Enforcement (what we do every time)
-1. **Before ANY SSH command**: Use the canonical form above (never bare `ssh root@...`)
+1. **Before ANY SSH command**: Use `ssh dixis-prod` (never bare `ssh root@...` — root is disabled)
 2. **Document in all VPS-related docs**: Include full SSH command with `-o IdentitiesOnly=yes`
 3. **Verify in PR**: Any PR touching VPS access must include canonical SSH command
 4. **STATE.md entry**: "SSH/fail2ban: Canonical SSH config enforced" (closed 2025-12-19)


### PR DESCRIPTION
## Summary
- **ssh-access.md**: Fixed User `root` → `deploy`, added Root Login DISABLED notice
- **SOP-VPS-DEPLOY.md**: Complete rewrite — deploy user, pnpm, `prod-deploy-clean.sh` reference, architecture diagram, troubleshooting for DNS/CloudFlare issues
- **DEPLOY-FRONTEND.md**: Marked as DEPRECATED with pointers to current SOP
- **PROCESS-IMPROVEMENTS.md**: Updated SSH examples from root to deploy user

## Why
Root login was disabled on VPS (security hardening) but 4 documentation files still referenced `root@147.93.126.235`. This caused repeated SSH "Permission denied" failures in agent sessions, requiring the user to manually remind about the correct access method each time.

## Test plan
- [x] `ssh dixis-prod 'whoami'` returns `deploy`
- [x] VPS deploy completed successfully using `deploy` user
- [x] No active docs reference `root@147.93.126.235` (only archive + commented-out)

---
*Generated-by: claude-agent | Pass: docs-consolidation*