### PR TITLE
fix: disable Sentry autoInstrumentMiddleware — unblocks 2B auth redirects

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -118,4 +118,10 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withSentryConfig(nextConfig, { silent: true });
+export default withSentryConfig(nextConfig, {
+  silent: true,
+  // Disable Sentry's auto-wrapping of middleware. Its Rollup-based loader
+  // silently swallows middleware logic in standalone builds, causing our
+  // auth redirects to never execute. We handle errors manually instead.
+  autoInstrumentMiddleware: false,
+});

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -13,6 +13,11 @@ import type { NextRequest } from 'next/server'
  * This middleware checks for auth cookies (set by Sanctum SPA auth)
  * and redirects to login if missing. Does NOT verify token validity
  * (that's the backend's job) — just checks presence for fast redirect.
+ *
+ * NOTE: Sentry autoInstrumentMiddleware is disabled in next.config.ts
+ * because its Rollup-based wrapping loader silently swallows middleware
+ * logic in standalone builds. We keep Sentry error reporting via the
+ * try/catch + Sentry.captureException pattern instead.
  */
 
 const PROTECTED_PREFIXES = ['/producer', '/admin', '/account']


### PR DESCRIPTION
## Summary

- Disable `autoInstrumentMiddleware` in `withSentryConfig` options
- Add explanatory comments in middleware.ts and next.config.ts

## Problem

Strategic Fix 2B (PR #2873) added server-side auth middleware for `/producer`, `/admin`, `/account` routes. The code was correct and built cleanly, but **after deploying to production, the middleware had no effect** — unprotected routes returned HTTP 200 instead of 307 redirect.

**Root cause**: `@sentry/nextjs` v10.23.0's `withSentryConfig()` uses a Rollup-based webpack loader to auto-wrap `middleware.ts`. In standalone builds, this wrapping process silently swallows the middleware logic — the compiled `middleware.js` contained 125KB of Sentry instrumentation but **zero** occurrences of our auth strings (`producer`, `admin`, `account`, `dixis_session`).

## Fix

Set `autoInstrumentMiddleware: false` in the Sentry config. This:
- ✅ Preserves all other Sentry features (error reporting, tracing, server components)
- ✅ Lets our auth middleware compile and execute correctly
- ✅ No loss of Sentry middleware monitoring (we don't need perf tracing on a simple cookie check)

## Test plan

- [ ] `npx tsc --noEmit` — 0 errors
- [ ] `pnpm build` — clean standalone build
- [ ] Deploy to VPS, verify `curl -sI "https://dixis.gr/producer/dashboard"` returns 307 redirect to `/auth/login`
- [ ] Verify authenticated access still works (login → producer dashboard loads)

## LOC

+12/-1 (13 LOC)