### PR TITLE
fix(security): add Plausible Analytics to CSP allow-list

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -71,13 +71,13 @@ const nextConfig: NextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              // Stripe Elements requires js.stripe.com scripts
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com",
+              // Stripe Elements requires js.stripe.com scripts; Plausible analytics script
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://plausible.io",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https:",
               "font-src 'self' data:",
-              // Stripe API calls require api.stripe.com and r.stripe.com (analytics)
-              `connect-src 'self' ${apiOrigin} ${sentryDsn} https://api.stripe.com https://r.stripe.com`,
+              // Stripe API calls, Sentry, and Plausible analytics
+              `connect-src 'self' ${apiOrigin} ${sentryDsn} https://api.stripe.com https://r.stripe.com https://plausible.io`,
               // Stripe Elements uses iframes from js.stripe.com and hooks.stripe.com
               "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
               "frame-ancestors 'none'",


### PR DESCRIPTION
## Summary
- Added `https://plausible.io` to `script-src` CSP directive (for loading the Plausible script)
- Added `https://plausible.io` to `connect-src` CSP directive (for sending analytics events)

## Context
The `<Analytics>` component already exists in `layout.tsx` and supports Plausible out of the box.
This CSP change is the prerequisite — after merging, just set env vars on production:
```
NEXT_PUBLIC_ANALYTICS_PROVIDER=plausible
NEXT_PUBLIC_ANALYTICS_DOMAIN=dixis.gr
```

Part of Producer Launch Prep (docs/PRIORITY-PLAN.md Phase A1).

## Test plan
- [ ] `npm run build` passes
- [ ] CSP header includes plausible.io (verify after deploy)
- [ ] After setting env vars, Plausible script loads without CSP errors