### PR TITLE
style: unify brand colors across all storefront pages

### DIFF
--- a/frontend/src/app/(storefront)/cart/page.tsx
+++ b/frontend/src/app/(storefront)/cart/page.tsx
@@ -29,14 +29,14 @@ export default function CartPage() {
   }
 
   return (
-    <main className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
+    <main className="min-h-screen bg-neutral-50 py-8 px-4 sm:px-6 lg:px-8">
       <div className="max-w-5xl mx-auto">
         <h1 className="text-xl sm:text-2xl font-bold mb-4">Καλάθι</h1>
 
         {list.length === 0 ? (
           <div className="bg-white border rounded-xl p-10 text-center" data-testid="empty-cart">
-            <p className="text-gray-600 mb-4" data-testid="empty-cart-message">Το καλάθι σας είναι άδειο.</p>
-            <Link href="/products" className="inline-block bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700">
+            <p className="text-neutral-600 mb-4" data-testid="empty-cart-message">Το καλάθι σας είναι άδειο.</p>
+            <Link href="/products" className="inline-block bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light">
               Συνέχεια αγορών
             </Link>
           </div>
@@ -46,22 +46,22 @@ export default function CartPage() {
               {list.map((it) => (
                 <div key={it.id} className="p-4 flex gap-4 items-start justify-between overflow-visible">
                   <div className="flex gap-4 items-center flex-1 min-w-0">
-                    <div className="w-16 h-16 sm:w-20 sm:h-20 bg-gray-100 overflow-hidden rounded shrink-0">
+                    <div className="w-16 h-16 sm:w-20 sm:h-20 bg-neutral-100 overflow-hidden rounded shrink-0">
                       {it.imageUrl ? (
                         <Image src={it.imageUrl} alt={it.title} width={80} height={80} className="w-full h-full object-cover"/>
                       ) : (
-                        <div className="w-full h-full flex items-center justify-center text-gray-400">
+                        <div className="w-full h-full flex items-center justify-center text-neutral-400">
                           📦
                         </div>
                       )}
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="font-semibold leading-tight line-clamp-2">{it.title}</div>
-                      <div className="text-sm text-gray-500">{fmt.format(it.priceCents / 100)}</div>
+                      <div className="text-sm text-neutral-500">{fmt.format(it.priceCents / 100)}</div>
                       <div className="mt-2 flex items-center gap-3 flex-wrap">
-                        <button type="button" onClick={() => dec(it.id)} className="h-11 w-11 rounded border hover:bg-gray-50 flex items-center justify-center text-lg" data-testid="qty-minus">−</button>
+                        <button type="button" onClick={() => dec(it.id)} className="h-11 w-11 rounded border hover:bg-neutral-50 flex items-center justify-center text-lg" data-testid="qty-minus">−</button>
                         <span className="min-w-8 text-center" data-testid="qty">{it.qty}</span>
-                        <button type="button" onClick={() => inc(it.id)} className="h-11 w-11 rounded border hover:bg-gray-50 flex items-center justify-center text-lg" data-testid="qty-plus">+</button>
+                        <button type="button" onClick={() => inc(it.id)} className="h-11 w-11 rounded border hover:bg-neutral-50 flex items-center justify-center text-lg" data-testid="qty-plus">+</button>
                       </div>
                     </div>
                   </div>
@@ -74,21 +74,21 @@ export default function CartPage() {
 
             <aside className="bg-white border rounded-xl p-6 h-fit">
               <div className="flex items-center justify-between">
-                <span className="text-gray-600">Υποσύνολο</span>
+                <span className="text-neutral-600">Υποσύνολο</span>
                 <span className="text-lg font-bold" data-testid="total">Σύνολο: {fmt.format(totalCents / 100)}</span>
               </div>
-              <p className="text-xs text-gray-500 mt-2">Οι τελικές χρεώσεις (μεταφορικά/ΦΠΑ) υπολογίζονται κατά την ολοκλήρωση.</p>
+              <p className="text-xs text-neutral-500 mt-2">Οι τελικές χρεώσεις (μεταφορικά/ΦΠΑ) υπολογίζονται κατά την ολοκλήρωση.</p>
               <button onClick={clear} className="mt-2 w-full inline-flex justify-center border border-red-300 text-red-600 px-4 py-2 rounded-lg hover:bg-red-50">
                 Καθαρισμός
               </button>
               <button
                 onClick={handleCheckout}
-                className="mt-4 w-full inline-flex justify-center bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700"
+                className="mt-4 w-full inline-flex justify-center bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light"
                 data-testid="go-checkout"
               >
                 Ολοκλήρωση παραγγελίας
               </button>
-              <Link href="/products" className="mt-2 w-full inline-flex justify-center border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50">
+              <Link href="/products" className="mt-2 w-full inline-flex justify-center border border-neutral-300 text-neutral-700 px-4 py-2 rounded-lg hover:bg-neutral-50">
                 Συνέχεια αγορών
               </Link>
             </aside>

--- a/frontend/src/app/(storefront)/checkout/CustomerDetailsForm.tsx
+++ b/frontend/src/app/(storefront)/checkout/CustomerDetailsForm.tsx
@@ -98,7 +98,7 @@ export default function CustomerDetailsForm({
             data-testid="checkout-email"
           />
           {isGuest && (
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-neutral-500 mt-1">
               {t('checkoutPage.emailRequired')}
             </p>
           )}

--- a/frontend/src/app/(storefront)/checkout/OrderSummary.tsx
+++ b/frontend/src/app/(storefront)/checkout/OrderSummary.tsx
@@ -61,7 +61,7 @@ export default function OrderSummary({
 
         {/* Zone info fallback for single-producer */}
         {!cartShippingQuote && shippingQuote?.zone_name && (
-          <p className="text-xs text-gray-500" data-testid="shipping-zone">
+          <p className="text-xs text-neutral-500" data-testid="shipping-zone">
             {t('checkoutPage.shippingZone')}: {shippingQuote.zone_name}
           </p>
         )}
@@ -85,7 +85,7 @@ export default function OrderSummary({
         </div>
 
         {!shippingQuote && (
-          <p className="text-xs text-gray-500 mt-1">
+          <p className="text-xs text-neutral-500 mt-1">
             {t('checkoutPage.shippingNote')}
           </p>
         )}

--- a/frontend/src/app/(storefront)/checkout/page.tsx
+++ b/frontend/src/app/(storefront)/checkout/page.tsx
@@ -48,7 +48,7 @@ function CheckoutContent() {
   // SSR/hydration loading
   if (!isMounted) {
     return (
-      <main className="min-h-screen bg-gray-50 py-8 px-4">
+      <main className="min-h-screen bg-neutral-50 py-8 px-4">
         <div className="max-w-2xl mx-auto bg-white border rounded-xl p-6 sm:p-10 text-center">
           <LoadingSpinner text={t('checkoutPage.loading')} />
         </div>
@@ -59,10 +59,10 @@ function CheckoutContent() {
   // Empty cart
   if (Object.keys(cartItems).length === 0 && !stripeClientSecret) {
     return (
-      <main className="min-h-screen bg-gray-50 py-8 px-4">
+      <main className="min-h-screen bg-neutral-50 py-8 px-4">
         <div className="max-w-2xl mx-auto bg-white border rounded-xl p-6 sm:p-10 text-center">
-          <p className="text-gray-600 mb-4">{t('checkoutPage.emptyCart')}</p>
-          <a href="/products" className="inline-block bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 active:opacity-90 touch-manipulation">
+          <p className="text-neutral-600 mb-4">{t('checkoutPage.emptyCart')}</p>
+          <a href="/products" className="inline-block bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light active:opacity-90 touch-manipulation">
             {t('checkoutPage.viewProducts')}
           </a>
         </div>
@@ -73,13 +73,13 @@ function CheckoutContent() {
   // Stripe payment view
   if (stripeClientSecret && pendingOrderId) {
     return (
-      <main className="min-h-screen bg-gray-50 py-8 px-4" data-testid="checkout-page">
+      <main className="min-h-screen bg-neutral-50 py-8 px-4" data-testid="checkout-page">
         <div className="max-w-2xl mx-auto">
           <h1 className="text-xl sm:text-2xl font-bold mb-6">{t('checkout.title')}</h1>
 
           <div className="bg-white border rounded-xl p-6 mb-6">
             <h2 className="font-semibold mb-4">{t('checkoutPage.cardPayment') || 'Card Payment'}</h2>
-            <p className="text-sm text-gray-600 mb-4">
+            <p className="text-sm text-neutral-600 mb-4">
               {t('checkoutPage.securePayment') || 'Complete your payment securely with Stripe.'}
             </p>
 
@@ -101,7 +101,7 @@ function CheckoutContent() {
             <button
               type="button"
               onClick={handleCancelPayment}
-              className="mt-4 w-full h-10 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50"
+              className="mt-4 w-full h-10 border border-neutral-300 text-neutral-700 rounded-lg hover:bg-neutral-50"
             >
               {t('checkoutPage.cancelPayment') || 'Cancel and go back'}
             </button>
@@ -113,7 +113,7 @@ function CheckoutContent() {
 
   // Main checkout view
   return (
-    <main className="min-h-screen bg-gray-50 py-8 px-4" data-testid="checkout-page">
+    <main className="min-h-screen bg-neutral-50 py-8 px-4" data-testid="checkout-page">
       <div className="max-w-2xl mx-auto">
         <h1 className="text-xl sm:text-2xl font-bold mb-6" data-testid="checkout-title">{t('checkout.title')}</h1>
 
@@ -159,7 +159,7 @@ function CheckoutContent() {
           <button
             type="submit"
             disabled={loading || cardProcessing || !!cartShippingError || shippingLoading || (!shippingQuote && !cartShippingQuote)}
-            className="w-full h-12 mt-4 bg-emerald-600 hover:bg-emerald-700 disabled:bg-gray-400 text-white font-medium rounded-lg text-base touch-manipulation active:opacity-90"
+            className="w-full h-12 mt-4 bg-primary hover:bg-primary-light disabled:bg-neutral-400 text-white font-medium rounded-lg text-base touch-manipulation active:opacity-90"
             data-testid="checkout-submit"
           >
             {cardProcessing
@@ -188,7 +188,7 @@ export default function CheckoutPage() {
   const t = useTranslations()
   return (
     <Suspense fallback={
-      <main className="min-h-screen bg-gray-50 py-8 px-4">
+      <main className="min-h-screen bg-neutral-50 py-8 px-4">
         <div className="max-w-2xl mx-auto bg-white border rounded-xl p-6 sm:p-10 text-center">
           <LoadingSpinner text={t('checkoutPage.loading')} />
         </div>

--- a/frontend/src/app/(storefront)/checkout/success/page.tsx
+++ b/frontend/src/app/(storefront)/checkout/success/page.tsx
@@ -8,11 +8,11 @@ function SuccessContent() {
   const orderId = searchParams?.get('orderId') || 'N/A'
 
   return (
-    <main className="min-h-screen bg-gray-50 py-8 px-4">
+    <main className="min-h-screen bg-neutral-50 py-8 px-4">
       <div className="max-w-2xl mx-auto bg-white border rounded-xl p-10 text-center" data-testid="success-page">
         <div className="mb-6">
           <svg
-            className="w-16 h-16 text-green-600 mx-auto"
+            className="w-16 h-16 text-primary mx-auto"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -28,25 +28,25 @@ function SuccessContent() {
 
         <h1 className="text-2xl font-bold mb-4">Επιτυχία!</h1>
 
-        <p className="text-gray-600 mb-2">
+        <p className="text-neutral-600 mb-2">
           Η παραγγελία σας καταχωρήθηκε επιτυχώς.
         </p>
 
-        <p className="text-sm text-gray-500 mb-6" data-testid="order-id">
+        <p className="text-sm text-neutral-500 mb-6" data-testid="order-id">
           Κωδικός παραγγελίας: <span className="font-mono font-semibold">{orderId}</span>
         </p>
 
         <div className="space-y-3">
           <Link
             href="/products"
-            className="inline-block w-full bg-emerald-600 text-white px-6 py-3 rounded-lg hover:bg-emerald-700"
+            className="inline-block w-full bg-primary text-white px-6 py-3 rounded-lg hover:bg-primary-light"
           >
             Συνέχεια αγορών
           </Link>
 
           <Link
             href="/"
-            className="inline-block w-full border border-gray-300 text-gray-700 px-6 py-3 rounded-lg hover:bg-gray-50"
+            className="inline-block w-full border border-neutral-300 text-neutral-700 px-6 py-3 rounded-lg hover:bg-neutral-50"
           >
             Πίσω στην αρχική
           </Link>
@@ -58,7 +58,7 @@ function SuccessContent() {
 
 export default function CheckoutSuccessPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen bg-gray-50 flex items-center justify-center text-gray-500">Φόρτωση…</div>}>
+    <Suspense fallback={<div className="min-h-screen bg-neutral-50 flex items-center justify-center text-neutral-500">Φόρτωση…</div>}>
       <SuccessContent />
     </Suspense>
   )

--- a/frontend/src/app/(storefront)/order/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/order/[id]/page.tsx
@@ -9,7 +9,7 @@ export default async function OrderConfirmation({ params }: { params: Promise<{ 
     <main className="container mx-auto px-4 py-16">
       <div className="max-w-md mx-auto text-center">
         <div className="mb-6">
-          <svg className="mx-auto w-16 h-16 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="mx-auto w-16 h-16 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
         </div>
@@ -18,24 +18,24 @@ export default async function OrderConfirmation({ params }: { params: Promise<{ 
           {t('order.success.title')}
         </h1>
         
-        <p className="text-gray-600 mb-6">
+        <p className="text-neutral-600 mb-6">
           {t('order.success.body', { id })}
         </p>
         
-        <p className="text-sm text-gray-500 mb-8" data-testid="order-id">
+        <p className="text-sm text-neutral-500 mb-8" data-testid="order-id">
           {t('checkout.orderId')}: <span className="font-mono font-medium">{id}</span>
         </p>
         
         <div className="space-y-3">
           <Link
             href="/products"
-            className="block bg-green-600 hover:bg-green-700 text-white font-medium py-3 px-6 rounded-lg transition"
+            className="block bg-primary hover:bg-primary-light text-white font-medium py-3 px-6 rounded-lg transition"
           >
             {t('cart.continue')}
           </Link>
           <Link
             href="/"
-            className="block text-blue-600 hover:underline"
+            className="block text-primary hover:underline"
           >
             {t('nav.home')}
           </Link>

--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -201,7 +201,7 @@ export default async function Page({ searchParams }: PageProps) {
   };
 
   return (
-    <main className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
+    <main className="min-h-screen bg-neutral-50 py-8 px-4 sm:px-6 lg:px-8">
       <div className="max-w-7xl mx-auto">
         {/* Demo mode banner */}
         {isDemo && (
@@ -212,8 +212,8 @@ export default async function Page({ searchParams }: PageProps) {
 
         <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6 gap-4">
           <div>
-            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Προϊόντα</h1>
-            <p className="mt-1 text-sm text-gray-600">
+            <h1 className="text-2xl sm:text-3xl font-bold text-neutral-900">Προϊόντα</h1>
+            <p className="mt-1 text-sm text-neutral-600">
               {searchQuery
                 ? `${total} αποτέλεσμα${total !== 1 ? 'τα' : ''} για "${searchQuery}"`
                 : `Απευθείας από παραγωγούς — ${categoryFilter ? `${total} στην κατηγορία` : `${apiTotal || total} συνολικά`}.`}
@@ -221,14 +221,14 @@ export default async function Page({ searchParams }: PageProps) {
           </div>
 
           {/* Search Input */}
-          <Suspense fallback={<div className="h-10 w-full max-w-md bg-gray-100 rounded-lg animate-pulse" />}>
+          <Suspense fallback={<div className="h-10 w-full max-w-md bg-neutral-100 rounded-lg animate-pulse" />}>
             <ProductSearchInput />
           </Suspense>
         </div>
 
         {/* Category Strip */}
         <div className="mb-6">
-          <Suspense fallback={<div className="h-10 bg-gray-100 rounded animate-pulse" />}>
+          <Suspense fallback={<div className="h-10 bg-neutral-100 rounded animate-pulse" />}>
             <CategoryStrip
               selectedCategory={categoryFilter}
               dynamicCategories={activeCategories}
@@ -255,10 +255,10 @@ export default async function Page({ searchParams }: PageProps) {
           </div>
         ) : (
           <div
-            className="text-center py-20 bg-white rounded-xl border border-dashed border-gray-300"
+            className="text-center py-20 bg-white rounded-xl border border-dashed border-neutral-300"
             data-testid="no-results"
           >
-            <p className="text-gray-500 text-lg">{getEmptyMessage()}</p>
+            <p className="text-neutral-500 text-lg">{getEmptyMessage()}</p>
           </div>
         )}
       </div>

--- a/frontend/src/app/(storefront)/thank-you/page.tsx
+++ b/frontend/src/app/(storefront)/thank-you/page.tsx
@@ -93,9 +93,9 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
 
   if (loading) {
     return (
-      <main className="min-h-screen bg-gray-50 py-8 px-4">
+      <main className="min-h-screen bg-neutral-50 py-8 px-4">
         <div className="max-w-2xl mx-auto bg-white border rounded-xl p-10 text-center">
-          <p className="text-gray-600">Φόρτωση...</p>
+          <p className="text-neutral-600">Φόρτωση...</p>
         </div>
       </main>
     )
@@ -103,10 +103,10 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
 
   if (error || !order) {
     return (
-      <main className="min-h-screen bg-gray-50 py-8 px-4">
+      <main className="min-h-screen bg-neutral-50 py-8 px-4">
         <div className="max-w-2xl mx-auto bg-white border rounded-xl p-10 text-center">
           <p className="text-red-600 mb-4">{error || 'Δεν βρέθηκε η παραγγελία'}</p>
-          <a href="/products" className="inline-block bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700">
+          <a href="/products" className="inline-block bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light">
             Συνέχεια στα προϊόντα
           </a>
         </div>
@@ -115,19 +115,19 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
   }
 
   return (
-    <main className="min-h-screen bg-gray-50 py-8 px-4" data-testid="thank-you-page">
+    <main className="min-h-screen bg-neutral-50 py-8 px-4" data-testid="thank-you-page">
       <div className="max-w-2xl mx-auto">
         <div className="bg-white border rounded-xl p-8 text-center">
           <div className="mb-6">
             <div className="text-5xl mb-4">✓</div>
-            <h1 className="text-3xl font-bold text-emerald-600 mb-2">Ευχαριστούμε!</h1>
-            <p className="text-gray-600">Η παραγγελία σας καταχωρήθηκε επιτυχώς.</p>
+            <h1 className="text-3xl font-bold text-primary mb-2">Ευχαριστούμε!</h1>
+            <p className="text-neutral-600">Η παραγγελία σας καταχωρήθηκε επιτυχώς.</p>
           </div>
 
-          <div className="bg-gray-50 border rounded-lg p-6 mb-6 text-left">
+          <div className="bg-neutral-50 border rounded-lg p-6 mb-6 text-left">
             <div className="text-center mb-4">
-              <p className="text-sm text-gray-500 mb-1">Αριθμός παραγγελίας:</p>
-              <p className="text-xl font-bold font-mono text-emerald-600" data-testid="order-id">{order.id}</p>
+              <p className="text-sm text-neutral-500 mb-1">Αριθμός παραγγελίας:</p>
+              <p className="text-xl font-bold font-mono text-primary" data-testid="order-id">{order.id}</p>
             </div>
 
             <div className="border-t pt-4">
@@ -153,9 +153,9 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
                 {/* Pass MP-SHIPPING-BREAKDOWN-TRUTH-01: Show per-producer shipping for multi-producer orders */}
                 {order.isMultiProducer && order.shippingLines && order.shippingLines.length > 1 ? (
                   <>
-                    <div className="text-gray-600 font-medium pt-1">Μεταφορικά ανά παραγωγό:</div>
+                    <div className="text-neutral-600 font-medium pt-1">Μεταφορικά ανά παραγωγό:</div>
                     {order.shippingLines.map((line, idx) => (
-                      <div key={idx} className="flex justify-between pl-3 text-gray-600">
+                      <div key={idx} className="flex justify-between pl-3 text-neutral-600">
                         <span>{line.producer_name}:</span>
                         <span>
                           {line.free_shipping_applied
@@ -164,7 +164,7 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
                         </span>
                       </div>
                     ))}
-                    <div className="flex justify-between font-medium border-t border-gray-200 pt-1">
+                    <div className="flex justify-between font-medium border-t border-neutral-200 pt-1">
                       <span>Σύνολο μεταφορικών:</span>
                       <span>{fmt.format(order.shipping || 0)}</span>
                     </div>
@@ -203,7 +203,7 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
 
             {order.email && (
               <div className="border-t pt-4 mt-4">
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-neutral-600">
                   Θα λάβετε email επιβεβαίωσης στο <span className="font-medium">{order.email}</span>
                 </p>
               </div>
@@ -211,13 +211,13 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
 
             {/* Pass TRACKING-DISPLAY-01: Tracking link for customer */}
             {order.publicToken && (
-              <div className="border-t pt-4 mt-4 bg-emerald-50 -mx-6 -mb-6 px-6 py-4 rounded-b-lg">
-                <p className="text-sm text-gray-700 mb-2">
+              <div className="border-t pt-4 mt-4 bg-primary-pale -mx-6 -mb-6 px-6 py-4 rounded-b-lg">
+                <p className="text-sm text-neutral-700 mb-2">
                   Παρακολουθήστε την παραγγελία σας:
                 </p>
                 <a
                   href={`/track/${order.publicToken}`}
-                  className="inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700 font-medium"
+                  className="inline-flex items-center gap-2 text-primary hover:text-primary-light font-medium"
                   data-testid="tracking-link"
                 >
                   <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -225,7 +225,7 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
                   </svg>
                   Σελίδα παρακολούθησης
                 </a>
-                <p className="text-xs text-gray-500 mt-2">
+                <p className="text-xs text-neutral-500 mt-2">
                   Μπορείτε να αποθηκεύσετε αυτόν τον σύνδεσμο για να ελέγχετε την κατάσταση της παραγγελίας σας.
                 </p>
               </div>
@@ -235,13 +235,13 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
           <div className="flex gap-3 justify-center">
             <a
               href="/products"
-              className="inline-block bg-emerald-600 text-white px-6 py-3 rounded-lg hover:bg-emerald-700 font-medium"
+              className="inline-block bg-primary text-white px-6 py-3 rounded-lg hover:bg-primary-light font-medium"
             >
               Συνέχεια στα προϊόντα
             </a>
             <a
               href="/"
-              className="inline-block border border-gray-300 text-gray-700 px-6 py-3 rounded-lg hover:bg-gray-50"
+              className="inline-block border border-neutral-300 text-neutral-700 px-6 py-3 rounded-lg hover:bg-neutral-50"
             >
               Αρχική σελίδα
             </a>

--- a/frontend/src/components/payment/StripePaymentForm.tsx
+++ b/frontend/src/components/payment/StripePaymentForm.tsx
@@ -99,7 +99,7 @@ export default function StripePaymentForm({
         <PaymentElement />
       </div>
 
-      <div className="text-sm text-gray-600">
+      <div className="text-sm text-neutral-600">
         <p>Συνολικό ποσό: <strong>€{amount.toFixed(2)}</strong></p>
         <p>Ασφαλής πληρωμή μέσω Stripe</p>
       </div>
@@ -107,7 +107,7 @@ export default function StripePaymentForm({
       <button
         type="submit"
         disabled={!stripe || disabled || isProcessing}
-        className="w-full px-6 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+        className="w-full px-6 py-3 bg-primary text-white rounded-md hover:bg-primary-light disabled:bg-neutral-400 disabled:cursor-not-allowed transition-colors"
       >
         {isProcessing ? 'Επεξεργασία...' : `Πληρωμή €${amount.toFixed(2)}`}
       </button>


### PR DESCRIPTION
## Summary

- Replace generic Tailwind colors with Dixis brand palette across all 9 customer-facing storefront pages
- `gray-*` → `neutral-*` (consistent gray tones from brand config)
- `emerald-600/700` → `primary/primary-light` (Dixis Cyprus Green #0f5c2e)
- `blue-600/700` → `primary/primary-light` (CTA buttons, links)
- `green-600` → `primary` (success icons)

## Files changed (9)

| File | Changes |
|------|---------|
| `cart/page.tsx` | bg, text, borders, CTA buttons |
| `checkout/page.tsx` | bg, empty state CTA, submit button, cancel button |
| `checkout/success/page.tsx` | bg, text, success icon, CTA buttons |
| `checkout/OrderSummary.tsx` | hint text color |
| `checkout/CustomerDetailsForm.tsx` | hint text color |
| `order/[id]/page.tsx` | success icon, text, CTA, home link |
| `thank-you/page.tsx` | bg, all text/border colors, CTAs, tracking section |
| `products/page.tsx` | bg, heading, subtext, empty state |
| `StripePaymentForm.tsx` | pay button (blue→primary), disabled state |

## Impact

- All customer-facing pages now use the same brand color palette
- No logic changes — pure CSS class name swaps
- 66 insertions, 66 deletions (zero net change)

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — clean pass
- [ ] Visual: Cart page uses brand primary for CTAs
- [ ] Visual: Checkout submit button is brand green (not emerald)
- [ ] Visual: Stripe pay button is brand green (not blue)
- [ ] Visual: Thank-you page uses consistent neutral/primary palette