### PR TITLE
style: brand color unification round 3 — shared components

### DIFF
--- a/frontend/src/components/AddToCartButton.tsx
+++ b/frontend/src/components/AddToCartButton.tsx
@@ -66,7 +66,7 @@ export default function AddToCartButton(props: {
     <button
       className={`h-9 sm:h-11 px-3 sm:px-4 w-full sm:w-auto rounded text-sm transition-colors ${
         isAdded
-          ? 'bg-emerald-600 text-white'
+          ? 'bg-primary text-white'
           : 'bg-neutral-900 text-white hover:bg-neutral-800'
       }`}
       onClick={handleClick}

--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -110,8 +110,8 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
             whitespace-nowrap transition-all duration-200
             ${
               !currentCat
-                ? 'bg-green-600 text-white shadow-md'
-                : 'bg-white text-gray-700 border border-gray-200 hover:border-green-400 hover:bg-green-50'
+                ? 'bg-primary text-white shadow-md'
+                : 'bg-white text-neutral-700 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale'
             }
           `}
         >
@@ -134,8 +134,8 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
                     whitespace-nowrap transition-all duration-200
                     ${
                       isSelected
-                        ? 'bg-green-600 text-white shadow-md'
-                        : 'bg-white text-gray-700 border border-gray-200 hover:border-green-400 hover:bg-green-50'
+                        ? 'bg-primary text-white shadow-md'
+                        : 'bg-white text-neutral-700 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale'
                     }
                   `}
                 >
@@ -158,8 +158,8 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
                     whitespace-nowrap transition-all duration-200
                     ${
                       isSelected
-                        ? 'bg-green-600 text-white shadow-md'
-                        : 'bg-white text-gray-700 border border-gray-200 hover:border-green-400 hover:bg-green-50'
+                        ? 'bg-primary text-white shadow-md'
+                        : 'bg-white text-neutral-700 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale'
                     }
                   `}
                 >

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -85,7 +85,7 @@ export default function Navigation() {
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
           <div className="flex items-center">
-            <Link href="/" className="text-xl font-bold text-green-600">
+            <Link href="/" className="text-xl font-bold text-primary">
               Project Dixis
             </Link>
           </div>
@@ -95,7 +95,7 @@ export default function Navigation() {
             <div className="ml-10 flex items-baseline space-x-4">
               <Link
                 href="/"
-                className="text-gray-700 hover:text-green-600 px-3 py-2 rounded-md text-sm font-medium"
+                className="text-neutral-700 hover:text-primary px-3 py-2 rounded-md text-sm font-medium"
                 data-testid="nav-products"
               >
                 Products
@@ -103,7 +103,7 @@ export default function Navigation() {
 
               <Link
                 href="/contact"
-                className="text-gray-700 hover:text-green-600 px-3 py-2 rounded-md text-sm font-medium"
+                className="text-neutral-700 hover:text-primary px-3 py-2 rounded-md text-sm font-medium"
                 data-testid="nav-contact"
               >
                 Επικοινωνία
@@ -114,7 +114,7 @@ export default function Navigation() {
               {isAuthenticated && isProducer && (
                 <Link
                   href="/producer/dashboard"
-                  className="text-gray-700 hover:text-green-600 px-3 py-2 rounded-md text-sm font-medium"
+                  className="text-neutral-700 hover:text-primary px-3 py-2 rounded-md text-sm font-medium"
                   data-testid="nav-dashboard"
                 >
                   Dashboard
@@ -127,13 +127,13 @@ export default function Navigation() {
           <div className="hidden md:flex items-center space-x-4">
             {isAuthenticated ? (
               <div data-testid="user-menu" className="flex items-center space-x-4">
-                <span className="text-sm text-gray-700">
+                <span className="text-sm text-neutral-700">
                   Hello, {user?.name}
                 </span>
                 <button
                   data-testid="logout-btn"
                   onClick={handleLogout}
-                  className="bg-gray-100 hover:bg-gray-200 text-gray-700 px-3 py-2 rounded-md text-sm font-medium"
+                  className="bg-neutral-100 hover:bg-neutral-200 text-neutral-700 px-3 py-2 rounded-md text-sm font-medium"
                 >
                   Logout
                 </button>
@@ -142,14 +142,14 @@ export default function Navigation() {
               <div className="flex items-center space-x-2">
                 <Link
                   href="/auth/login"
-                  className="text-gray-700 hover:text-green-600 px-3 py-2 rounded-md text-sm font-medium"
+                  className="text-neutral-700 hover:text-primary px-3 py-2 rounded-md text-sm font-medium"
                   data-testid="nav-login"
                 >
                   Login
                 </Link>
                 <Link
                   href="/auth/register"
-                  className="bg-green-600 hover:bg-green-700 text-white px-3 py-2 rounded-md text-sm font-medium"
+                  className="bg-primary hover:bg-primary-light text-white px-3 py-2 rounded-md text-sm font-medium"
                   data-testid="nav-register"
                 >
                   Sign Up
@@ -164,7 +164,7 @@ export default function Navigation() {
               ref={mobileMenuButtonRef}
               data-testid="mobile-menu-button"
               onClick={toggleMobileMenu}
-              className="bg-gray-50 p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-500 transition-colors"
+              className="bg-neutral-50 p-2 rounded-md text-neutral-400 hover:text-neutral-500 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary transition-colors"
               aria-expanded={mobileMenuOpen}
               aria-controls="mobile-menu"
               aria-label={mobileMenuOpen ? 'Close main menu' : 'Open main menu'}
@@ -197,7 +197,7 @@ export default function Navigation() {
             <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
               <Link
                 href="/"
-                className="text-gray-700 hover:text-green-600 block px-3 py-2 rounded-md text-base font-medium"
+                className="text-neutral-700 hover:text-primary block px-3 py-2 rounded-md text-base font-medium"
                 data-testid="mobile-nav-products"
               >
                 Products
@@ -205,7 +205,7 @@ export default function Navigation() {
 
               <Link
                 href="/contact"
-                className="text-gray-700 hover:text-green-600 block px-3 py-2 rounded-md text-base font-medium"
+                className="text-neutral-700 hover:text-primary block px-3 py-2 rounded-md text-base font-medium"
                 data-testid="mobile-nav-contact"
               >
                 Επικοινωνία
@@ -219,7 +219,7 @@ export default function Navigation() {
               {isAuthenticated && isProducer && (
                 <Link
                   href="/producer/dashboard"
-                  className="text-gray-700 hover:text-green-600 block px-3 py-2 rounded-md text-base font-medium"
+                  className="text-neutral-700 hover:text-primary block px-3 py-2 rounded-md text-base font-medium"
                   data-testid="mobile-nav-dashboard"
                   >
                   Dashboard
@@ -228,28 +228,28 @@ export default function Navigation() {
             </div>
             
             {/* Mobile Auth Section */}
-            <div className="pt-4 pb-3 border-t border-gray-200">
+            <div className="pt-4 pb-3 border-t border-neutral-200">
               {isAuthenticated ? (
                 <div className="flex items-center px-5">
                   <div className="flex-shrink-0">
-                    <div className="h-8 w-8 bg-green-100 rounded-full flex items-center justify-center">
-                      <span className="text-sm font-medium text-green-600">
+                    <div className="h-8 w-8 bg-primary-pale rounded-full flex items-center justify-center">
+                      <span className="text-sm font-medium text-primary">
                         {user?.name?.charAt(0).toUpperCase()}
                       </span>
                     </div>
                   </div>
                   <div className="ml-3">
-                    <div className="text-base font-medium text-gray-800">
+                    <div className="text-base font-medium text-neutral-800">
                       {user?.name}
                     </div>
-                    <div className="text-sm font-medium text-gray-500">
+                    <div className="text-sm font-medium text-neutral-500">
                       {user?.role === 'producer' ? 'Producer' : 'Consumer'}
                     </div>
                   </div>
                   <button
                     data-testid="mobile-logout-btn"
                     onClick={handleLogout}
-                    className="ml-auto bg-gray-100 hover:bg-gray-200 text-gray-700 px-3 py-2 rounded-md text-sm font-medium"
+                    className="ml-auto bg-neutral-100 hover:bg-neutral-200 text-neutral-700 px-3 py-2 rounded-md text-sm font-medium"
                   >
                     Logout
                   </button>
@@ -258,14 +258,14 @@ export default function Navigation() {
                 <div className="px-2 space-y-1">
                   <Link
                     href="/auth/login"
-                    className="text-gray-700 hover:text-green-600 block px-3 py-2 rounded-md text-base font-medium"
+                    className="text-neutral-700 hover:text-primary block px-3 py-2 rounded-md text-base font-medium"
                     data-testid="mobile-nav-login"
                       >
                     Login
                   </Link>
                   <Link
                     href="/auth/register"
-                    className="bg-green-600 hover:bg-green-700 text-white block px-3 py-2 rounded-md text-base font-medium"
+                    className="bg-primary hover:bg-primary-light text-white block px-3 py-2 rounded-md text-base font-medium"
                     data-testid="mobile-nav-register"
                       >
                     Sign Up

--- a/frontend/src/components/ProducerCard.tsx
+++ b/frontend/src/components/ProducerCard.tsx
@@ -43,10 +43,10 @@ export function ProducerCard({ id, slug, name, region, description, imageUrl, pr
       </div>
 
       <div className="px-4 pt-4 pb-2 flex-grow flex flex-col">
-        <h2 className="text-base font-bold text-gray-900 line-clamp-1 leading-tight">
+        <h2 className="text-base font-bold text-neutral-900 line-clamp-1 leading-tight">
           {name}
         </h2>
-        <p className="text-xs text-gray-500 mt-1 flex items-center gap-1">
+        <p className="text-xs text-neutral-500 mt-1 flex items-center gap-1">
           <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -54,12 +54,12 @@ export function ProducerCard({ id, slug, name, region, description, imageUrl, pr
           {region}
         </p>
         {description && (
-          <p className="text-sm text-gray-600 mt-2 line-clamp-2">{description}</p>
+          <p className="text-sm text-neutral-600 mt-2 line-clamp-2">{description}</p>
         )}
       </div>
 
       <div className="px-4 pb-4 mt-auto pt-2 border-t border-neutral-100 flex items-center justify-between">
-        <span className="text-sm text-gray-500">
+        <span className="text-sm text-neutral-500">
           {productsCount} {productsCount === 1 ? 'προϊόν' : 'προϊόντα'}
         </span>
         <span className="text-sm font-medium text-primary group-hover:underline">

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -43,7 +43,7 @@ export function ProductCard({ id, title, producer, producerId, producerSlug, pri
               className="object-cover group-hover:scale-105 transition-transform duration-500"
             />
           ) : (
-            <div className="w-full h-full flex items-center justify-center text-gray-400">
+            <div className="w-full h-full flex items-center justify-center text-neutral-400">
               <svg className="w-16 h-16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
@@ -68,7 +68,7 @@ export function ProductCard({ id, title, producer, producerId, producerSlug, pri
           </span>
         )}
         <Link href={productUrl} className="block mt-1">
-          <h3 data-testid="product-card-title" className="text-sm sm:text-base font-bold text-gray-900 line-clamp-2 leading-tight hover:text-primary/80 transition-colors">
+          <h3 data-testid="product-card-title" className="text-sm sm:text-base font-bold text-neutral-900 line-clamp-2 leading-tight hover:text-primary/80 transition-colors">
             {title}
           </h3>
         </Link>

--- a/frontend/src/components/ProductSearchInput.tsx
+++ b/frontend/src/components/ProductSearchInput.tsx
@@ -71,14 +71,14 @@ export function ProductSearchInput() {
         placeholder={t('products.searchPlaceholder')}
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
-        className="w-full px-4 py-2 pr-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none transition-all"
+        className="w-full px-4 py-2 pr-10 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all"
         aria-label={t('products.searchPlaceholder')}
       />
       {inputValue && (
         <button
           type="button"
           onClick={handleClear}
-          className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-neutral-400 hover:text-neutral-600"
           aria-label={t('common.cancel')}
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -88,7 +88,7 @@ export function ProductSearchInput() {
       )}
       {isPending && (
         <div className="absolute right-10 top-1/2 -translate-y-1/2">
-          <div className="w-4 h-4 border-2 border-green-500 border-t-transparent rounded-full animate-spin" />
+          <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
         </div>
       )}
     </div>

--- a/frontend/src/components/checkout/PaymentMethodSelector.tsx
+++ b/frontend/src/components/checkout/PaymentMethodSelector.tsx
@@ -44,8 +44,8 @@ export default function PaymentMethodSelector({
         htmlFor="payment-cod"
         className={`flex items-center gap-3 p-4 border rounded-lg cursor-pointer transition-colors ${
           value === 'cod'
-            ? 'border-emerald-600 bg-emerald-50'
-            : 'border-gray-200 hover:border-gray-300'
+            ? 'border-primary bg-primary-pale'
+            : 'border-neutral-200 hover:border-neutral-300'
         } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
       >
         <input
@@ -55,12 +55,12 @@ export default function PaymentMethodSelector({
           value="cod"
           checked={value === 'cod'}
           onChange={() => onChange('cod')}
-          className="w-5 h-5 text-emerald-600 focus:ring-emerald-500"
+          className="w-5 h-5 text-primary focus:ring-primary"
           data-testid="payment-cod"
         />
         <div className="flex-1">
           <span className="font-medium">Αντικαταβολή</span>
-          <p className="text-sm text-gray-500">Πληρωμή κατά την παράδοση</p>
+          <p className="text-sm text-neutral-500">Πληρωμή κατά την παράδοση</p>
           {codFee != null && codFee > 0 && (
             <p className="text-xs text-amber-600 mt-0.5" data-testid="cod-fee-note">
               +{new Intl.NumberFormat('el-GR', { style: 'currency', currency: 'EUR' }).format(codFee)} χρέωση αντικαταβολής
@@ -75,8 +75,8 @@ export default function PaymentMethodSelector({
           htmlFor="payment-card"
           className={`flex items-center gap-3 p-4 border rounded-lg cursor-pointer transition-colors ${
             value === 'card'
-              ? 'border-emerald-600 bg-emerald-50'
-              : 'border-gray-200 hover:border-gray-300'
+              ? 'border-primary bg-primary-pale'
+              : 'border-neutral-200 hover:border-neutral-300'
           } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
         >
           <input
@@ -86,16 +86,16 @@ export default function PaymentMethodSelector({
             value="card"
             checked={value === 'card'}
             onChange={() => onChange('card')}
-            className="w-5 h-5 text-emerald-600 focus:ring-emerald-500"
+            className="w-5 h-5 text-primary focus:ring-primary"
             data-testid="payment-card"
           />
           <div className="flex-1">
             <span className="font-medium">Κάρτα</span>
-            <p className="text-sm text-gray-500">Ασφαλής πληρωμή με κάρτα</p>
+            <p className="text-sm text-neutral-500">Ασφαλής πληρωμή με κάρτα</p>
           </div>
           <div className="flex gap-1">
-            <span className="text-xs bg-gray-100 px-2 py-1 rounded">Visa</span>
-            <span className="text-xs bg-gray-100 px-2 py-1 rounded">MC</span>
+            <span className="text-xs bg-neutral-100 px-2 py-1 rounded">Visa</span>
+            <span className="text-xs bg-neutral-100 px-2 py-1 rounded">MC</span>
           </div>
         </label>
       )}
@@ -106,7 +106,7 @@ export default function PaymentMethodSelector({
         <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg" data-testid="guest-card-notice">
           <p className="text-sm text-amber-800">
             Για πληρωμή με κάρτα απαιτείται σύνδεση.{' '}
-            <a href="/login?redirect=/checkout" className="font-medium text-emerald-600 hover:underline">Συνδεθείτε</a>
+            <a href="/login?redirect=/checkout" className="font-medium text-primary hover:underline">Συνδεθείτε</a>
           </p>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Convert off-brand colors in 7 high-visibility shared components used across the entire storefront
- These components appear on **every page** (Navigation), **product browsing** (CategoryStrip, ProductCard, SearchInput), **checkout** (PaymentMethodSelector), and **producer pages** (ProducerCard)

## Files Changed (7)
| Component | Impact | Changes |
|-----------|--------|---------|
| **Navigation.tsx** | Every page | Logo, nav links, auth buttons, mobile menu: green→primary, gray→neutral |
| **CategoryStrip.tsx** | /products | Active pill bg-green→bg-primary, hover states |
| **ProductCard.tsx** | Everywhere products shown | Placeholder icon, title: gray→neutral |
| **ProductSearchInput.tsx** | /products | Border, focus ring, spinner: gray→neutral, green→primary |
| **AddToCartButton.tsx** | All product cards | "Added" state: emerald-600→primary |
| **PaymentMethodSelector.tsx** | Checkout | Radio borders, selected state: emerald→primary, gray→neutral |
| **ProducerCard.tsx** | /producers | Name, region, description text: gray→neutral |

**Total**: 47 insertions, 47 deletions (pure color token swaps)

## Verification
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — clean pass
- [x] No localhost in bundle check passed

## Test Plan
- [ ] Visual: Navigation logo + links show brand green
- [ ] Visual: Category strip pills use brand primary colors
- [ ] Visual: Payment method selector uses brand primary for active state
- [ ] No functional changes — pure CSS class swaps

Generated-by: Claude (BRAND-COLOR-UNIFY-03)