### PR TITLE
style: freshen brand palette + Hellenize navigation

### DIFF
--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -85,8 +85,8 @@ export default function Navigation() {
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
           <div className="flex items-center">
-            <Link href="/" className="text-xl font-bold text-primary">
-              Project Dixis
+            <Link href="/" className="text-xl font-bold text-primary-dark">
+              Dixis
             </Link>
           </div>
 
@@ -98,26 +98,18 @@ export default function Navigation() {
                 className="text-neutral-700 hover:text-primary px-3 py-2 rounded-md text-sm font-medium"
                 data-testid="nav-products"
               >
-                Products
-              </Link>
-
-              <Link
-                href="/contact"
-                className="text-neutral-700 hover:text-primary px-3 py-2 rounded-md text-sm font-medium"
-                data-testid="nav-contact"
-              >
-                Επικοινωνία
+                Προϊόντα
               </Link>
 
               <CartIcon />
-              
+
               {isAuthenticated && isProducer && (
                 <Link
                   href="/producer/dashboard"
                   className="text-neutral-700 hover:text-primary px-3 py-2 rounded-md text-sm font-medium"
                   data-testid="nav-dashboard"
                 >
-                  Dashboard
+                  Πίνακας
                 </Link>
               )}
             </div>
@@ -128,14 +120,14 @@ export default function Navigation() {
             {isAuthenticated ? (
               <div data-testid="user-menu" className="flex items-center space-x-4">
                 <span className="text-sm text-neutral-700">
-                  Hello, {user?.name}
+                  Γεια, {user?.name}
                 </span>
                 <button
                   data-testid="logout-btn"
                   onClick={handleLogout}
                   className="bg-neutral-100 hover:bg-neutral-200 text-neutral-700 px-3 py-2 rounded-md text-sm font-medium"
                 >
-                  Logout
+                  Αποσύνδεση
                 </button>
               </div>
             ) : (
@@ -145,14 +137,14 @@ export default function Navigation() {
                   className="text-neutral-700 hover:text-primary px-3 py-2 rounded-md text-sm font-medium"
                   data-testid="nav-login"
                 >
-                  Login
+                  Σύνδεση
                 </Link>
                 <Link
                   href="/auth/register"
                   className="bg-primary hover:bg-primary-light text-white px-3 py-2 rounded-md text-sm font-medium"
                   data-testid="nav-register"
                 >
-                  Sign Up
+                  Εγγραφή
                 </Link>
               </div>
             )}
@@ -200,29 +192,21 @@ export default function Navigation() {
                 className="text-neutral-700 hover:text-primary block px-3 py-2 rounded-md text-base font-medium"
                 data-testid="mobile-nav-products"
               >
-                Products
-              </Link>
-
-              <Link
-                href="/contact"
-                className="text-neutral-700 hover:text-primary block px-3 py-2 rounded-md text-base font-medium"
-                data-testid="mobile-nav-contact"
-              >
-                Επικοινωνία
+                Προϊόντα
               </Link>
 
               <CartIcon
                 className="block text-base font-medium"
                 isMobile={true}
               />
-              
+
               {isAuthenticated && isProducer && (
                 <Link
                   href="/producer/dashboard"
                   className="text-neutral-700 hover:text-primary block px-3 py-2 rounded-md text-base font-medium"
                   data-testid="mobile-nav-dashboard"
                   >
-                  Dashboard
+                  Πίνακας
                 </Link>
               )}
             </div>
@@ -243,7 +227,7 @@ export default function Navigation() {
                       {user?.name}
                     </div>
                     <div className="text-sm font-medium text-neutral-500">
-                      {user?.role === 'producer' ? 'Producer' : 'Consumer'}
+                      {user?.role === 'producer' ? 'Παραγωγός' : 'Πελάτης'}
                     </div>
                   </div>
                   <button

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -14,10 +14,11 @@ const config: Config = {
           DEFAULT: 'hsl(var(--brand-primary))',
           foreground: 'hsl(var(--brand-primary-foreground))'
         },
-        // Primary - Cyprus Green (agricultural, trust, freshness)
+        // Primary - Fresh Mediterranean Green (alive, natural, inviting)
         primary: {
-          DEFAULT: '#0f5c2e',
-          light: '#1a7a3e',
+          DEFAULT: '#1a7a3e',
+          light: '#1f8f48',
+          dark: '#0f5c2e',
           pale: '#e8f5ed',
           foreground: '#ffffff'
         },
@@ -62,7 +63,7 @@ const config: Config = {
         'sm': '0 1px 2px rgba(0,0,0,0.05)',
         'md': '0 4px 12px rgba(0,0,0,0.08)',
         'lg': '0 8px 24px rgba(0,0,0,0.12)',
-        'glow': '0 0 20px rgba(15,92,46,0.15)',
+        'glow': '0 0 20px rgba(26,122,62,0.15)',
         'card': '0 2px 8px rgba(0,0,0,0.06), 0 8px 16px rgba(0,0,0,0.04)',
         'card-hover': '0 4px 12px rgba(0,0,0,0.1), 0 12px 24px rgba(0,0,0,0.08)'
       },


### PR DESCRIPTION
## Summary
- **Brighten primary green** from `#0f5c2e` → `#1a7a3e` — warmer, more alive, better for a food marketplace. Old dark kept as `primary-dark` for logos.
- **Visible hover state** `#1f8f48` — users now see the hover change on buttons/links.
- **Hellenize Navigation** — all labels in Greek: Προϊόντα, Σύνδεση, Εγγραφή, Αποσύνδεση, Πίνακας, Παραγωγός/Πελάτης.
- **Simplify logo** to just "Dixis" with `text-primary-dark`.
- **Remove duplicate** Επικοινωνία link from nav (already in footer).

## AC
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — clean pass
- [x] 2 files, 18 insertions, 33 deletions (well under 300 LOC)
- [x] WCAG AA: #1a7a3e on white = ~5.25:1 contrast ratio ✅
- [x] All nav labels in Greek for Greek-first marketplace

## Test plan
- [ ] Visual: Nav labels should all be in Greek
- [ ] Visual: Green should be noticeably brighter/warmer
- [ ] Hover: Buttons/links should have visible hover color shift
- [ ] Mobile: Menu labels all in Greek, role labels Παραγωγός/Πελάτης
- [ ] Logo: Shows "Dixis" in dark green

Generated-by: Claude agent