### PR TITLE
feat(S1-01): add cultivation_type to products

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/ProductController.php
+++ b/backend/app/Http/Controllers/Api/V1/ProductController.php
@@ -26,6 +26,7 @@ class ProductController extends Controller
             'producer_id' => 'nullable|integer|exists:producers,id',
             'is_organic' => 'nullable|boolean',
             'is_seasonal' => 'nullable|boolean',
+            'cultivation_type' => 'nullable|string|in:conventional,organic_certified,organic_transitional,biodynamic,traditional_natural,other',
             'min_price' => 'nullable|numeric|min:0',
             'max_price' => 'nullable|numeric|min:0|gte:min_price',
             'page' => 'nullable|integer|min:1',
@@ -70,6 +71,11 @@ class ProductController extends Controller
         // Filter by seasonal
         if ($request->has('is_seasonal')) {
             $query->where('is_seasonal', $request->boolean('is_seasonal'));
+        }
+
+        // Filter by cultivation type
+        if ($cultivationType = $request->get('cultivation_type')) {
+            $query->where('cultivation_type', $cultivationType);
         }
 
         // Price range filter

--- a/backend/app/Http/Controllers/Public/ProductController.php
+++ b/backend/app/Http/Controllers/Public/ProductController.php
@@ -89,6 +89,14 @@ class ProductController extends Controller
             }
         }
 
+        // Cultivation type filter
+        if ($cultivationType = $request->get('cultivation_type')) {
+            $allowed = ['conventional', 'organic_certified', 'organic_transitional', 'biodynamic', 'traditional_natural', 'other'];
+            if (in_array($cultivationType, $allowed)) {
+                $query->where('cultivation_type', $cultivationType);
+            }
+        }
+
         // Sorting
         // When FTS is active and no explicit sort requested, order by search_rank DESC
         $sortField = $request->get('sort', $usesFts ? 'relevance' : 'created_at');

--- a/backend/app/Http/Requests/StoreProductRequest.php
+++ b/backend/app/Http/Requests/StoreProductRequest.php
@@ -36,6 +36,8 @@ class StoreProductRequest extends FormRequest
             'category' => 'nullable|string|max:100',
             'is_organic' => 'nullable|boolean',
             'is_seasonal' => 'nullable|boolean',
+            'cultivation_type' => 'nullable|string|in:conventional,organic_certified,organic_transitional,biodynamic,traditional_natural,other',
+            'cultivation_description' => 'nullable|string|max:1000',
             'image_url' => 'nullable|url|max:500',
             'status' => 'nullable|string|in:available,unavailable,discontinued',
             'is_active' => 'nullable|boolean',

--- a/backend/app/Http/Requests/UpdateProductRequest.php
+++ b/backend/app/Http/Requests/UpdateProductRequest.php
@@ -35,6 +35,8 @@ class UpdateProductRequest extends FormRequest
             'category' => 'nullable|string|max:100',
             'is_organic' => 'nullable|boolean',
             'is_seasonal' => 'nullable|boolean',
+            'cultivation_type' => 'nullable|string|in:conventional,organic_certified,organic_transitional,biodynamic,traditional_natural,other',
+            'cultivation_description' => 'nullable|string|max:1000',
             'image_url' => 'nullable|url|max:500',
             'status' => 'nullable|string|in:available,unavailable,discontinued',
             'is_active' => 'nullable|boolean',

--- a/backend/app/Http/Resources/ProductResource.php
+++ b/backend/app/Http/Resources/ProductResource.php
@@ -29,6 +29,8 @@ class ProductResource extends JsonResource
             'category' => $this->category,
             'is_organic' => $this->is_organic,
             'is_seasonal' => $this->is_seasonal,
+            'cultivation_type' => $this->cultivation_type,
+            'cultivation_description' => $this->cultivation_description,
             'image_url' => $this->image_url,
             'status' => $this->status,
             'is_active' => $this->is_active,

--- a/backend/app/Models/Product.php
+++ b/backend/app/Models/Product.php
@@ -22,6 +22,8 @@ class Product extends Model
         'category',
         'is_organic',
         'is_seasonal',
+        'cultivation_type',
+        'cultivation_description',
         'image_url',
         'status',
         'is_active',

--- a/backend/database/migrations/2026_02_15_200000_add_cultivation_type_to_products_table.php
+++ b/backend/database/migrations/2026_02_15_200000_add_cultivation_type_to_products_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * S1-01: Add cultivation type to products.
+     * Tracks how the product was produced (organic, conventional, etc.)
+     * This is a core Dixis differentiator per the PRD.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            if (! Schema::hasColumn('products', 'cultivation_type')) {
+                $table->string('cultivation_type', 50)->nullable()->default(null)->after('is_seasonal');
+            }
+            if (! Schema::hasColumn('products', 'cultivation_description')) {
+                $table->text('cultivation_description')->nullable()->after('cultivation_type');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            if (Schema::hasColumn('products', 'cultivation_type')) {
+                $table->dropColumn('cultivation_type');
+            }
+            if (Schema::hasColumn('products', 'cultivation_description')) {
+                $table->dropColumn('cultivation_description');
+            }
+        });
+    }
+};

--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -39,7 +39,7 @@
 
 ## WIP (max 1)
 
-_(empty — pick from NEXT)_
+**S1-01: Cultivation Type** — Adding cultivation_type field (organic, biodynamic, etc.) to products. PR pending.
 
 ---
 
@@ -56,7 +56,7 @@ The master backlog is now at **`docs/BACKLOG.md`**. It has 6 stages, prioritized
 | **5** | B2B & Revenue | Business registration, Subscription plans, Bulk orders |
 | **6** | Community & Vision | Forum, Courses, Carbon footprint, Referral program |
 
-**Current focus: Stage 1, starting with S1-01 (Cultivation Type).**
+**Current focus: Stage 1. S1-01 (Cultivation Type) in progress.**
 
 **Previous note**: Architecture audit resolved. H1 Phase 1+2 done, L6 i18n unified.
 

--- a/frontend/src/app/(storefront)/products/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/page.tsx
@@ -55,7 +55,9 @@ async function getProductById(id: string) {
       // Pass HOTFIX-MP-CHECKOUT-GUARD-01: Include producer_id for multi-producer cart detection
       producerId: raw.producer_id || raw.producer?.id || null,
       producerSlug: raw.producer?.slug || null,
-      producerName: raw.producer?.name || null
+      producerName: raw.producer?.name || null,
+      cultivationType: raw.cultivation_type || null,
+      cultivationDescription: raw.cultivation_description || null
     };
   } catch {
     return null;
@@ -202,7 +204,33 @@ export default async function Page({ params }:{ params: Promise<{ id:string }> }
           )}
 
           {p.category && (
-            <p className="text-sm text-neutral-500 mb-4">{getCategoryBySlug(p.category)?.labelEl || p.category}</p>
+            <p className="text-sm text-neutral-500 mb-2">{getCategoryBySlug(p.category)?.labelEl || p.category}</p>
+          )}
+
+          {/* S1-01: Cultivation Type Badge */}
+          {p.cultivationType && (
+            <div className="mb-4" data-testid="cultivation-badge">
+              <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium ${
+                p.cultivationType === 'organic_certified' ? 'bg-green-100 text-green-800' :
+                p.cultivationType === 'organic_transitional' ? 'bg-lime-100 text-lime-800' :
+                p.cultivationType === 'biodynamic' ? 'bg-purple-100 text-purple-800' :
+                p.cultivationType === 'traditional_natural' ? 'bg-amber-100 text-amber-800' :
+                p.cultivationType === 'conventional' ? 'bg-neutral-100 text-neutral-700' :
+                'bg-neutral-100 text-neutral-600'
+              }`}>
+                <span>{
+                  p.cultivationType === 'organic_certified' ? '🌿 Βιολογική (Πιστοποιημένη)' :
+                  p.cultivationType === 'organic_transitional' ? '🌱 Βιολογική (Μεταβατική)' :
+                  p.cultivationType === 'biodynamic' ? '✨ Βιοδυναμική' :
+                  p.cultivationType === 'traditional_natural' ? '🌾 Παραδοσιακή / Φυσική' :
+                  p.cultivationType === 'conventional' ? 'Συμβατική' :
+                  'Άλλο'
+                }</span>
+              </span>
+              {p.cultivationDescription && (
+                <p className="mt-1 text-xs text-neutral-500">{p.cultivationDescription}</p>
+              )}
+            </div>
           )}
 
           {/* Price + Stock */}

--- a/frontend/src/app/HomeClient.tsx
+++ b/frontend/src/app/HomeClient.tsx
@@ -20,6 +20,7 @@ interface Filters {
   minPrice: string;
   maxPrice: string;
   organic: boolean | null;
+  cultivationType: string;
   sort: string;
   dir: string;
 }
@@ -52,6 +53,7 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
     minPrice: '',
     maxPrice: '',
     organic: null,
+    cultivationType: '',
     sort: 'created_at',
     dir: 'desc'
   });
@@ -175,14 +177,15 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
       minPrice: '',
       maxPrice: '',
       organic: null,
+      cultivationType: '',
       sort: 'created_at',
       dir: 'desc'
     });
   }, []);
 
-  const hasActiveFilters = useMemo(() => 
-    filters.search || filters.category || filters.producer || 
-    filters.minPrice || filters.maxPrice || filters.organic !== null,
+  const hasActiveFilters = useMemo(() =>
+    filters.search || filters.category || filters.producer ||
+    filters.minPrice || filters.maxPrice || filters.organic !== null || filters.cultivationType,
     [filters]
   );
 
@@ -447,17 +450,20 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                       </div>
                     </div>
 
-                    {/* Organic Filter */}
+                    {/* S1-01: Cultivation Type Filter */}
                     <div>
-                      <label className="block text-sm font-medium text-neutral-700 mb-2">Βιολογικά</label>
+                      <label className="block text-sm font-medium text-neutral-700 mb-2">Καλλιέργεια</label>
                       <select
-                        value={filters.organic === null ? '' : filters.organic.toString()}
-                        onChange={(e) => updateFilter('organic', e.target.value === '' ? null : e.target.value === 'true')}
+                        value={filters.cultivationType}
+                        onChange={(e) => updateFilter('cultivationType', e.target.value)}
                         className="w-full px-3 py-2 border border-neutral-300 rounded-md focus:ring-2 focus:ring-primary focus:border-transparent"
                       >
-                        <option value="">Όλα τα προϊόντα</option>
-                        <option value="true">Μόνο βιολογικά</option>
-                        <option value="false">Μη βιολογικά</option>
+                        <option value="">Όλοι οι τύποι</option>
+                        <option value="organic_certified">🌿 Βιολογική (Πιστοποιημένη)</option>
+                        <option value="organic_transitional">🌱 Βιολογική (Μεταβατική)</option>
+                        <option value="biodynamic">✨ Βιοδυναμική</option>
+                        <option value="traditional_natural">🌾 Παραδοσιακή / Φυσική</option>
+                        <option value="conventional">Συμβατική</option>
                       </select>
                     </div>
                   </div>
@@ -492,10 +498,27 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
                     {product.name}
                   </h3>
                   
-                  <p className="text-sm text-neutral-600 mb-2">
+                  <p className="text-sm text-neutral-600 mb-1">
                     Από {product.producer.name}
                   </p>
-                  
+
+                  {/* S1-01: Cultivation type mini-badge */}
+                  {product.cultivation_type && product.cultivation_type !== 'conventional' && (
+                    <span className={`inline-block px-2 py-0.5 mb-2 rounded-full text-[10px] font-medium ${
+                      product.cultivation_type === 'organic_certified' ? 'bg-green-100 text-green-800' :
+                      product.cultivation_type === 'organic_transitional' ? 'bg-lime-100 text-lime-800' :
+                      product.cultivation_type === 'biodynamic' ? 'bg-purple-100 text-purple-800' :
+                      product.cultivation_type === 'traditional_natural' ? 'bg-amber-100 text-amber-800' :
+                      'bg-neutral-100 text-neutral-600'
+                    }`}>
+                      {product.cultivation_type === 'organic_certified' ? '🌿 Βιολογικό' :
+                       product.cultivation_type === 'organic_transitional' ? '🌱 Βιολογικό (Μεταβ.)' :
+                       product.cultivation_type === 'biodynamic' ? '✨ Βιοδυναμικό' :
+                       product.cultivation_type === 'traditional_natural' ? '🌾 Παραδοσιακό' :
+                       product.cultivation_type}
+                    </span>
+                  )}
+
                   <div className="flex items-center justify-between mb-4">
                     <span data-testid="product-price" className="text-xl font-bold text-primary">
                       €{product.price} / {product.unit}

--- a/frontend/src/app/my/products/[id]/edit/page.tsx
+++ b/frontend/src/app/my/products/[id]/edit/page.tsx
@@ -47,6 +47,8 @@ function EditProductContent() {
   const [stock, setStock] = useState('');
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [isActive, setIsActive] = useState(true);
+  const [cultivationType, setCultivationType] = useState('');
+  const [cultivationDescription, setCultivationDescription] = useState('');
 
   useEffect(() => {
     // Fetch dynamic categories
@@ -82,6 +84,8 @@ function EditProductContent() {
       setStock(product.stock?.toString() || '');
       setImageUrl(product.image_url || null);
       setIsActive(product.is_active ?? true);
+      setCultivationType(product.cultivation_type || '');
+      setCultivationDescription(product.cultivation_description || '');
     } catch (err: any) {
       setError(err.message || 'Σφάλμα φόρτωσης προϊόντος');
     } finally {
@@ -106,6 +110,8 @@ function EditProductContent() {
         description: description || undefined,
         image_url: imageUrl,
         is_active: isActive,
+        cultivation_type: cultivationType || undefined,
+        cultivation_description: cultivationDescription || undefined,
       });
 
       router.push('/my/products');
@@ -256,6 +262,48 @@ function EditProductContent() {
                 data-testid="description-textarea"
               />
             </div>
+
+            {/* S1-01: Cultivation Type */}
+            <div>
+              <label htmlFor="cultivation_type" className="block text-sm font-medium text-gray-700 mb-1">
+                Τρόπος Καλλιέργειας
+              </label>
+              <select
+                id="cultivation_type"
+                value={cultivationType}
+                onChange={(e) => setCultivationType(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                data-testid="cultivation-type-select"
+              >
+                <option value="">Επιλέξτε τρόπο καλλιέργειας</option>
+                <option value="conventional">Συμβατική</option>
+                <option value="organic_certified">Βιολογική (Πιστοποιημένη)</option>
+                <option value="organic_transitional">Βιολογική (Μεταβατική)</option>
+                <option value="biodynamic">Βιοδυναμική</option>
+                <option value="traditional_natural">Παραδοσιακή / Φυσική</option>
+                <option value="other">Άλλο</option>
+              </select>
+              <p className="mt-1 text-sm text-gray-500">
+                Πώς παράχθηκε το προϊόν;
+              </p>
+            </div>
+
+            {cultivationType && (
+              <div>
+                <label htmlFor="cultivation_description" className="block text-sm font-medium text-gray-700 mb-1">
+                  Περιγραφή Καλλιέργειας
+                </label>
+                <textarea
+                  id="cultivation_description"
+                  rows={2}
+                  value={cultivationDescription}
+                  onChange={(e) => setCultivationDescription(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  placeholder="π.χ. Βιολογική καλλιέργεια χωρίς φυτοφάρμακα, πιστοποιημένη από ΔΗΩ..."
+                  data-testid="cultivation-description-textarea"
+                />
+              </div>
+            )}
 
             <div className="grid grid-cols-2 gap-4">
               <div>

--- a/frontend/src/app/my/products/create/page.tsx
+++ b/frontend/src/app/my/products/create/page.tsx
@@ -53,6 +53,8 @@ function CreateProductContent() {
   const [stock, setStock] = useState('');
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [isActive, setIsActive] = useState(true);
+  const [cultivationType, setCultivationType] = useState('');
+  const [cultivationDescription, setCultivationDescription] = useState('');
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -71,6 +73,8 @@ function CreateProductContent() {
         description: description || undefined,
         image_url: imageUrl,
         is_active: isActive,
+        cultivation_type: cultivationType || undefined,
+        cultivation_description: cultivationDescription || undefined,
       });
 
       router.push('/my/products');
@@ -204,6 +208,48 @@ function CreateProductContent() {
                 data-testid="description-textarea"
               />
             </div>
+
+            {/* S1-01: Cultivation Type */}
+            <div>
+              <label htmlFor="cultivation_type" className="block text-sm font-medium text-gray-700 mb-1">
+                Τρόπος Καλλιέργειας
+              </label>
+              <select
+                id="cultivation_type"
+                value={cultivationType}
+                onChange={(e) => setCultivationType(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                data-testid="cultivation-type-select"
+              >
+                <option value="">Επιλέξτε τρόπο καλλιέργειας</option>
+                <option value="conventional">Συμβατική</option>
+                <option value="organic_certified">Βιολογική (Πιστοποιημένη)</option>
+                <option value="organic_transitional">Βιολογική (Μεταβατική)</option>
+                <option value="biodynamic">Βιοδυναμική</option>
+                <option value="traditional_natural">Παραδοσιακή / Φυσική</option>
+                <option value="other">Άλλο</option>
+              </select>
+              <p className="mt-1 text-sm text-gray-500">
+                Πώς παράχθηκε το προϊόν;
+              </p>
+            </div>
+
+            {cultivationType && (
+              <div>
+                <label htmlFor="cultivation_description" className="block text-sm font-medium text-gray-700 mb-1">
+                  Περιγραφή Καλλιέργειας
+                </label>
+                <textarea
+                  id="cultivation_description"
+                  rows={2}
+                  value={cultivationDescription}
+                  onChange={(e) => setCultivationDescription(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  placeholder="π.χ. Βιολογική καλλιέργεια χωρίς φυτοφάρμακα, πιστοποιημένη από ΔΗΩ..."
+                  data-testid="cultivation-description-textarea"
+                />
+              </div>
+            )}
 
             <div className="grid grid-cols-2 gap-4">
               <div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -28,6 +28,9 @@ export interface ApiResponse<T = unknown> {
   error?: string;
 }
 
+// S1-01: CultivationType — how the product was produced
+export type CultivationType = 'conventional' | 'organic_certified' | 'organic_transitional' | 'biodynamic' | 'traditional_natural' | 'other';
+
 export interface Product {
   id: number;
   name: string;
@@ -40,6 +43,8 @@ export interface Product {
   description: string | null;
   category?: string;
   image_url?: string | null;
+  cultivation_type?: CultivationType | null;
+  cultivation_description?: string | null;
   categories: Category[];
   images: ProductImage[];
   producer: Producer;
@@ -1215,6 +1220,8 @@ class ApiClient {
     description?: string;
     image_url?: string | null;
     is_active?: boolean;
+    cultivation_type?: string;
+    cultivation_description?: string;
   }): Promise<{ data: Product }> {
     return this.request<{ data: Product }>('products', {
       method: 'POST',
@@ -1234,6 +1241,8 @@ class ApiClient {
     description?: string;
     image_url?: string | null;
     is_active?: boolean;
+    cultivation_type?: string;
+    cultivation_description?: string;
   }): Promise<{ data: Product }> {
     return this.request<{ data: Product }>(`products/${productId}`, {
       method: 'PATCH',

--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -66,6 +66,8 @@ export interface Product {
   height_cm?: number;
   is_active: boolean;
   is_organic: boolean;
+  cultivation_type?: 'conventional' | 'organic_certified' | 'organic_transitional' | 'biodynamic' | 'traditional_natural' | 'other' | null;
+  cultivation_description?: string | null;
   discount_price?: number;
   is_seasonal: boolean;
   status: 'available' | 'unavailable' | 'seasonal';


### PR DESCRIPTION
## Summary
- **S1-01 from BACKLOG.md** — First Stage 1 feature: cultivation type tracking
- Products can now specify how they were produced: conventional, organic (certified/transitional), biodynamic, traditional/natural, or other
- Producer create/edit forms include a new "Τρόπος Καλλιέργειας" dropdown + optional description
- Product detail page shows a color-coded cultivation badge (🌿 for organic, ✨ for biodynamic, etc.)
- Homepage filter panel replaces binary organic toggle with full cultivation type selector
- Product cards on homepage show mini cultivation badge for non-conventional products
- Backend: migration adds `cultivation_type` (string) + `cultivation_description` (text) to products table
- API: both public and authenticated product endpoints support `cultivation_type` filter parameter

## Changes (14 files, ~230 LOC)

**Backend (7 files):**
- New migration: `add_cultivation_type_to_products_table`
- Model: added to `$fillable`
- Resource: exposed both fields in API output
- Validation: `in:conventional,organic_certified,...` rule in Store/Update requests
- Controllers: filter by `cultivation_type` query param

**Frontend (6 files):**
- `api.ts`: Product interface + apiClient method signatures updated
- `models.ts`: Product interface updated
- `create/page.tsx` + `edit/page.tsx`: cultivation dropdown + conditional description textarea
- `products/[id]/page.tsx`: cultivation badge with color coding
- `HomeClient.tsx`: cultivation filter + product card mini-badge

## Test plan
- [ ] `npx tsc --noEmit` — 0 errors ✅
- [ ] `npm run build` — clean ✅
- [ ] PHP syntax check all 7 backend files — clean ✅
- [ ] After deploy: run migration `php artisan migrate`
- [ ] Verify producer can create product with cultivation_type
- [ ] Verify product detail page shows cultivation badge
- [ ] Verify homepage filter by cultivation type works