### PR TITLE
feat: admin email notification on new orders (ADMIN-NOTIFY-01)

### DIFF
--- a/backend/app/Mail/AdminNewOrder.php
+++ b/backend/app/Mail/AdminNewOrder.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Order;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Pass ADMIN-NOTIFY-01: Admin notification for new orders (Greek).
+ *
+ * Sends a summary email to the admin when a new order is placed.
+ * Includes order total, item count, payment method, and a link
+ * to the admin dashboard.
+ */
+class AdminNewOrder extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public Order $order
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "Νέα Παραγγελία #{$this->order->id} — €"
+                . number_format($this->order->total, 2) . " — Dixis",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.orders.admin-new-order',
+            with: [
+                'order' => $this->order,
+                'orderNumber' => $this->order->id,
+                'itemCount' => $this->order->orderItems->count(),
+                'paymentMethod' => $this->formatPaymentMethod(),
+                'total' => number_format($this->order->total, 2),
+                'customerName' => $this->getCustomerName(),
+                'customerEmail' => $this->getCustomerEmail(),
+                'adminUrl' => config('app.url') . '/admin/orders/' . $this->order->id,
+            ],
+        );
+    }
+
+    private function formatPaymentMethod(): string
+    {
+        return match ($this->order->payment_method) {
+            'COD', 'cod' => 'Αντικαταβολή',
+            'CARD', 'card' => 'Κάρτα',
+            default => $this->order->payment_method ?? 'Αντικαταβολή',
+        };
+    }
+
+    private function getCustomerName(): string
+    {
+        if ($this->order->user?->name) {
+            return $this->order->user->name;
+        }
+        $address = $this->order->shipping_address;
+        if (is_array($address) && isset($address['name'])) {
+            return $address['name'];
+        }
+        return 'Guest';
+    }
+
+    private function getCustomerEmail(): string
+    {
+        if ($this->order->user?->email) {
+            return $this->order->user->email;
+        }
+        $address = $this->order->shipping_address;
+        if (is_array($address) && isset($address['email'])) {
+            return $address['email'];
+        }
+        return '-';
+    }
+}

--- a/backend/config/notifications.php
+++ b/backend/config/notifications.php
@@ -62,4 +62,15 @@ return [
     |
     */
     'email_verification_required' => env('EMAIL_VERIFICATION_REQUIRED', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pass ADMIN-NOTIFY-01: Admin Notification Email
+    |--------------------------------------------------------------------------
+    |
+    | Email address that receives admin notifications for new orders.
+    | Falls back to MAIL_FROM_ADDRESS if not set.
+    |
+    */
+    'admin_notify_email' => env('ADMIN_NOTIFY_EMAIL', env('MAIL_FROM_ADDRESS', 'info@dixis.gr')),
 ];

--- a/backend/resources/views/emails/orders/admin-new-order.blade.php
+++ b/backend/resources/views/emails/orders/admin-new-order.blade.php
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="el">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Νέα Παραγγελία - Dixis Admin</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: #1a7a3e; color: white; padding: 20px; text-align: center; border-radius: 8px 8px 0 0; }
+        .header h1 { margin: 0; font-size: 1.3em; }
+        .content { background: #f9fafb; padding: 20px; border: 1px solid #e5e7eb; }
+        .summary-box { background: white; padding: 15px; border-radius: 8px; margin: 15px 0; border-left: 4px solid #1a7a3e; }
+        .summary-row { display: flex; justify-content: space-between; padding: 6px 0; }
+        .summary-label { color: #6b7280; font-size: 0.9em; }
+        .summary-value { font-weight: 600; }
+        .total-highlight { font-size: 1.4em; color: #1a7a3e; font-weight: bold; text-align: center; padding: 12px 0; }
+        .btn { display: inline-block; background: #1a7a3e; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: 600; margin-top: 10px; }
+        .btn:hover { background: #0f5c2e; }
+        .footer { text-align: center; padding: 20px; color: #6b7280; font-size: 0.85em; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>Νέα Παραγγελία #{{ $orderNumber }}</h1>
+    </div>
+
+    <div class="content">
+        <div class="total-highlight">
+            €{{ $total }}
+        </div>
+
+        <div class="summary-box">
+            <div class="summary-row">
+                <span class="summary-label">Πελάτης:</span>
+                <span class="summary-value">{{ $customerName }}</span>
+            </div>
+            <div class="summary-row">
+                <span class="summary-label">Email:</span>
+                <span class="summary-value">{{ $customerEmail }}</span>
+            </div>
+            <div class="summary-row">
+                <span class="summary-label">Προϊόντα:</span>
+                <span class="summary-value">{{ $itemCount }} {{ $itemCount === 1 ? 'τεμάχιο' : 'τεμάχια' }}</span>
+            </div>
+            <div class="summary-row">
+                <span class="summary-label">Πληρωμή:</span>
+                <span class="summary-value">{{ $paymentMethod }}</span>
+            </div>
+        </div>
+
+        <div style="text-align: center; padding: 10px 0;">
+            <a href="{{ $adminUrl }}" class="btn">Δες την Παραγγελία →</a>
+        </div>
+    </div>
+
+    <div class="footer">
+        <p>Dixis Admin — Αυτόματη ειδοποίηση</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- **New Mailable**: `AdminNewOrder` — sends order summary to admin when new order is placed
- **Blade template**: Greek, inline CSS, shows total/customer/payment + link to admin dashboard
- **Service hook**: Added `sendAdminNotification()` step C in `OrderEmailService::sendOrderPlacedNotifications()`
- **Config**: `ADMIN_NOTIFY_EMAIL` env var in `notifications.php` (falls back to `MAIL_FROM_ADDRESS`)

## How it works
1. Customer places order → `sendOrderPlacedNotifications()` fires
2. Step A: Consumer confirmation ✅ (existing)
3. Step B: Producer notifications ✅ (existing)
4. **Step C: Admin notification** ✅ (NEW)

Follows all existing patterns: feature-flagged, idempotent (no double-sends), graceful failure (never crashes checkout).

## Test plan
- [ ] Set `ADMIN_NOTIFY_EMAIL=kourkoutisp@gmail.com` on VPS
- [ ] Place a test order on production
- [ ] Verify admin receives email with correct order summary
- [ ] Verify no duplicate emails on page refresh / webhook retry