### PR TITLE
style: brand color round 4 — customer-facing pages

### DIFF
--- a/frontend/src/app/(storefront)/checkout/CustomerDetailsForm.tsx
+++ b/frontend/src/app/(storefront)/checkout/CustomerDetailsForm.tsx
@@ -45,8 +45,8 @@ export default function CustomerDetailsForm({
       )}
 
       {savedAddress && (
-        <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg" data-testid="saved-address-notice">
-          <p className="text-sm text-green-800">
+        <div className="mb-4 p-3 bg-primary-pale border border-primary/20 rounded-lg" data-testid="saved-address-notice">
+          <p className="text-sm text-primary-dark">
             Χρησιμοποιείται η αποθηκευμένη διεύθυνση αποστολής σας.
           </p>
         </div>

--- a/frontend/src/app/auth/forgot-password/page.tsx
+++ b/frontend/src/app/auth/forgot-password/page.tsx
@@ -48,16 +48,16 @@ export default function ForgotPassword() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-neutral-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="text-center">
-          <Link href="/" className="text-2xl font-bold text-green-600">
+          <Link href="/" className="text-2xl font-bold text-primary">
             Dixis
           </Link>
-          <h1 className="mt-6 text-3xl font-bold text-gray-900" data-testid="page-title">
+          <h1 className="mt-6 text-3xl font-bold text-neutral-900" data-testid="page-title">
             {t('auth.forgotPassword.title')}
           </h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-neutral-600">
             {t('auth.forgotPassword.subtitle')}
           </p>
         </div>
@@ -67,14 +67,14 @@ export default function ForgotPassword() {
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           {success ? (
             <div className="text-center">
-              <div className="rounded-md bg-green-50 p-4 mb-6" data-testid="success-message">
-                <div className="text-sm text-green-700">
+              <div className="rounded-md bg-primary-pale p-4 mb-6" data-testid="success-message">
+                <div className="text-sm text-primary-dark">
                   {t('auth.forgotPassword.success')}
                 </div>
               </div>
               <Link
                 href="/auth/login"
-                className="text-sm font-medium text-green-600 hover:text-green-500"
+                className="text-sm font-medium text-primary hover:text-primary-light"
               >
                 {t('auth.forgotPassword.backToLogin')}
               </Link>
@@ -88,7 +88,7 @@ export default function ForgotPassword() {
               )}
 
               <div>
-                <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                <label htmlFor="email" className="block text-sm font-medium text-neutral-700">
                   {t('auth.forgotPassword.email')}
                 </label>
                 <div className="mt-1">
@@ -101,7 +101,7 @@ export default function ForgotPassword() {
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     data-testid="forgot-password-email"
-                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500"
+                    className="appearance-none block w-full px-3 py-2 border border-neutral-300 rounded-md placeholder-neutral-400 focus:outline-none focus:ring-primary focus:border-primary"
                     placeholder={t('auth.forgotPassword.emailPlaceholder')}
                   />
                 </div>
@@ -112,7 +112,7 @@ export default function ForgotPassword() {
                   type="submit"
                   disabled={loading}
                   data-testid="forgot-password-submit"
-                  className="w-full flex justify-center items-center gap-2 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                  className="w-full flex justify-center items-center gap-2 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:bg-neutral-400 disabled:cursor-not-allowed transition-colors"
                 >
                   {loading && (
                     <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -130,7 +130,7 @@ export default function ForgotPassword() {
             <div className="text-center">
               <Link
                 href="/auth/login"
-                className="text-sm text-gray-600 hover:text-green-600"
+                className="text-sm text-neutral-600 hover:text-primary"
               >
                 {t('auth.forgotPassword.backToLogin')}
               </Link>

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -57,20 +57,20 @@ function LoginForm() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-neutral-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="text-center">
-          <Link href="/" className="text-2xl font-bold text-green-600">
+          <Link href="/" className="text-2xl font-bold text-primary">
             Dixis
           </Link>
-          <h1 className="mt-6 text-3xl font-bold text-gray-900" data-testid="page-title">
+          <h1 className="mt-6 text-3xl font-bold text-neutral-900" data-testid="page-title">
             {t('auth.login.title')}
           </h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-neutral-600">
             {t('auth.login.subtitle')}{' '}
             <Link
               href="/auth/register"
-              className="font-medium text-green-600 hover:text-green-500"
+              className="font-medium text-primary hover:text-primary-light"
             >
               {t('auth.login.createAccount')}
             </Link>
@@ -88,7 +88,7 @@ function LoginForm() {
             )}
 
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="email" className="block text-sm font-medium text-neutral-700">
                 {t('auth.login.email')}
               </label>
               <div className="mt-1">
@@ -101,7 +101,7 @@ function LoginForm() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   data-testid="login-email"
-                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500"
+                  className="appearance-none block w-full px-3 py-2 border border-neutral-300 rounded-md placeholder-neutral-400 focus:outline-none focus:ring-primary focus:border-primary"
                   placeholder={t('auth.login.emailPlaceholder')}
                 />
               </div>
@@ -109,12 +109,12 @@ function LoginForm() {
 
             <div>
               <div className="flex items-center justify-between">
-                <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                <label htmlFor="password" className="block text-sm font-medium text-neutral-700">
                   {t('auth.login.password')}
                 </label>
                 <Link
                   href="/auth/forgot-password"
-                  className="text-sm text-green-600 hover:text-green-500"
+                  className="text-sm text-primary hover:text-primary-light"
                   data-testid="forgot-password-link"
                 >
                   {t('auth.forgotPassword.title')}
@@ -130,7 +130,7 @@ function LoginForm() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   data-testid="login-password"
-                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500"
+                  className="appearance-none block w-full px-3 py-2 border border-neutral-300 rounded-md placeholder-neutral-400 focus:outline-none focus:ring-primary focus:border-primary"
                   placeholder={t('auth.login.passwordPlaceholder')}
                 />
               </div>
@@ -141,7 +141,7 @@ function LoginForm() {
                 type="submit"
                 disabled={loading}
                 data-testid="login-submit"
-                className="w-full flex justify-center items-center gap-2 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                className="w-full flex justify-center items-center gap-2 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:bg-neutral-400 disabled:cursor-not-allowed transition-colors"
               >
                 {loading && (
                   <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -158,18 +158,18 @@ function LoginForm() {
             <div className="text-center">
               <Link
                 href="/"
-                className="text-sm text-gray-600 hover:text-green-600"
+                className="text-sm text-neutral-600 hover:text-primary"
               >
                 ← {t('auth.login.backToProducts')}
               </Link>
             </div>
           </div>
 
-          <div className="mt-4 pt-4 border-t border-gray-200">
+          <div className="mt-4 pt-4 border-t border-neutral-200">
             <div className="text-center">
               <Link
                 href="/auth/admin-login"
-                className="text-sm text-gray-600 hover:text-green-600"
+                className="text-sm text-neutral-600 hover:text-primary"
               >
                 Είσοδος Διαχειριστή
               </Link>

--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -80,20 +80,20 @@ export default function Register() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-neutral-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="text-center">
-          <Link href="/" className="text-2xl font-bold text-green-600">
+          <Link href="/" className="text-2xl font-bold text-primary">
             Dixis
           </Link>
-          <h1 className="mt-6 text-3xl font-bold text-gray-900" data-testid="page-title">
+          <h1 className="mt-6 text-3xl font-bold text-neutral-900" data-testid="page-title">
             Δημιουργία Λογαριασμού
           </h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-neutral-600">
             Ή{' '}
             <Link
               href="/auth/login"
-              className="font-medium text-green-600 hover:text-green-500"
+              className="font-medium text-primary hover:text-primary-light"
             >
               συνδεθείτε στον υπάρχοντα λογαριασμό σας
             </Link>
@@ -111,7 +111,7 @@ export default function Register() {
             )}
 
             <div>
-              <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="name" className="block text-sm font-medium text-neutral-700">
                 Ονοματεπώνυμο
               </label>
               <div className="mt-1">
@@ -124,14 +124,14 @@ export default function Register() {
                   value={formData.name}
                   onChange={handleChange}
                   data-testid="register-name"
-                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500"
+                  className="appearance-none block w-full px-3 py-2 border border-neutral-300 rounded-md placeholder-neutral-400 focus:outline-none focus:ring-primary focus:border-primary"
                   placeholder="Εισάγετε το ονοματεπώνυμό σας"
                 />
               </div>
             </div>
 
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="email" className="block text-sm font-medium text-neutral-700">
                 Ηλ. Ταχυδρομείο
               </label>
               <div className="mt-1">
@@ -144,14 +144,14 @@ export default function Register() {
                   value={formData.email}
                   onChange={handleChange}
                   data-testid="register-email"
-                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500"
+                  className="appearance-none block w-full px-3 py-2 border border-neutral-300 rounded-md placeholder-neutral-400 focus:outline-none focus:ring-primary focus:border-primary"
                   placeholder="Εισάγετε το email σας"
                 />
               </div>
             </div>
 
             <div>
-              <label htmlFor="role" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="role" className="block text-sm font-medium text-neutral-700">
                 Τύπος Λογαριασμού
               </label>
               <div className="mt-1">
@@ -161,19 +161,19 @@ export default function Register() {
                   value={formData.role}
                   onChange={handleChange}
                   data-testid="register-role"
-                  className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-green-500 focus:border-green-500"
+                  className="block w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-primary focus:border-primary"
                 >
                   <option value="consumer">Καταναλωτής (Αγορά προϊόντων)</option>
                   <option value="producer">Παραγωγός (Πώληση προϊόντων)</option>
                 </select>
               </div>
-              <p className="mt-1 text-xs text-gray-500">
+              <p className="mt-1 text-xs text-neutral-500">
                 Επιλέξτε &ldquo;Καταναλωτής&rdquo; για αγορά ή &ldquo;Παραγωγός&rdquo; για πώληση προϊόντων
               </p>
             </div>
 
             <div>
-              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="password" className="block text-sm font-medium text-neutral-700">
                 Κωδικός Πρόσβασης
               </label>
               <div className="mt-1">
@@ -186,17 +186,17 @@ export default function Register() {
                   value={formData.password}
                   onChange={handleChange}
                   data-testid="register-password"
-                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500"
+                  className="appearance-none block w-full px-3 py-2 border border-neutral-300 rounded-md placeholder-neutral-400 focus:outline-none focus:ring-primary focus:border-primary"
                   placeholder="Δημιουργήστε έναν κωδικό"
                 />
               </div>
-              <p className="mt-1 text-xs text-gray-500">
+              <p className="mt-1 text-xs text-neutral-500">
                 Ο κωδικός πρέπει να έχει τουλάχιστον 8 χαρακτήρες
               </p>
             </div>
 
             <div>
-              <label htmlFor="password_confirmation" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="password_confirmation" className="block text-sm font-medium text-neutral-700">
                 Επιβεβαίωση Κωδικού
               </label>
               <div className="mt-1">
@@ -209,7 +209,7 @@ export default function Register() {
                   value={formData.password_confirmation}
                   onChange={handleChange}
                   data-testid="register-password-confirm"
-                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500"
+                  className="appearance-none block w-full px-3 py-2 border border-neutral-300 rounded-md placeholder-neutral-400 focus:outline-none focus:ring-primary focus:border-primary"
                   placeholder="Επιβεβαιώστε τον κωδικό σας"
                 />
               </div>
@@ -220,7 +220,7 @@ export default function Register() {
                 type="submit"
                 disabled={registerLoading}
                 data-testid="register-submit"
-                className="w-full flex justify-center items-center gap-2 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                className="w-full flex justify-center items-center gap-2 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:bg-neutral-400 disabled:cursor-not-allowed transition-colors"
               >
                 {registerLoading && (
                   <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -237,7 +237,7 @@ export default function Register() {
             <div className="text-center">
               <Link
                 href="/"
-                className="text-sm text-gray-600 hover:text-green-600"
+                className="text-sm text-neutral-600 hover:text-primary"
               >
                 ← Επιστροφή στα Προϊόντα
               </Link>

--- a/frontend/src/app/auth/reset-password/page.tsx
+++ b/frontend/src/app/auth/reset-password/page.tsx
@@ -82,16 +82,16 @@ function ResetPasswordForm() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-neutral-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="text-center">
-          <Link href="/" className="text-2xl font-bold text-green-600">
+          <Link href="/" className="text-2xl font-bold text-primary">
             Dixis
           </Link>
-          <h1 className="mt-6 text-3xl font-bold text-gray-900" data-testid="page-title">
+          <h1 className="mt-6 text-3xl font-bold text-neutral-900" data-testid="page-title">
             {t('auth.resetPassword.title')}
           </h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-neutral-600">
             {t('auth.resetPassword.subtitle')}
           </p>
         </div>
@@ -101,14 +101,14 @@ function ResetPasswordForm() {
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           {success ? (
             <div className="text-center">
-              <div className="rounded-md bg-green-50 p-4 mb-6" data-testid="success-message">
-                <div className="text-sm text-green-700">
+              <div className="rounded-md bg-primary-pale p-4 mb-6" data-testid="success-message">
+                <div className="text-sm text-primary-dark">
                   {t('auth.resetPassword.success')}
                 </div>
               </div>
               <Link
                 href="/auth/login"
-                className="text-sm font-medium text-green-600 hover:text-green-500"
+                className="text-sm font-medium text-primary hover:text-primary-light"
               >
                 {t('auth.resetPassword.backToLogin')}
               </Link>
@@ -122,7 +122,7 @@ function ResetPasswordForm() {
               )}
 
               <div>
-                <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                <label htmlFor="password" className="block text-sm font-medium text-neutral-700">
                   {t('auth.resetPassword.password')}
                 </label>
                 <div className="mt-1">
@@ -135,14 +135,14 @@ function ResetPasswordForm() {
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                     data-testid="reset-password-password"
-                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500"
+                    className="appearance-none block w-full px-3 py-2 border border-neutral-300 rounded-md placeholder-neutral-400 focus:outline-none focus:ring-primary focus:border-primary"
                     placeholder={t('auth.resetPassword.passwordPlaceholder')}
                   />
                 </div>
               </div>
 
               <div>
-                <label htmlFor="password_confirmation" className="block text-sm font-medium text-gray-700">
+                <label htmlFor="password_confirmation" className="block text-sm font-medium text-neutral-700">
                   {t('auth.resetPassword.confirmPassword')}
                 </label>
                 <div className="mt-1">
@@ -155,7 +155,7 @@ function ResetPasswordForm() {
                     value={passwordConfirmation}
                     onChange={(e) => setPasswordConfirmation(e.target.value)}
                     data-testid="reset-password-confirm"
-                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500"
+                    className="appearance-none block w-full px-3 py-2 border border-neutral-300 rounded-md placeholder-neutral-400 focus:outline-none focus:ring-primary focus:border-primary"
                     placeholder={t('auth.resetPassword.confirmPlaceholder')}
                   />
                 </div>
@@ -166,7 +166,7 @@ function ResetPasswordForm() {
                   type="submit"
                   disabled={loading || !token || !email}
                   data-testid="reset-password-submit"
-                  className="w-full flex justify-center items-center gap-2 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                  className="w-full flex justify-center items-center gap-2 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:bg-neutral-400 disabled:cursor-not-allowed transition-colors"
                 >
                   {loading && (
                     <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -184,7 +184,7 @@ function ResetPasswordForm() {
             <div className="text-center">
               <Link
                 href="/auth/login"
-                className="text-sm text-gray-600 hover:text-green-600"
+                className="text-sm text-neutral-600 hover:text-primary"
               >
                 {t('auth.resetPassword.backToLogin')}
               </Link>
@@ -199,8 +199,8 @@ function ResetPasswordForm() {
 export default function ResetPassword() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-gray-600">Loading...</div>
+      <div className="min-h-screen bg-neutral-50 flex items-center justify-center">
+        <div className="text-neutral-600">Loading...</div>
       </div>
     }>
       <ResetPasswordForm />

--- a/frontend/src/app/auth/verify-email/page.tsx
+++ b/frontend/src/app/auth/verify-email/page.tsx
@@ -94,13 +94,13 @@ function VerifyEmailForm() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-neutral-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="text-center">
-          <Link href="/" className="text-2xl font-bold text-green-600">
+          <Link href="/" className="text-2xl font-bold text-primary">
             Dixis
           </Link>
-          <h1 className="mt-6 text-3xl font-bold text-gray-900" data-testid="page-title">
+          <h1 className="mt-6 text-3xl font-bold text-neutral-900" data-testid="page-title">
             {t('auth.verifyEmail.title')}
           </h1>
         </div>
@@ -112,7 +112,7 @@ function VerifyEmailForm() {
           {state === 'loading' && (
             <div className="text-center" data-testid="verify-loading">
               <svg
-                className="animate-spin h-12 w-12 text-green-600 mx-auto"
+                className="animate-spin h-12 w-12 text-primary mx-auto"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -131,16 +131,16 @@ function VerifyEmailForm() {
                   d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                 />
               </svg>
-              <p className="mt-4 text-gray-600">{t('auth.verifyEmail.verifying')}</p>
+              <p className="mt-4 text-neutral-600">{t('auth.verifyEmail.verifying')}</p>
             </div>
           )}
 
           {/* Success State */}
           {state === 'success' && (
             <div className="text-center" data-testid="verify-success">
-              <div className="rounded-full bg-green-100 p-3 mx-auto w-fit">
+              <div className="rounded-full bg-primary-pale p-3 mx-auto w-fit">
                 <svg
-                  className="h-8 w-8 text-green-600"
+                  className="h-8 w-8 text-primary"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -153,14 +153,14 @@ function VerifyEmailForm() {
                   />
                 </svg>
               </div>
-              <h2 className="mt-4 text-lg font-medium text-gray-900">
+              <h2 className="mt-4 text-lg font-medium text-neutral-900">
                 {t('auth.verifyEmail.successTitle')}
               </h2>
-              <p className="mt-2 text-sm text-gray-600">{message}</p>
+              <p className="mt-2 text-sm text-neutral-600">{message}</p>
               <Link
                 href="/auth/login"
                 data-testid="login-link"
-                className="mt-6 inline-block w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+                className="mt-6 inline-block w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
               >
                 {t('auth.verifyEmail.goToLogin')}
               </Link>
@@ -185,14 +185,14 @@ function VerifyEmailForm() {
                   />
                 </svg>
               </div>
-              <h2 className="mt-4 text-lg font-medium text-gray-900">
+              <h2 className="mt-4 text-lg font-medium text-neutral-900">
                 {t('auth.verifyEmail.expiredTitle')}
               </h2>
-              <p className="mt-2 text-sm text-gray-600">{message}</p>
+              <p className="mt-2 text-sm text-neutral-600">{message}</p>
 
               {resendSuccess ? (
-                <div className="mt-4 rounded-md bg-green-50 p-4">
-                  <p className="text-sm text-green-700">
+                <div className="mt-4 rounded-md bg-primary-pale p-4">
+                  <p className="text-sm text-primary-dark">
                     {t('auth.verifyEmail.resendSuccess')}
                   </p>
                 </div>
@@ -201,7 +201,7 @@ function VerifyEmailForm() {
                   onClick={handleResend}
                   disabled={resendLoading}
                   data-testid="resend-button"
-                  className="mt-4 inline-flex items-center justify-center gap-2 w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:bg-gray-400"
+                  className="mt-4 inline-flex items-center justify-center gap-2 w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:bg-neutral-400"
                 >
                   {resendLoading && (
                     <svg
@@ -249,13 +249,13 @@ function VerifyEmailForm() {
                   />
                 </svg>
               </div>
-              <h2 className="mt-4 text-lg font-medium text-gray-900">
+              <h2 className="mt-4 text-lg font-medium text-neutral-900">
                 {t('auth.verifyEmail.errorTitle')}
               </h2>
-              <p className="mt-2 text-sm text-gray-600">{message}</p>
+              <p className="mt-2 text-sm text-neutral-600">{message}</p>
               <Link
                 href="/auth/login"
-                className="mt-6 inline-block text-sm font-medium text-green-600 hover:text-green-500"
+                className="mt-6 inline-block text-sm font-medium text-primary hover:text-primary-light"
               >
                 {t('auth.verifyEmail.backToLogin')}
               </Link>
@@ -265,9 +265,9 @@ function VerifyEmailForm() {
           {/* Missing Params State */}
           {state === 'missing' && (
             <div className="text-center" data-testid="verify-missing">
-              <div className="rounded-full bg-gray-100 p-3 mx-auto w-fit">
+              <div className="rounded-full bg-neutral-100 p-3 mx-auto w-fit">
                 <svg
-                  className="h-8 w-8 text-gray-600"
+                  className="h-8 w-8 text-neutral-600"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -280,13 +280,13 @@ function VerifyEmailForm() {
                   />
                 </svg>
               </div>
-              <h2 className="mt-4 text-lg font-medium text-gray-900">
+              <h2 className="mt-4 text-lg font-medium text-neutral-900">
                 {t('auth.verifyEmail.missingTitle')}
               </h2>
-              <p className="mt-2 text-sm text-gray-600">{message}</p>
+              <p className="mt-2 text-sm text-neutral-600">{message}</p>
               <Link
                 href="/auth/login"
-                className="mt-6 inline-block text-sm font-medium text-green-600 hover:text-green-500"
+                className="mt-6 inline-block text-sm font-medium text-primary hover:text-primary-light"
               >
                 {t('auth.verifyEmail.backToLogin')}
               </Link>
@@ -307,8 +307,8 @@ export default function VerifyEmail() {
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-          <div className="text-gray-600">Loading...</div>
+        <div className="min-h-screen bg-neutral-50 flex items-center justify-center">
+          <div className="text-neutral-600">Loading...</div>
         </div>
       }
     >

--- a/frontend/src/app/track/[token]/page.tsx
+++ b/frontend/src/app/track/[token]/page.tsx
@@ -64,11 +64,11 @@ export default async function TrackPage({ params }: { params: { token: string } 
 
   if (!order) {
     return (
-      <div className="min-h-screen bg-gray-50 py-8 px-4">
+      <div className="min-h-screen bg-neutral-50 py-8 px-4">
         <div className="max-w-xl mx-auto bg-white rounded-xl shadow-sm p-8 text-center">
           <div className="text-5xl mb-4">🔍</div>
-          <h1 className="text-xl font-semibold text-gray-900 mb-2">Παραγγελία δεν βρέθηκε</h1>
-          <p className="text-gray-600">
+          <h1 className="text-xl font-semibold text-neutral-900 mb-2">Παραγγελία δεν βρέθηκε</h1>
+          <p className="text-neutral-600">
             Ο σύνδεσμος παρακολούθησης δεν είναι έγκυρος ή η παραγγελία δεν υπάρχει.
           </p>
         </div>
@@ -89,60 +89,60 @@ export default async function TrackPage({ params }: { params: { token: string } 
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8 px-4">
+    <div className="min-h-screen bg-neutral-50 py-8 px-4">
       <div className="max-w-xl mx-auto">
         <div className="bg-white rounded-xl shadow-sm p-6">
-          <h1 className="text-2xl font-bold text-gray-900 mb-6">Παρακολούθηση Παραγγελίας</h1>
+          <h1 className="text-2xl font-bold text-neutral-900 mb-6">Παρακολούθηση Παραγγελίας</h1>
 
           {/* Order Info */}
           <div className="space-y-4">
             <div className="flex items-center justify-between pb-4 border-b">
-              <span className="text-gray-600">Κωδικός:</span>
+              <span className="text-neutral-600">Κωδικός:</span>
               <span className="font-mono font-semibold text-lg">#{order.id}</span>
             </div>
 
             <div className="flex items-center justify-between pb-4 border-b">
-              <span className="text-gray-600">Κατάσταση:</span>
+              <span className="text-neutral-600">Κατάσταση:</span>
               <StatusBadge status={order.status} />
             </div>
 
             <div className="flex items-center justify-between pb-4 border-b">
-              <span className="text-gray-600">Ημερομηνία:</span>
+              <span className="text-neutral-600">Ημερομηνία:</span>
               <span>{formatDateStable(order.created_at)}</span>
             </div>
 
             <div className="flex items-center justify-between pb-4 border-b">
-              <span className="text-gray-600">Προϊόντα:</span>
+              <span className="text-neutral-600">Προϊόντα:</span>
               <span>{order.items_count} τεμάχια</span>
             </div>
 
             <div className="flex items-center justify-between pb-4 border-b">
-              <span className="text-gray-600">Σύνολο:</span>
-              <span className="font-semibold text-emerald-600">{fmt(order.total)}</span>
+              <span className="text-neutral-600">Σύνολο:</span>
+              <span className="font-semibold text-primary">{fmt(order.total)}</span>
             </div>
           </div>
 
           {/* Shipment Info */}
           {order.shipment && (
             <div className="mt-6 pt-6 border-t">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">Πληροφορίες Αποστολής</h2>
+              <h2 className="text-lg font-semibold text-neutral-900 mb-4">Πληροφορίες Αποστολής</h2>
 
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
-                  <span className="text-gray-600">Κατάσταση αποστολής:</span>
+                  <span className="text-neutral-600">Κατάσταση αποστολής:</span>
                   <span className="capitalize">{statusLabels[order.shipment.status] || order.shipment.status}</span>
                 </div>
 
                 {order.shipment.carrier_code && (
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-600">Μεταφορέας:</span>
+                    <span className="text-neutral-600">Μεταφορέας:</span>
                     <span className="uppercase">{order.shipment.carrier_code}</span>
                   </div>
                 )}
 
                 {order.shipment.tracking_code && (
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-600">Αριθμός Αποστολής:</span>
+                    <span className="text-neutral-600">Αριθμός Αποστολής:</span>
                     <span className="font-mono">{order.shipment.tracking_code}</span>
                   </div>
                 )}
@@ -153,7 +153,7 @@ export default async function TrackPage({ params }: { params: { token: string } 
                       href={order.shipment.tracking_url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors"
+                      className="inline-flex items-center gap-2 bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light transition-colors"
                     >
                       Παρακολούθηση στον Μεταφορέα
                       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -170,20 +170,20 @@ export default async function TrackPage({ params }: { params: { token: string } 
 
                 {order.shipment.shipped_at && (
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-600">Ημ/νία αποστολής:</span>
+                    <span className="text-neutral-600">Ημ/νία αποστολής:</span>
                     <span>{formatDateStable(order.shipment.shipped_at)}</span>
                   </div>
                 )}
 
                 {order.shipment.estimated_delivery && !order.shipment.delivered_at && (
                   <div className="flex items-center justify-between">
-                    <span className="text-gray-600">Εκτιμώμενη παράδοση:</span>
+                    <span className="text-neutral-600">Εκτιμώμενη παράδοση:</span>
                     <span>{formatDateStable(order.shipment.estimated_delivery)}</span>
                   </div>
                 )}
 
                 {order.shipment.delivered_at && (
-                  <div className="flex items-center justify-between text-emerald-600">
+                  <div className="flex items-center justify-between text-primary">
                     <span>Παραδόθηκε:</span>
                     <span>{formatDateStable(order.shipment.delivered_at)}</span>
                   </div>
@@ -194,10 +194,10 @@ export default async function TrackPage({ params }: { params: { token: string } 
 
           {/* Footer */}
           <div className="mt-8 pt-6 border-t text-center">
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-neutral-500">
               Αυτός ο σύνδεσμος είναι μόνο για ενημέρωση κατάστασης.
             </p>
-            <a href="/" className="text-emerald-600 hover:underline text-sm mt-2 inline-block">
+            <a href="/" className="text-primary hover:underline text-sm mt-2 inline-block">
               Επιστροφή στην αρχική
             </a>
           </div>

--- a/frontend/src/components/CartBadge.tsx
+++ b/frontend/src/components/CartBadge.tsx
@@ -15,7 +15,7 @@ export function CartBadge() {
   return (
     <Link
       href="/cart"
-      className="relative inline-flex items-center gap-2 rounded-lg px-3 py-2 border border-gray-200 bg-white hover:shadow-md transition-shadow"
+      className="relative inline-flex items-center gap-2 rounded-lg px-3 py-2 border border-neutral-200 bg-white hover:shadow-md transition-shadow"
       aria-label="Μετάβαση στο καλάθι"
       data-testid="nav-cart cart-icon-active"
     >
@@ -36,7 +36,7 @@ export function CartBadge() {
       <span className="text-sm font-medium">Καλάθι</span>
       {displayCount > 0 && (
         <span
-          className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-emerald-600 px-1.5 text-xs font-bold text-white"
+          className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-primary px-1.5 text-xs font-bold text-white"
           aria-live="polite"
           aria-atomic="true"
           data-testid="cart-item-count"

--- a/frontend/src/components/FilterStrip.tsx
+++ b/frontend/src/components/FilterStrip.tsx
@@ -34,13 +34,13 @@ export function FilterStrip({ label, options, selected, paramName, basePath }: F
 
   const pillBase =
     'px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-all duration-200'
-  const pillActive = 'bg-green-600 text-white shadow-sm'
+  const pillActive = 'bg-primary text-white shadow-sm'
   const pillInactive =
-    'bg-white text-gray-700 border border-gray-200 hover:border-green-400 hover:bg-green-50'
+    'bg-white text-neutral-700 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale'
 
   return (
     <div className="flex items-center gap-2 overflow-x-auto scrollbar-hide pb-1">
-      <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider shrink-0">
+      <span className="text-xs font-semibold text-neutral-500 uppercase tracking-wider shrink-0">
         {label}
       </span>
       <button

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -50,7 +50,7 @@ function ToastItem({ toast }: ToastProps) {
   const getToastStyles = (type: ToastType['type']) => {
     switch (type) {
       case 'success':
-        return 'bg-green-600 text-white border border-green-700 shadow-green-200/50';
+        return 'bg-primary text-white border border-primary-dark shadow-primary/20/50';
       case 'error':
         return 'bg-red-600 text-white border border-red-700 shadow-red-200/50';
       case 'warning':
@@ -58,7 +58,7 @@ function ToastItem({ toast }: ToastProps) {
       case 'info':
         return 'bg-blue-600 text-white border border-blue-700 shadow-blue-200/50';
       default:
-        return 'bg-gray-600 text-white border border-gray-700 shadow-gray-200/50';
+        return 'bg-neutral-600 text-white border border-neutral-700 shadow-neutral-200/50';
     }
   };
 

--- a/frontend/src/components/cart/CartClient.tsx
+++ b/frontend/src/components/cart/CartClient.tsx
@@ -38,7 +38,7 @@ export default function CartClient({ items }: { items: CartItem[] }) {
   };
 
   if (!items.length) {
-    return <p className="text-gray-500">Το καλάθι σας είναι άδειο.</p>;
+    return <p className="text-neutral-500">Το καλάθι σας είναι άδειο.</p>;
   }
 
   return (
@@ -65,7 +65,7 @@ export default function CartClient({ items }: { items: CartItem[] }) {
                 <div className="flex items-center gap-2">
                   <button
                     onClick={() => updateQty(item.slug, item.qty - 1)}
-                    className="px-2 py-1 bg-gray-200 rounded hover:bg-gray-300"
+                    className="px-2 py-1 bg-neutral-200 rounded hover:bg-neutral-300"
                     disabled={isPending}
                   >
                     -
@@ -73,7 +73,7 @@ export default function CartClient({ items }: { items: CartItem[] }) {
                   <span className="min-w-[2rem] text-center">{item.qty}</span>
                   <button
                     onClick={() => updateQty(item.slug, item.qty + 1)}
-                    className="px-2 py-1 bg-gray-200 rounded hover:bg-gray-300"
+                    className="px-2 py-1 bg-neutral-200 rounded hover:bg-neutral-300"
                     disabled={isPending}
                   >
                     +


### PR DESCRIPTION
## Summary
- **11 customer-facing files** migrated from generic Tailwind colors to brand palette
- Auth pages: `gray-*` → `neutral-*`, `green-*` → `primary-*` (login, register, forgot/reset password, verify email)
- Cart & Checkout: `gray-*` → `neutral-*`, `emerald-*` → `primary` (CartClient, CartBadge, CustomerDetailsForm)
- Order tracking: `gray-*` → `neutral-*`, `emerald-*` → `primary` (track/[token])
- Toast: `green-600` → `primary` for success toasts
- FilterStrip: `green-*` → `primary-*` for active/hover states

## AC
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — clean pass
- [x] 11 files, 117 insertions, 117 deletions (under 300 LOC limit)
- [x] Zero `gray-`, `green-`, `emerald-` remaining in edited files
- [x] Pure color token swaps — zero functional changes

## Test plan
- [ ] Auth pages: Login/Register forms render with green brand buttons, neutral backgrounds
- [ ] Cart badge: Shows primary green instead of emerald
- [ ] Track page: Order total and CTA use primary green
- [ ] Toast: Success toast matches brand green
- [ ] FilterStrip: Active pills use primary green

Generated-by: Claude agent