### PR TITLE
fix: hellenize last English UI strings (skip-link, email labels)

### DIFF
--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -132,7 +132,7 @@ export default function Register() {
 
             <div>
               <label htmlFor="email" className="block text-sm font-medium text-gray-700">
-                Email
+                Ηλ. Ταχυδρομείο
               </label>
               <div className="mt-1">
                 <input

--- a/frontend/src/components/SkipLink.tsx
+++ b/frontend/src/components/SkipLink.tsx
@@ -16,7 +16,7 @@ export default function SkipLink() {
       className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-green-600 text-white px-4 py-2 rounded-md z-50 focus:outline-none focus:ring-2 focus:ring-green-500"
       onClick={handleClick}
     >
-      Skip to main content
+      Μετάβαση στο περιεχόμενο
     </a>
   );
 }

--- a/frontend/src/components/checkout/AddressForm.tsx
+++ b/frontend/src/components/checkout/AddressForm.tsx
@@ -92,7 +92,7 @@ export default function AddressForm({ initial, onChange }: Props) {
       />
       <Field
         id="email"
-        label="Email"
+        label="Ηλ. Ταχυδρομείο"
         value={addr.email ?? ''}
         onC={(v) => set('email', v)}
         error={errors.email}


### PR DESCRIPTION
## Summary

Greek Market Readiness audit found 2 remaining English strings visible to customers:

- **SkipLink.tsx**: "Skip to main content" → «Μετάβαση στο περιεχόμενο»
- **Register page**: "Email" label → «Ηλ. Ταχυδρομείο»
- **Checkout AddressForm**: "Email" label → «Ηλ. Ταχυδρομείο»

## LOC

3 lines changed (3 string replacements)