### PR TITLE
feat: Strategic Fix 2B — middleware auth for protected routes

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,5 +1,42 @@
-// 🔒 Locked middleware scope: ΜΟΝΟ /ops/* — public & βασικά API μένουν εκτός
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+/**
+ * Strategic Fix 2B: Server-side auth middleware for protected routes.
+ *
+ * Previously only /ops/* was protected. Producer, admin, and account pages
+ * relied on client-side AuthGuard which:
+ * 1. Flashes page content before redirecting
+ * 2. Can be bypassed by disabling JS
+ * 3. Shows a loading spinner instead of a proper redirect
+ *
+ * This middleware checks for auth cookies (set by Sanctum SPA auth)
+ * and redirects to login if missing. Does NOT verify token validity
+ * (that's the backend's job) — just checks presence for fast redirect.
+ */
+
+const PROTECTED_PREFIXES = ['/producer', '/admin', '/account']
+const LOGIN_PATH = '/auth/login'
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  // Only intercept protected paths
+  const needsAuth = PROTECTED_PREFIXES.some(prefix => pathname.startsWith(prefix))
+  if (!needsAuth) return NextResponse.next()
+
+  // Check for session cookie (Sanctum SPA auth) or mock session (E2E tests)
+  const hasSession = request.cookies.has('dixis_session') || request.cookies.has('mock_session')
+
+  if (!hasSession) {
+    const loginUrl = new URL(LOGIN_PATH, request.url)
+    loginUrl.searchParams.set('redirect', pathname)
+    return NextResponse.redirect(loginUrl)
+  }
+
+  return NextResponse.next()
+}
+
 export const config = {
-  matcher: ['/ops/:path*'],
-};
-// Καμία λογική εδώ — αν χρειαστεί προστασία για άλλα paths, θα μπει ρητά σε νέο pass.
+  matcher: ['/ops/:path*', '/producer/:path*', '/admin/:path*', '/account/:path*'],
+}


### PR DESCRIPTION
## Summary
- Add server-side auth middleware for `/producer/*`, `/admin/*`, `/account/*` routes
- Previously these relied on client-side AuthGuard only (content flash, JS-bypassable)
- Login page now supports `?redirect=/path` to return user to intended page after login

## Changes
- **`middleware.ts`**: Cookie-based auth check (dixis_session OR mock_session), redirect to `/auth/login?redirect=/path`
- **`login/page.tsx`**: Read redirect param, use it for post-login redirect, wrapped in Suspense for Next.js 15

## Verification
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — clean (middleware 45.1 kB)
- [ ] Manual: `/producer/dashboard` in incognito → redirects to login
- [ ] Manual: Login → redirects back to `/producer/dashboard`
- [ ] E2E tests pass (integration tests set dixis_session cookie)

## Context
Strategic Fix 2B from `docs/AGENT/STRATEGIC-FIXES.md`. Depends on 2A (Sanctum SPA auth) which was deployed in PRs #2867-#2868. This is the **last remaining security item** in the strategic fixes queue.

Generated-by: Claude AI Agent