### PR TITLE
style: unify brand palette across all producer & my pages

### DIFF
--- a/frontend/src/app/my/error.tsx
+++ b/frontend/src/app/my/error.tsx
@@ -12,7 +12,7 @@ export default function MyAccountError({
       <h1 className="text-2xl font-bold text-red-600 mb-2">
         Σφάλμα στον Λογαριασμό
       </h1>
-      <p className="text-gray-500 mb-4">
+      <p className="text-neutral-500 mb-4">
         Παρουσιάστηκε πρόβλημα κατά τη φόρτωση της σελίδας.
       </p>
       <button

--- a/frontend/src/app/my/products/[id]/edit/page.tsx
+++ b/frontend/src/app/my/products/[id]/edit/page.tsx
@@ -124,14 +124,14 @@ function EditProductContent() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 py-8">
+      <div className="min-h-screen bg-neutral-50 py-8">
         <div className="max-w-3xl mx-auto px-4">
           <div className="bg-white rounded-lg shadow-sm p-8">
             <div className="animate-pulse space-y-4">
-              <div className="h-6 bg-gray-200 rounded w-1/3"></div>
-              <div className="h-10 bg-gray-200 rounded"></div>
-              <div className="h-10 bg-gray-200 rounded"></div>
-              <div className="h-32 bg-gray-200 rounded"></div>
+              <div className="h-6 bg-neutral-200 rounded w-1/3"></div>
+              <div className="h-10 bg-neutral-200 rounded"></div>
+              <div className="h-10 bg-neutral-200 rounded"></div>
+              <div className="h-32 bg-neutral-200 rounded"></div>
             </div>
           </div>
         </div>
@@ -140,14 +140,14 @@ function EditProductContent() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-neutral-50 py-8">
       <div className="max-w-3xl mx-auto px-4">
         <div className="bg-white rounded-lg shadow-sm">
-          <div className="px-6 py-4 border-b border-gray-200">
-            <h1 className="text-2xl font-bold text-gray-900" data-testid="page-title">
+          <div className="px-6 py-4 border-b border-neutral-200">
+            <h1 className="text-2xl font-bold text-neutral-900" data-testid="page-title">
               Επεξεργασία Προϊόντος
             </h1>
-            <p className="mt-1 text-gray-600">
+            <p className="mt-1 text-neutral-600">
               Ενημερώστε τα στοιχεία του προϊόντος σας
             </p>
           </div>
@@ -160,7 +160,7 @@ function EditProductContent() {
 
           <form onSubmit={handleSubmit} className="p-6 space-y-6">
             <div>
-              <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="title" className="block text-sm font-medium text-neutral-700 mb-1">
                 Τίτλος Προϊόντος *
               </label>
               <input
@@ -169,14 +169,14 @@ function EditProductContent() {
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 required
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="π.χ. Βιολογικές Ντομάτες Κρήτης"
                 data-testid="title-input"
               />
             </div>
 
             <div>
-              <label htmlFor="slug" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="slug" className="block text-sm font-medium text-neutral-700 mb-1">
                 Όνομα (slug) *
               </label>
               <input
@@ -192,18 +192,18 @@ function EditProductContent() {
                   setSlug(normalized);
                 }}
                 required
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="π.χ. biologikes-tomates"
                 data-testid="slug-input"
               />
-              <p className="mt-1 text-sm text-gray-500">
+              <p className="mt-1 text-sm text-neutral-500">
                 Χρησιμοποιείται στο URL (μόνο λατινικά, παύλες)
               </p>
             </div>
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label htmlFor="category" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="category" className="block text-sm font-medium text-neutral-700 mb-1">
                   Κατηγορία *
                 </label>
                 <select
@@ -212,7 +212,7 @@ function EditProductContent() {
                   onChange={(e) => setCategory(e.target.value)}
                   required
                   disabled={categoriesLoading}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500 disabled:bg-gray-100"
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-neutral-100"
                   data-testid="category-select"
                 >
                   <option value="">
@@ -227,7 +227,7 @@ function EditProductContent() {
               </div>
 
               <div>
-                <label htmlFor="unit" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="unit" className="block text-sm font-medium text-neutral-700 mb-1">
                   Μονάδα Μέτρησης *
                 </label>
                 <select
@@ -235,7 +235,7 @@ function EditProductContent() {
                   value={unit}
                   onChange={(e) => setUnit(e.target.value)}
                   required
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                   data-testid="unit-select"
                 >
                   <option value="">Επιλέξτε μονάδα</option>
@@ -249,7 +249,7 @@ function EditProductContent() {
             </div>
 
             <div>
-              <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="description" className="block text-sm font-medium text-neutral-700 mb-1">
                 Περιγραφή
               </label>
               <textarea
@@ -257,7 +257,7 @@ function EditProductContent() {
                 rows={4}
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="Περιγραφή προϊόντος..."
                 data-testid="description-textarea"
               />
@@ -265,14 +265,14 @@ function EditProductContent() {
 
             {/* S1-01: Cultivation Type */}
             <div>
-              <label htmlFor="cultivation_type" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="cultivation_type" className="block text-sm font-medium text-neutral-700 mb-1">
                 Τρόπος Καλλιέργειας
               </label>
               <select
                 id="cultivation_type"
                 value={cultivationType}
                 onChange={(e) => setCultivationType(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 data-testid="cultivation-type-select"
               >
                 <option value="">Επιλέξτε τρόπο καλλιέργειας</option>
@@ -283,14 +283,14 @@ function EditProductContent() {
                 <option value="traditional_natural">Παραδοσιακή / Φυσική</option>
                 <option value="other">Άλλο</option>
               </select>
-              <p className="mt-1 text-sm text-gray-500">
+              <p className="mt-1 text-sm text-neutral-500">
                 Πώς παράχθηκε το προϊόν;
               </p>
             </div>
 
             {cultivationType && (
               <div>
-                <label htmlFor="cultivation_description" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="cultivation_description" className="block text-sm font-medium text-neutral-700 mb-1">
                   Περιγραφή Καλλιέργειας
                 </label>
                 <textarea
@@ -298,7 +298,7 @@ function EditProductContent() {
                   rows={2}
                   value={cultivationDescription}
                   onChange={(e) => setCultivationDescription(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                   placeholder="π.χ. Βιολογική καλλιέργεια χωρίς φυτοφάρμακα, πιστοποιημένη από ΔΗΩ..."
                   data-testid="cultivation-description-textarea"
                 />
@@ -307,7 +307,7 @@ function EditProductContent() {
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label htmlFor="price" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="price" className="block text-sm font-medium text-neutral-700 mb-1">
                   Τιμή (€) *
                 </label>
                 <input
@@ -318,14 +318,14 @@ function EditProductContent() {
                   value={price}
                   onChange={(e) => setPrice(e.target.value)}
                   required
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                   placeholder="π.χ. 3.50"
                   data-testid="price-input"
                 />
               </div>
 
               <div>
-                <label htmlFor="stock" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="stock" className="block text-sm font-medium text-neutral-700 mb-1">
                   Απόθεμα *
                 </label>
                 <input
@@ -335,7 +335,7 @@ function EditProductContent() {
                   value={stock}
                   onChange={(e) => setStock(e.target.value)}
                   required
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                   placeholder="π.χ. 25"
                   data-testid="stock-input"
                 />
@@ -358,19 +358,19 @@ function EditProductContent() {
                 type="checkbox"
                 checked={isActive}
                 onChange={(e) => setIsActive(e.target.checked)}
-                className="h-4 w-4 text-green-600 focus:ring-green-500 border-gray-300 rounded"
+                className="h-4 w-4 text-primary focus:ring-primary border-neutral-300 rounded"
                 data-testid="active-checkbox"
               />
-              <label htmlFor="is_active" className="ml-2 block text-sm text-gray-700">
+              <label htmlFor="is_active" className="ml-2 block text-sm text-neutral-700">
                 Ενεργό προϊόν (ορατό στους πελάτες)
               </label>
             </div>
 
-            <div className="flex gap-3 pt-4 border-t border-gray-200">
+            <div className="flex gap-3 pt-4 border-t border-neutral-200">
               <button
                 type="submit"
                 disabled={busy}
-                className="flex-1 bg-green-600 text-white py-2 px-4 rounded-lg hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-light disabled:bg-neutral-400 disabled:cursor-not-allowed transition-colors"
                 data-testid="submit-btn"
               >
                 {busy ? 'Ενημέρωση...' : 'Ενημέρωση Προϊόντος'}
@@ -379,7 +379,7 @@ function EditProductContent() {
                 type="button"
                 onClick={() => router.back()}
                 disabled={busy}
-                className="flex-1 bg-gray-100 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-200 disabled:bg-gray-50 disabled:cursor-not-allowed transition-colors"
+                className="flex-1 bg-neutral-100 text-neutral-700 py-2 px-4 rounded-lg hover:bg-neutral-200 disabled:bg-neutral-50 disabled:cursor-not-allowed transition-colors"
                 data-testid="cancel-btn"
               >
                 Ακύρωση

--- a/frontend/src/app/my/products/create/page.tsx
+++ b/frontend/src/app/my/products/create/page.tsx
@@ -86,14 +86,14 @@ function CreateProductContent() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-neutral-50 py-8">
       <div className="max-w-3xl mx-auto px-4">
         <div className="bg-white rounded-lg shadow-sm">
-          <div className="px-6 py-4 border-b border-gray-200">
-            <h1 className="text-2xl font-bold text-gray-900" data-testid="page-title">
+          <div className="px-6 py-4 border-b border-neutral-200">
+            <h1 className="text-2xl font-bold text-neutral-900" data-testid="page-title">
               Νέο Προϊόν
             </h1>
-            <p className="mt-1 text-gray-600">
+            <p className="mt-1 text-neutral-600">
               Προσθέστε ένα νέο προϊόν στον κατάλογό σας
             </p>
           </div>
@@ -106,7 +106,7 @@ function CreateProductContent() {
 
           <form onSubmit={handleSubmit} className="p-6 space-y-6">
             <div>
-              <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="title" className="block text-sm font-medium text-neutral-700 mb-1">
                 Τίτλος Προϊόντος *
               </label>
               <input
@@ -115,14 +115,14 @@ function CreateProductContent() {
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 required
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="π.χ. Βιολογικές Ντομάτες Κρήτης"
                 data-testid="title-input"
               />
             </div>
 
             <div>
-              <label htmlFor="slug" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="slug" className="block text-sm font-medium text-neutral-700 mb-1">
                 Όνομα (slug) *
               </label>
               <input
@@ -138,18 +138,18 @@ function CreateProductContent() {
                   setSlug(normalized);
                 }}
                 required
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="π.χ. biologikes-tomates"
                 data-testid="slug-input"
               />
-              <p className="mt-1 text-sm text-gray-500">
+              <p className="mt-1 text-sm text-neutral-500">
                 Χρησιμοποιείται στο URL (μόνο λατινικά, παύλες)
               </p>
             </div>
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label htmlFor="category" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="category" className="block text-sm font-medium text-neutral-700 mb-1">
                   Κατηγορία *
                 </label>
                 <select
@@ -158,7 +158,7 @@ function CreateProductContent() {
                   onChange={(e) => setCategory(e.target.value)}
                   required
                   disabled={categoriesLoading}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500 disabled:bg-gray-100"
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-neutral-100"
                   data-testid="category-select"
                 >
                   <option value="">
@@ -173,7 +173,7 @@ function CreateProductContent() {
               </div>
 
               <div>
-                <label htmlFor="unit" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="unit" className="block text-sm font-medium text-neutral-700 mb-1">
                   Μονάδα Μέτρησης *
                 </label>
                 <select
@@ -181,7 +181,7 @@ function CreateProductContent() {
                   value={unit}
                   onChange={(e) => setUnit(e.target.value)}
                   required
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                   data-testid="unit-select"
                 >
                   <option value="">Επιλέξτε μονάδα</option>
@@ -195,7 +195,7 @@ function CreateProductContent() {
             </div>
 
             <div>
-              <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="description" className="block text-sm font-medium text-neutral-700 mb-1">
                 Περιγραφή
               </label>
               <textarea
@@ -203,7 +203,7 @@ function CreateProductContent() {
                 rows={4}
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="Περιγραφή προϊόντος..."
                 data-testid="description-textarea"
               />
@@ -211,14 +211,14 @@ function CreateProductContent() {
 
             {/* S1-01: Cultivation Type */}
             <div>
-              <label htmlFor="cultivation_type" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="cultivation_type" className="block text-sm font-medium text-neutral-700 mb-1">
                 Τρόπος Καλλιέργειας
               </label>
               <select
                 id="cultivation_type"
                 value={cultivationType}
                 onChange={(e) => setCultivationType(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 data-testid="cultivation-type-select"
               >
                 <option value="">Επιλέξτε τρόπο καλλιέργειας</option>
@@ -229,14 +229,14 @@ function CreateProductContent() {
                 <option value="traditional_natural">Παραδοσιακή / Φυσική</option>
                 <option value="other">Άλλο</option>
               </select>
-              <p className="mt-1 text-sm text-gray-500">
+              <p className="mt-1 text-sm text-neutral-500">
                 Πώς παράχθηκε το προϊόν;
               </p>
             </div>
 
             {cultivationType && (
               <div>
-                <label htmlFor="cultivation_description" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="cultivation_description" className="block text-sm font-medium text-neutral-700 mb-1">
                   Περιγραφή Καλλιέργειας
                 </label>
                 <textarea
@@ -244,7 +244,7 @@ function CreateProductContent() {
                   rows={2}
                   value={cultivationDescription}
                   onChange={(e) => setCultivationDescription(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                   placeholder="π.χ. Βιολογική καλλιέργεια χωρίς φυτοφάρμακα, πιστοποιημένη από ΔΗΩ..."
                   data-testid="cultivation-description-textarea"
                 />
@@ -253,7 +253,7 @@ function CreateProductContent() {
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label htmlFor="price" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="price" className="block text-sm font-medium text-neutral-700 mb-1">
                   Τιμή (€) *
                 </label>
                 <input
@@ -264,14 +264,14 @@ function CreateProductContent() {
                   value={price}
                   onChange={(e) => setPrice(e.target.value)}
                   required
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                   placeholder="π.χ. 3.50"
                   data-testid="price-input"
                 />
               </div>
 
               <div>
-                <label htmlFor="stock" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="stock" className="block text-sm font-medium text-neutral-700 mb-1">
                   Απόθεμα *
                 </label>
                 <input
@@ -281,7 +281,7 @@ function CreateProductContent() {
                   value={stock}
                   onChange={(e) => setStock(e.target.value)}
                   required
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                   placeholder="π.χ. 25"
                   data-testid="stock-input"
                 />
@@ -304,19 +304,19 @@ function CreateProductContent() {
                 type="checkbox"
                 checked={isActive}
                 onChange={(e) => setIsActive(e.target.checked)}
-                className="h-4 w-4 text-green-600 focus:ring-green-500 border-gray-300 rounded"
+                className="h-4 w-4 text-primary focus:ring-primary border-neutral-300 rounded"
                 data-testid="active-checkbox"
               />
-              <label htmlFor="is_active" className="ml-2 block text-sm text-gray-700">
+              <label htmlFor="is_active" className="ml-2 block text-sm text-neutral-700">
                 Ενεργό προϊόν (ορατό στους πελάτες)
               </label>
             </div>
 
-            <div className="flex gap-3 pt-4 border-t border-gray-200">
+            <div className="flex gap-3 pt-4 border-t border-neutral-200">
               <button
                 type="submit"
                 disabled={busy}
-                className="flex-1 bg-green-600 text-white py-2 px-4 rounded-lg hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-light disabled:bg-neutral-400 disabled:cursor-not-allowed transition-colors"
                 data-testid="submit-btn"
               >
                 {busy ? 'Δημιουργία...' : 'Δημιουργία Προϊόντος'}
@@ -325,7 +325,7 @@ function CreateProductContent() {
                 type="button"
                 onClick={() => router.back()}
                 disabled={busy}
-                className="flex-1 bg-gray-100 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-200 disabled:bg-gray-50 disabled:cursor-not-allowed transition-colors"
+                className="flex-1 bg-neutral-100 text-neutral-700 py-2 px-4 rounded-lg hover:bg-neutral-200 disabled:bg-neutral-50 disabled:cursor-not-allowed transition-colors"
                 data-testid="cancel-btn"
               >
                 Ακύρωση

--- a/frontend/src/app/my/products/page.tsx
+++ b/frontend/src/app/my/products/page.tsx
@@ -186,14 +186,14 @@ function ProducerProductsContent() {
   // Loading state
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 py-8">
+      <div className="min-h-screen bg-neutral-50 py-8">
         <div className="max-w-6xl mx-auto px-4">
           <div className="bg-white rounded-lg shadow-sm p-8">
             <div className="animate-pulse">
-              <div className="h-6 bg-gray-200 rounded w-1/3 mb-6"></div>
+              <div className="h-6 bg-neutral-200 rounded w-1/3 mb-6"></div>
               <div className="space-y-4">
                 {[...Array(3)].map((_, i) => (
-                  <div key={i} className="h-20 bg-gray-200 rounded"></div>
+                  <div key={i} className="h-20 bg-neutral-200 rounded"></div>
                 ))}
               </div>
             </div>
@@ -206,7 +206,7 @@ function ProducerProductsContent() {
   // Redirect to onboarding if not approved
   if (!producerStatus.isApproved) {
     return (
-      <div className="min-h-screen bg-gray-50 py-8">
+      <div className="min-h-screen bg-neutral-50 py-8">
         <div className="max-w-2xl mx-auto px-4">
           <div className="bg-white rounded-lg shadow-sm p-8">
             <div className="text-center" data-testid="not-approved-notice">
@@ -216,15 +216,15 @@ function ProducerProductsContent() {
                   <div className="w-16 h-16 mx-auto mb-4 bg-blue-100 rounded-full flex items-center justify-center">
                     <span className="text-2xl">📝</span>
                   </div>
-                  <h2 className="text-xl font-semibold text-gray-900 mb-2" data-testid="no-profile-title">
+                  <h2 className="text-xl font-semibold text-neutral-900 mb-2" data-testid="no-profile-title">
                     Απαιτείται Αίτηση Παραγωγού
                   </h2>
-                  <p className="text-gray-600 mb-6" data-testid="no-profile-message">
+                  <p className="text-neutral-600 mb-6" data-testid="no-profile-message">
                     Για να διαχειρίζεστε προϊόντα, πρέπει πρώτα να υποβάλετε αίτηση παραγωγού και να εγκριθείτε.
                   </p>
                   <button
                     onClick={() => router.push('/producer/onboarding')}
-                    className="bg-green-600 text-white px-6 py-3 rounded-lg hover:bg-green-700 transition-colors"
+                    className="bg-primary text-white px-6 py-3 rounded-lg hover:bg-primary-light transition-colors"
                     data-testid="goto-onboarding-btn"
                   >
                     Υποβολή Αίτησης Παραγωγού
@@ -236,10 +236,10 @@ function ProducerProductsContent() {
                   <div className="w-16 h-16 mx-auto mb-4 bg-yellow-100 rounded-full flex items-center justify-center">
                     <span className="text-2xl">⏳</span>
                   </div>
-                  <h2 className="text-xl font-semibold text-gray-900 mb-2" data-testid="pending-approval-title">
+                  <h2 className="text-xl font-semibold text-neutral-900 mb-2" data-testid="pending-approval-title">
                     Ολοκληρώστε το Προφίλ σας
                   </h2>
-                  <p className="text-gray-600 mb-6" data-testid="pending-approval-message">
+                  <p className="text-neutral-600 mb-6" data-testid="pending-approval-message">
                     Το προφίλ σας δεν έχει ενεργοποιηθεί ακόμα. Ολοκληρώστε τη ρύθμιση για να διαχειρίζεστε προϊόντα.
                   </p>
                   <div className="space-y-3">
@@ -253,7 +253,7 @@ function ProducerProductsContent() {
                     <br />
                     <button
                       onClick={() => router.push('/producer/dashboard')}
-                      className="bg-gray-100 text-gray-700 px-6 py-3 rounded-lg hover:bg-gray-200 transition-colors"
+                      className="bg-neutral-100 text-neutral-700 px-6 py-3 rounded-lg hover:bg-neutral-200 transition-colors"
                       data-testid="goto-dashboard-btn"
                     >
                       Πίνακας Ελέγχου
@@ -266,16 +266,16 @@ function ProducerProductsContent() {
                   <div className="w-16 h-16 mx-auto mb-4 bg-red-100 rounded-full flex items-center justify-center">
                     <span className="text-2xl">❌</span>
                   </div>
-                  <h2 className="text-xl font-semibold text-gray-900 mb-2" data-testid="rejected-title">
+                  <h2 className="text-xl font-semibold text-neutral-900 mb-2" data-testid="rejected-title">
                     Λογαριασμός Ανενεργός
                   </h2>
-                  <p className="text-gray-600 mb-6" data-testid="rejected-message">
+                  <p className="text-neutral-600 mb-6" data-testid="rejected-message">
                     Ο λογαριασμός σας είναι προσωρινά ανενεργός. Επικοινωνήστε μαζί μας για περισσότερες πληροφορίες.
                   </p>
                   <div className="space-y-3">
                     <button
                       onClick={() => router.push('/producer/onboarding')}
-                      className="bg-green-600 text-white px-6 py-3 rounded-lg hover:bg-green-700 transition-colors"
+                      className="bg-primary text-white px-6 py-3 rounded-lg hover:bg-primary-light transition-colors"
                       data-testid="resubmit-btn"
                     >
                       Νέα Αίτηση
@@ -283,7 +283,7 @@ function ProducerProductsContent() {
                     <br />
                     <button
                       onClick={() => router.push('/contact')}
-                      className="bg-gray-100 text-gray-700 px-6 py-3 rounded-lg hover:bg-gray-200 transition-colors"
+                      className="bg-neutral-100 text-neutral-700 px-6 py-3 rounded-lg hover:bg-neutral-200 transition-colors"
                       data-testid="contact-support-btn"
                     >
                       Επικοινωνία
@@ -300,22 +300,22 @@ function ProducerProductsContent() {
 
   // Approved producer - show products management
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-neutral-50 py-8">
       <div className="max-w-6xl mx-auto px-4">
         <div className="bg-white rounded-lg shadow-sm">
-          <div className="px-6 py-4 border-b border-gray-200">
+          <div className="px-6 py-4 border-b border-neutral-200">
             <div className="flex items-center justify-between">
               <div>
-                <h1 className="text-2xl font-bold text-gray-900" data-testid="page-title">
+                <h1 className="text-2xl font-bold text-neutral-900" data-testid="page-title">
                   Διαχείριση Προϊόντων
                 </h1>
-                <p className="mt-1 text-gray-600">
+                <p className="mt-1 text-neutral-600">
                   Προσθήκη και επεξεργασία των προϊόντων σας
                 </p>
               </div>
               <button
                 onClick={() => router.push('/my/products/create')}
-                className="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors"
+                className="bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light transition-colors"
                 data-testid="add-product-btn"
               >
                 + Νέο Προϊόν
@@ -330,7 +330,7 @@ function ProducerProductsContent() {
           )}
 
           {/* Search and Filter */}
-          <div className="px-6 py-4 border-b border-gray-200">
+          <div className="px-6 py-4 border-b border-neutral-200">
             <div className="flex flex-col sm:flex-row gap-4">
               <div className="flex-1">
                 <input
@@ -338,7 +338,7 @@ function ProducerProductsContent() {
                   placeholder="Αναζήτηση προϊόντος..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  className="w-full px-4 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                   data-testid="search-input"
                 />
               </div>
@@ -346,7 +346,7 @@ function ProducerProductsContent() {
                 <select
                   value={categoryFilter}
                   onChange={(e) => setCategoryFilter(e.target.value)}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                  className="w-full px-4 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                   data-testid="category-filter"
                 >
                   <option value="">Όλες οι κατηγορίες</option>
@@ -360,7 +360,7 @@ function ProducerProductsContent() {
               {(searchQuery || categoryFilter) && (
                 <button
                   onClick={() => { setSearchQuery(''); setCategoryFilter(''); }}
-                  className="px-4 py-2 text-gray-600 hover:text-gray-800 border border-gray-300 rounded-lg hover:bg-gray-50"
+                  className="px-4 py-2 text-neutral-600 hover:text-neutral-800 border border-neutral-300 rounded-lg hover:bg-neutral-50"
                   data-testid="clear-filters-btn"
                 >
                   Καθαρισμός
@@ -372,13 +372,13 @@ function ProducerProductsContent() {
           <div className="p-6" data-testid="products-section">
             {products.length === 0 ? (
               <div className="text-center py-12" data-testid="no-products-state">
-                <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center">
+                <div className="w-16 h-16 mx-auto mb-4 bg-neutral-100 rounded-full flex items-center justify-center">
                   <span className="text-2xl">{searchQuery || categoryFilter ? '🔍' : '📦'}</span>
                 </div>
-                <h3 className="text-lg font-medium text-gray-900 mb-2">
+                <h3 className="text-lg font-medium text-neutral-900 mb-2">
                   {searchQuery || categoryFilter ? 'Δεν βρέθηκαν προϊόντα' : 'Κανένα προϊόν ακόμα'}
                 </h3>
-                <p className="text-gray-600 mb-6">
+                <p className="text-neutral-600 mb-6">
                   {searchQuery || categoryFilter
                     ? 'Δοκιμάστε διαφορετικούς όρους αναζήτησης ή φίλτρα.'
                     : 'Ξεκινήστε προσθέτοντας το πρώτο σας προϊόν για να το δουν οι πελάτες.'}
@@ -386,7 +386,7 @@ function ProducerProductsContent() {
                 {searchQuery || categoryFilter ? (
                   <button
                     onClick={() => { setSearchQuery(''); setCategoryFilter(''); }}
-                    className="bg-gray-100 text-gray-700 px-6 py-3 rounded-lg hover:bg-gray-200 transition-colors"
+                    className="bg-neutral-100 text-neutral-700 px-6 py-3 rounded-lg hover:bg-neutral-200 transition-colors"
                     data-testid="clear-filters-empty-btn"
                   >
                     Καθαρισμός Φίλτρων
@@ -394,7 +394,7 @@ function ProducerProductsContent() {
                 ) : (
                   <button
                     onClick={() => router.push('/my/products/create')}
-                    className="bg-green-600 text-white px-6 py-3 rounded-lg hover:bg-green-700 transition-colors"
+                    className="bg-primary text-white px-6 py-3 rounded-lg hover:bg-primary-light transition-colors"
                     data-testid="add-first-product-btn"
                   >
                     Προσθήκη Πρώτου Προϊόντος
@@ -403,30 +403,30 @@ function ProducerProductsContent() {
               </div>
             ) : (
               <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200" data-testid="products-table">
-                  <thead className="bg-gray-50">
+                <table className="min-w-full divide-y divide-neutral-200" data-testid="products-table">
+                  <thead className="bg-neutral-50">
                     <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                         Εικόνα
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                         Προϊόν
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                         Τιμή
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                         Απόθεμα
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                         Κατάσταση
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                         Ενέργειες
                       </th>
                     </tr>
                   </thead>
-                  <tbody className="bg-white divide-y divide-gray-200">
+                  <tbody className="bg-white divide-y divide-neutral-200">
                     {products.map((product) => (
                       <tr key={product.id} data-testid={`product-row-${product.id}`}>
                         <td className="px-6 py-4 whitespace-nowrap">
@@ -438,28 +438,28 @@ function ProducerProductsContent() {
                               data-testid={`product-thumbnail-${product.id}`}
                             />
                           ) : (
-                            <div className="w-12 h-12 bg-gray-200 rounded flex items-center justify-center" data-testid={`product-placeholder-${product.id}`}>
-                              <span className="text-gray-400 text-xs">📦</span>
+                            <div className="w-12 h-12 bg-neutral-200 rounded flex items-center justify-center" data-testid={`product-placeholder-${product.id}`}>
+                              <span className="text-neutral-400 text-xs">📦</span>
                             </div>
                           )}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div>
-                            <div className="text-sm font-medium text-gray-900" data-testid={`product-name-${product.id}`}>
+                            <div className="text-sm font-medium text-neutral-900" data-testid={`product-name-${product.id}`}>
                               {product.title || product.name}
                             </div>
-                            <div className="text-sm text-gray-500">{product.name}</div>
+                            <div className="text-sm text-neutral-500">{product.name}</div>
                           </div>
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900" data-testid={`product-price-${product.id}`}>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-900" data-testid={`product-price-${product.id}`}>
                           {product.price.toFixed(2)} {product.currency}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900" data-testid={`product-stock-${product.id}`}>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-900" data-testid={`product-stock-${product.id}`}>
                           {product.stock}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap" data-testid={`product-status-${product.id}`}>
                           <span className={`px-2 py-1 rounded-full text-xs font-medium ${
-                            product.is_active ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'
+                            product.is_active ? 'bg-primary-pale text-primary' : 'bg-neutral-100 text-neutral-800'
                           }`}>
                             {product.is_active ? 'Ενεργό' : 'Ανενεργό'}
                           </span>
@@ -474,7 +474,7 @@ function ProducerProductsContent() {
                           </button>
                           <button
                             onClick={() => router.push(`/products/${product.id}`)}
-                            className="text-green-600 hover:text-green-900"
+                            className="text-primary hover:text-primary-light"
                             data-testid={`view-product-${product.id}`}
                           >
                             Προβολή
@@ -500,12 +500,12 @@ function ProducerProductsContent() {
         {deleteModalOpen && (
           <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" data-testid="delete-modal">
             <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
-              <h3 className="text-xl font-bold text-gray-900 mb-4" data-testid="delete-modal-title">
+              <h3 className="text-xl font-bold text-neutral-900 mb-4" data-testid="delete-modal-title">
                 Επιβεβαίωση Διαγραφής
               </h3>
-              <p className="text-gray-600 mb-6" data-testid="delete-modal-message">
+              <p className="text-neutral-600 mb-6" data-testid="delete-modal-message">
                 Είστε σίγουροι ότι θέλετε να διαγράψετε το προϊόν{' '}
-                <strong className="text-gray-900">&quot;{productToDelete?.name}&quot;</strong>;
+                <strong className="text-neutral-900">&quot;{productToDelete?.name}&quot;</strong>;
                 <br />
                 Η ενέργεια αυτή δεν μπορεί να αναιρεθεί.
               </p>
@@ -513,7 +513,7 @@ function ProducerProductsContent() {
                 <button
                   onClick={() => setDeleteModalOpen(false)}
                   disabled={deleting}
-                  className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="px-4 py-2 border border-neutral-300 rounded-lg text-neutral-700 hover:bg-neutral-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                   data-testid="delete-modal-cancel"
                 >
                   Ακύρωση

--- a/frontend/src/app/producer/analytics/page.tsx
+++ b/frontend/src/app/producer/analytics/page.tsx
@@ -13,29 +13,29 @@ import AuthGuard from '@/components/AuthGuard';
 export default function ProducerAnalytics() {
   return (
     <AuthGuard requireAuth={true} requireRole="producer">
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-neutral-50">
         <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {/* Breadcrumb */}
           <nav className="flex mb-8" data-testid="breadcrumb">
-            <ol className="flex items-center space-x-2 text-sm text-gray-500">
+            <ol className="flex items-center space-x-2 text-sm text-neutral-500">
               <li>
-                <Link href="/" className="hover:text-green-600">Αρχική</Link>
+                <Link href="/" className="hover:text-primary">Αρχική</Link>
               </li>
               <li>/</li>
               <li>
-                <Link href="/producer/dashboard" className="hover:text-green-600">Πίνακας Παραγωγού</Link>
+                <Link href="/producer/dashboard" className="hover:text-primary">Πίνακας Παραγωγού</Link>
               </li>
               <li>/</li>
-              <li className="text-gray-900">Αναλυτικά</li>
+              <li className="text-neutral-900">Αναλυτικά</li>
             </ol>
           </nav>
 
           {/* Page Header */}
           <div className="mb-8">
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">
+            <h1 className="text-3xl font-bold text-neutral-900 mb-2">
               Αναλυτικά Παραγωγού
             </h1>
-            <p className="text-gray-600">
+            <p className="text-neutral-600">
               Παρακολουθήστε την απόδοση των προϊόντων και τα αναλυτικά πωλήσεων
             </p>
           </div>

--- a/frontend/src/app/producer/onboarding/page.tsx
+++ b/frontend/src/app/producer/onboarding/page.tsx
@@ -87,7 +87,7 @@ export default function ProducerOnboardingPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-neutral-50 flex items-center justify-center">
         <LoadingSpinner />
       </div>
     );
@@ -96,10 +96,10 @@ export default function ProducerOnboardingPage() {
   // Rejected state
   if (profile?.status === 'inactive' && profile.rejection_reason) {
     return (
-      <div className="min-h-screen bg-gray-50 py-8">
+      <div className="min-h-screen bg-neutral-50 py-8">
         <div className="max-w-2xl mx-auto px-4">
           <div className="bg-white rounded-lg shadow-sm p-8">
-            <h1 className="text-2xl font-bold text-gray-900 mb-4" data-testid="page-title">
+            <h1 className="text-2xl font-bold text-neutral-900 mb-4" data-testid="page-title">
               Ενημέρωση Αίτησης
             </h1>
             <div className="border rounded-lg p-6 bg-red-50 border-red-200 text-red-800">
@@ -119,10 +119,10 @@ export default function ProducerOnboardingPage() {
   // Pending state — already submitted
   if (profile?.status === 'pending' && (success || profile.business_name)) {
     return (
-      <div className="min-h-screen bg-gray-50 py-8">
+      <div className="min-h-screen bg-neutral-50 py-8">
         <div className="max-w-2xl mx-auto px-4">
           <div className="bg-white rounded-lg shadow-sm p-8">
-            <h1 className="text-2xl font-bold text-gray-900 mb-4" data-testid="page-title">
+            <h1 className="text-2xl font-bold text-neutral-900 mb-4" data-testid="page-title">
               Γίνετε Παραγωγός
             </h1>
             <div className="border rounded-lg p-6 bg-yellow-50 border-yellow-200 text-yellow-800" data-testid="pending-banner">
@@ -135,7 +135,7 @@ export default function ProducerOnboardingPage() {
             </div>
             <button
               onClick={() => router.push('/producer/dashboard')}
-              className="mt-6 w-full bg-green-600 text-white py-3 px-4 rounded-lg hover:bg-green-700 transition-colors font-medium"
+              className="mt-6 w-full bg-primary text-white py-3 px-4 rounded-lg hover:bg-primary-light transition-colors font-medium"
             >
               Μετάβαση στο Dashboard
             </button>
@@ -148,10 +148,10 @@ export default function ProducerOnboardingPage() {
   // Success just submitted
   if (success) {
     return (
-      <div className="min-h-screen bg-gray-50 py-8">
+      <div className="min-h-screen bg-neutral-50 py-8">
         <div className="max-w-2xl mx-auto px-4">
           <div className="bg-white rounded-lg shadow-sm p-8">
-            <h1 className="text-2xl font-bold text-gray-900 mb-4" data-testid="page-title">
+            <h1 className="text-2xl font-bold text-neutral-900 mb-4" data-testid="page-title">
               Γίνετε Παραγωγός
             </h1>
             <div className="border rounded-lg p-6 bg-green-50 border-green-200 text-green-800" data-testid="success-banner">
@@ -163,7 +163,7 @@ export default function ProducerOnboardingPage() {
             </div>
             <button
               onClick={() => router.push('/producer/dashboard')}
-              className="mt-6 w-full bg-green-600 text-white py-3 px-4 rounded-lg hover:bg-green-700 transition-colors font-medium"
+              className="mt-6 w-full bg-primary text-white py-3 px-4 rounded-lg hover:bg-primary-light transition-colors font-medium"
             >
               Μετάβαση στο Dashboard
             </button>
@@ -175,13 +175,13 @@ export default function ProducerOnboardingPage() {
 
   // Form state — show onboarding form
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-neutral-50 py-8">
       <div className="max-w-2xl mx-auto px-4">
         <div className="bg-white rounded-lg shadow-sm p-8">
-          <h1 className="text-2xl font-bold text-gray-900 mb-2" data-testid="page-title">
+          <h1 className="text-2xl font-bold text-neutral-900 mb-2" data-testid="page-title">
             Γίνετε Παραγωγός
           </h1>
-          <p className="text-gray-600 mb-6">
+          <p className="text-neutral-600 mb-6">
             Συμπληρώστε τα στοιχεία σας για να ξεκινήσετε να πουλάτε στο Dixis.
           </p>
 
@@ -193,7 +193,7 @@ export default function ProducerOnboardingPage() {
 
           <form onSubmit={handleSubmit} className="space-y-5" data-testid="onboarding-form">
             <div>
-              <label htmlFor="business_name" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="business_name" className="block text-sm font-medium text-neutral-700">
                 Επωνυμία Επιχείρησης <span className="text-red-500">*</span>
               </label>
               <input
@@ -203,13 +203,13 @@ export default function ProducerOnboardingPage() {
                 required
                 value={form.business_name}
                 onChange={handleChange}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-green-500 focus:border-green-500"
+                className="mt-1 block w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-primary focus:border-primary"
                 placeholder="π.χ. Αγρόκτημα Παπαδόπουλου"
               />
             </div>
 
             <div>
-              <label htmlFor="phone" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="phone" className="block text-sm font-medium text-neutral-700">
                 Τηλέφωνο <span className="text-red-500">*</span>
               </label>
               <input
@@ -219,14 +219,14 @@ export default function ProducerOnboardingPage() {
                 required
                 value={form.phone}
                 onChange={handleChange}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-green-500 focus:border-green-500"
+                className="mt-1 block w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-primary focus:border-primary"
                 placeholder="69XXXXXXXX"
               />
             </div>
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label htmlFor="city" className="block text-sm font-medium text-gray-700">
+                <label htmlFor="city" className="block text-sm font-medium text-neutral-700">
                   Πόλη <span className="text-red-500">*</span>
                 </label>
                 <input
@@ -236,12 +236,12 @@ export default function ProducerOnboardingPage() {
                   required
                   value={form.city}
                   onChange={handleChange}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-green-500 focus:border-green-500"
+                  className="mt-1 block w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-primary focus:border-primary"
                   placeholder="π.χ. Ηράκλειο"
                 />
               </div>
               <div>
-                <label htmlFor="region" className="block text-sm font-medium text-gray-700">
+                <label htmlFor="region" className="block text-sm font-medium text-neutral-700">
                   Περιφέρεια
                 </label>
                 <select
@@ -249,7 +249,7 @@ export default function ProducerOnboardingPage() {
                   name="region"
                   value={form.region}
                   onChange={handleChange}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-green-500 focus:border-green-500"
+                  className="mt-1 block w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-primary focus:border-primary"
                 >
                   <option value="">Επιλέξτε...</option>
                   <option value="Αττική">Αττική</option>
@@ -270,7 +270,7 @@ export default function ProducerOnboardingPage() {
             </div>
 
             <div>
-              <label htmlFor="description" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="description" className="block text-sm font-medium text-neutral-700">
                 Περιγραφή Επιχείρησης
               </label>
               <textarea
@@ -279,14 +279,14 @@ export default function ProducerOnboardingPage() {
                 rows={3}
                 value={form.description}
                 onChange={handleChange}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-green-500 focus:border-green-500"
+                className="mt-1 block w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-primary focus:border-primary"
                 placeholder="Πείτε μας λίγα λόγια για την επιχείρησή σας..."
               />
             </div>
 
             <div>
-              <label htmlFor="tax_id" className="block text-sm font-medium text-gray-700">
-                ΑΦΜ <span className="text-gray-400 text-xs">(προαιρετικό)</span>
+              <label htmlFor="tax_id" className="block text-sm font-medium text-neutral-700">
+                ΑΦΜ <span className="text-neutral-400 text-xs">(προαιρετικό)</span>
               </label>
               <input
                 id="tax_id"
@@ -294,7 +294,7 @@ export default function ProducerOnboardingPage() {
                 type="text"
                 value={form.tax_id}
                 onChange={handleChange}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-green-500 focus:border-green-500"
+                className="mt-1 block w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-primary focus:border-primary"
                 placeholder="9 ψηφία"
               />
             </div>
@@ -303,7 +303,7 @@ export default function ProducerOnboardingPage() {
               type="submit"
               disabled={submitting}
               data-testid="onboarding-submit"
-              className="w-full bg-green-600 text-white py-3 px-4 rounded-lg hover:bg-green-700 transition-colors font-medium disabled:bg-gray-400 disabled:cursor-not-allowed"
+              className="w-full bg-primary text-white py-3 px-4 rounded-lg hover:bg-primary-light transition-colors font-medium disabled:bg-neutral-400 disabled:cursor-not-allowed"
             >
               {submitting ? 'Υποβολή...' : 'Υποβολή Αίτησης'}
             </button>

--- a/frontend/src/app/producer/orders/[id]/page.tsx
+++ b/frontend/src/app/producer/orders/[id]/page.tsx
@@ -164,12 +164,12 @@ export default function ProducerOrderDetailsPage() {
 
   return (
     <AuthGuard requireAuth={true} requireRole="producer">
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-neutral-50">
         <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {/* Back Link */}
           <Link
             href="/producer/orders"
-            className="inline-flex items-center text-sm text-gray-600 hover:text-gray-900 mb-6"
+            className="inline-flex items-center text-sm text-neutral-600 hover:text-neutral-900 mb-6"
           >
             <svg
               className="w-4 h-4 mr-2"
@@ -211,7 +211,7 @@ export default function ProducerOrderDetailsPage() {
               <p className="text-red-600 mb-4">{error}</p>
               <button
                 onClick={loadOrder}
-                className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors"
+                className="bg-primary hover:bg-primary-light text-white px-4 py-2 rounded-lg transition-colors"
               >
                 Δοκιμάστε Ξανά
               </button>
@@ -222,10 +222,10 @@ export default function ProducerOrderDetailsPage() {
               <div className="bg-white rounded-lg shadow-md p-6">
                 <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
                   <div>
-                    <h1 className="text-2xl font-bold text-gray-900">
+                    <h1 className="text-2xl font-bold text-neutral-900">
                       Παραγγελία #{order.id}
                     </h1>
-                    <p className="text-sm text-gray-500 mt-1">
+                    <p className="text-sm text-neutral-500 mt-1">
                       {new Date(order.created_at).toLocaleDateString('el-GR', {
                         year: 'numeric',
                         month: 'long',
@@ -248,7 +248,7 @@ export default function ProducerOrderDetailsPage() {
               {/* Status Update Section */}
               {getNextStatus(order.status) && (
                 <div className="bg-white rounded-lg shadow-md p-6">
-                  <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                  <h2 className="text-lg font-semibold text-neutral-900 mb-4">
                     Ενημέρωση Κατάστασης
                   </h2>
                   <div className="flex items-center gap-4">
@@ -259,8 +259,8 @@ export default function ProducerOrderDetailsPage() {
                       disabled={updating}
                       className={`flex-1 sm:flex-none px-6 py-3 rounded-lg font-medium transition-colors ${
                         updating
-                          ? 'bg-gray-300 cursor-not-allowed'
-                          : 'bg-green-600 hover:bg-green-700 text-white'
+                          ? 'bg-neutral-300 cursor-not-allowed'
+                          : 'bg-primary hover:bg-primary-light text-white'
                       }`}
                     >
                       {updating ? (
@@ -290,7 +290,7 @@ export default function ProducerOrderDetailsPage() {
                         nextStatusLabels[order.status]
                       )}
                     </button>
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-neutral-500">
                       Τρέχουσα: {statusLabels[order.status]} →{' '}
                       {statusLabels[getNextStatus(order.status)!]}
                     </p>
@@ -354,20 +354,20 @@ export default function ProducerOrderDetailsPage() {
 
               {/* Customer Info + Shipping Address */}
               <div className="bg-white rounded-lg shadow-md p-6">
-                <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                <h2 className="text-lg font-semibold text-neutral-900 mb-4">
                   Πληροφορίες Πελάτη
                 </h2>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div>
-                    <p className="text-sm text-gray-500">Όνομα</p>
-                    <p className="text-gray-900">
+                    <p className="text-sm text-neutral-500">Όνομα</p>
+                    <p className="text-neutral-900">
                       {order.user?.name || 'Επισκέπτης'}
                     </p>
                   </div>
                   {(order.user?.email || order.shipping_address?.email) && (
                     <div>
-                      <p className="text-sm text-gray-500">Email</p>
-                      <p className="text-gray-900">
+                      <p className="text-sm text-neutral-500">Email</p>
+                      <p className="text-neutral-900">
                         {order.user?.email || order.shipping_address?.email}
                       </p>
                     </div>
@@ -409,7 +409,7 @@ export default function ProducerOrderDetailsPage() {
 
               {/* Order Items */}
               <div className="bg-white rounded-lg shadow-md p-6">
-                <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                <h2 className="text-lg font-semibold text-neutral-900 mb-4">
                   Προϊόντα ({order.orderItems.length})
                 </h2>
                 <div className="divide-y">
@@ -419,14 +419,14 @@ export default function ProducerOrderDetailsPage() {
                       className="py-4 flex justify-between items-center"
                     >
                       <div>
-                        <p className="font-medium text-gray-900">
+                        <p className="font-medium text-neutral-900">
                           {item.product_name || item.product?.name}
                         </p>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-neutral-500">
                           {item.quantity} × {formatCurrency(parseFloat(item.unit_price))}
                         </p>
                       </div>
-                      <p className="font-semibold text-gray-900">
+                      <p className="font-semibold text-neutral-900">
                         {formatCurrency(parseFloat(item.total_price))}
                       </p>
                     </div>
@@ -436,15 +436,15 @@ export default function ProducerOrderDetailsPage() {
                 {/* Order Summary */}
                 <div className="border-t pt-4 mt-4 space-y-2">
                   <div className="flex justify-between text-sm">
-                    <span className="text-gray-500">Υποσύνολο</span>
-                    <span className="text-gray-900">
+                    <span className="text-neutral-500">Υποσύνολο</span>
+                    <span className="text-neutral-900">
                       {formatCurrency(parseFloat(order.subtotal))}
                     </span>
                   </div>
                   {parseFloat(order.shipping_cost) > 0 && (
                     <div className="flex justify-between text-sm">
-                      <span className="text-gray-500">Μεταφορικά</span>
-                      <span className="text-gray-900">
+                      <span className="text-neutral-500">Μεταφορικά</span>
+                      <span className="text-neutral-900">
                         {formatCurrency(parseFloat(order.shipping_cost))}
                       </span>
                     </div>

--- a/frontend/src/app/producer/orders/page.tsx
+++ b/frontend/src/app/producer/orders/page.tsx
@@ -98,8 +98,8 @@ export default function ProducerOrdersPage() {
         onClick={() => setActiveFilter(status)}
         className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
           isActive
-            ? 'bg-green-600 text-white'
-            : 'bg-white text-gray-700 hover:bg-gray-50 border border-gray-300'
+            ? 'bg-primary text-white'
+            : 'bg-white text-neutral-700 hover:bg-neutral-50 border border-neutral-300'
         }`}
       >
         {label} ({count})
@@ -113,16 +113,16 @@ export default function ProducerOrdersPage() {
         <div className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow cursor-pointer">
         <div className="flex justify-between items-start mb-4">
           <div>
-            <h3 className="text-lg font-semibold text-gray-900">
+            <h3 className="text-lg font-semibold text-neutral-900">
               {t('producerOrders.orderNumber').replace('{id}', String(order.id))}
             </h3>
-            <p className="text-sm text-gray-600 mt-1">
+            <p className="text-sm text-neutral-600 mt-1">
               {order.user?.name || t('producerOrders.guest')}
             </p>
             <time
               dateTime={order.created_at}
               suppressHydrationWarning
-              className="block text-sm text-gray-500"
+              className="block text-sm text-neutral-500"
             >
               {mounted
                 ? new Date(order.created_at).toLocaleString('el-GR', {
@@ -143,7 +143,7 @@ export default function ProducerOrdersPage() {
             >
               {getStatusLabel(order.status)}
             </span>
-            <p className="text-xl font-bold text-gray-900 mt-2">
+            <p className="text-xl font-bold text-neutral-900 mt-2">
               {formatCurrency(parseFloat(order.total))}
             </p>
           </div>
@@ -151,7 +151,7 @@ export default function ProducerOrdersPage() {
 
         {/* Order Items */}
         <div className="border-t pt-4">
-          <h4 className="text-sm font-medium text-gray-700 mb-2">
+          <h4 className="text-sm font-medium text-neutral-700 mb-2">
             {t('producerOrders.products')} ({(order.orderItems ?? []).length})
           </h4>
           <div className="space-y-2">
@@ -160,13 +160,13 @@ export default function ProducerOrdersPage() {
                 key={item.id}
                 className="flex justify-between items-center text-sm"
               >
-                <span className="text-gray-700">
+                <span className="text-neutral-700">
                   {item.product_name || item.product?.name}
                 </span>
-                <span className="text-gray-600">
+                <span className="text-neutral-600">
                   {item.quantity} × {formatCurrency(parseFloat(item.unit_price))}
                   {' = '}
-                  <span className="font-medium text-gray-900">
+                  <span className="font-medium text-neutral-900">
                     {formatCurrency(parseFloat(item.total_price))}
                   </span>
                 </span>
@@ -201,12 +201,12 @@ export default function ProducerOrdersPage() {
 
   return (
     <AuthGuard requireAuth={true} requireRole="producer">
-      <div className="min-h-screen bg-gray-50" data-testid="producer-orders-page">
+      <div className="min-h-screen bg-neutral-50" data-testid="producer-orders-page">
         <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {/* Header */}
           <div className="mb-6">
-            <h1 className="text-3xl font-bold text-gray-900" data-testid="producer-orders-title">{t('producerOrders.title')}</h1>
-            <p className="text-gray-600 mt-2">
+            <h1 className="text-3xl font-bold text-neutral-900" data-testid="producer-orders-title">{t('producerOrders.title')}</h1>
+            <p className="text-neutral-600 mt-2">
               {t('producerOrders.subtitle')}
             </p>
           </div>
@@ -267,7 +267,7 @@ export default function ProducerOrdersPage() {
               <p className="text-red-600 mb-4">{error}</p>
               <button
                 onClick={loadOrders}
-                className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors"
+                className="bg-primary hover:bg-primary-light text-white px-4 py-2 rounded-lg transition-colors"
               >
                 {t('producerOrders.tryAgain')}
               </button>
@@ -275,7 +275,7 @@ export default function ProducerOrdersPage() {
           ) : orders.length === 0 ? (
             /* Empty State */
             <div className="text-center py-12">
-              <div className="text-gray-400 mb-4">
+              <div className="text-neutral-400 mb-4">
                 <svg
                   className="mx-auto h-12 w-12"
                   fill="none"
@@ -290,10 +290,10 @@ export default function ProducerOrdersPage() {
                   />
                 </svg>
               </div>
-              <h3 className="text-lg font-medium text-gray-900 mb-2">
+              <h3 className="text-lg font-medium text-neutral-900 mb-2">
                 {t('producerOrders.noOrders')}
               </h3>
-              <p className="text-gray-600">
+              <p className="text-neutral-600">
                 {activeFilter === 'all'
                   ? t('producerOrders.noOrdersYet')
                   : t('producerOrders.noOrdersStatus').replace('{status}', getStatusLabel(activeFilter as OrderStatus))}

--- a/frontend/src/app/producer/settings/page.tsx
+++ b/frontend/src/app/producer/settings/page.tsx
@@ -159,13 +159,13 @@ function ProducerSettingsContent() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 py-8">
+      <div className="min-h-screen bg-neutral-50 py-8">
         <div className="max-w-4xl mx-auto px-4">
           <div className="bg-white rounded-lg shadow-sm p-8">
             <div className="animate-pulse space-y-4">
-              <div className="h-6 bg-gray-200 rounded w-1/3"></div>
-              <div className="h-10 bg-gray-200 rounded"></div>
-              <div className="h-10 bg-gray-200 rounded"></div>
+              <div className="h-6 bg-neutral-200 rounded w-1/3"></div>
+              <div className="h-10 bg-neutral-200 rounded"></div>
+              <div className="h-10 bg-neutral-200 rounded"></div>
             </div>
           </div>
         </div>
@@ -174,12 +174,12 @@ function ProducerSettingsContent() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-neutral-50 py-8">
       <div className="max-w-4xl mx-auto px-4">
         <div className="bg-white rounded-lg shadow-sm">
-          <div className="px-6 py-4 border-b border-gray-200">
-            <h1 className="text-2xl font-bold text-gray-900">Ρυθμίσεις Παραγωγού</h1>
-            <p className="mt-1 text-gray-600">
+          <div className="px-6 py-4 border-b border-neutral-200">
+            <h1 className="text-2xl font-bold text-neutral-900">Ρυθμίσεις Παραγωγού</h1>
+            <p className="mt-1 text-neutral-600">
               Διαχειριστείτε τα στοιχεία της επιχείρησής σας
             </p>
           </div>
@@ -191,7 +191,7 @@ function ProducerSettingsContent() {
           )}
 
           {success && (
-            <div className="mx-6 mt-4 bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg">
+            <div className="mx-6 mt-4 bg-primary-pale border border-primary/20 text-primary px-4 py-3 rounded-lg">
               {success}
             </div>
           )}
@@ -199,11 +199,11 @@ function ProducerSettingsContent() {
           <form onSubmit={handleSubmit} className="p-6 space-y-8">
             {/* Basic Information */}
             <div>
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">Βασικά Στοιχεία</h2>
+              <h2 className="text-lg font-semibold text-neutral-900 mb-4">Βασικά Στοιχεία</h2>
               <div className="space-y-4">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
-                    <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">
+                    <label htmlFor="name" className="block text-sm font-medium text-neutral-700 mb-1">
                       Όνομα Παραγωγού *
                     </label>
                     <input
@@ -212,13 +212,13 @@ function ProducerSettingsContent() {
                       value={formData.name}
                       onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                       required
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                      className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                       placeholder="π.χ. Αγροκτήμα Κουτσογιάννη"
                     />
                   </div>
 
                   <div>
-                    <label htmlFor="business_name" className="block text-sm font-medium text-gray-700 mb-1">
+                    <label htmlFor="business_name" className="block text-sm font-medium text-neutral-700 mb-1">
                       Επωνυμία Επιχείρησης
                     </label>
                     <input
@@ -226,14 +226,14 @@ function ProducerSettingsContent() {
                       type="text"
                       value={formData.business_name}
                       onChange={(e) => setFormData({ ...formData, business_name: e.target.value })}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                      className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                       placeholder="π.χ. ΚΟΥΤΣΟΓΙΑΝΝΗΣ ΚΑΙ ΣΙΑ ΟΕ"
                     />
                   </div>
                 </div>
 
                 <div>
-                  <label htmlFor="slug" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label htmlFor="slug" className="block text-sm font-medium text-neutral-700 mb-1">
                     Αναγνωριστικό URL (Slug)
                   </label>
                   <input
@@ -248,16 +248,16 @@ function ProducerSettingsContent() {
                         .replace(/[^a-z0-9-]/g, '');
                       setFormData({ ...formData, slug: normalized });
                     }}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                    className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                     placeholder="π.χ. agrotima-koutsogianni"
                   />
-                  <p className="mt-1 text-sm text-gray-500">
+                  <p className="mt-1 text-sm text-neutral-500">
                     Χρησιμοποιείται στο URL (μόνο λατινικά, παύλες)
                   </p>
                 </div>
 
                 <div>
-                  <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label htmlFor="description" className="block text-sm font-medium text-neutral-700 mb-1">
                     Περιγραφή
                   </label>
                   <textarea
@@ -265,7 +265,7 @@ function ProducerSettingsContent() {
                     rows={4}
                     value={formData.description}
                     onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                    className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                     placeholder="Περιγράψτε την επιχείρησή σας..."
                   />
                 </div>
@@ -274,11 +274,11 @@ function ProducerSettingsContent() {
 
             {/* Contact Information */}
             <div>
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">Στοιχεία Επικοινωνίας</h2>
+              <h2 className="text-lg font-semibold text-neutral-900 mb-4">Στοιχεία Επικοινωνίας</h2>
               <div className="space-y-4">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
-                    <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+                    <label htmlFor="email" className="block text-sm font-medium text-neutral-700 mb-1">
                       Email
                     </label>
                     <input
@@ -286,13 +286,13 @@ function ProducerSettingsContent() {
                       type="email"
                       value={formData.email}
                       onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                      className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                       placeholder="email@example.com"
                     />
                   </div>
 
                   <div>
-                    <label htmlFor="phone" className="block text-sm font-medium text-gray-700 mb-1">
+                    <label htmlFor="phone" className="block text-sm font-medium text-neutral-700 mb-1">
                       Τηλέφωνο
                     </label>
                     <input
@@ -300,14 +300,14 @@ function ProducerSettingsContent() {
                       type="tel"
                       value={formData.phone}
                       onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                      className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                       placeholder="210 1234567"
                     />
                   </div>
                 </div>
 
                 <div>
-                  <label htmlFor="website" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label htmlFor="website" className="block text-sm font-medium text-neutral-700 mb-1">
                     Ιστοσελίδα
                   </label>
                   <input
@@ -315,13 +315,13 @@ function ProducerSettingsContent() {
                     type="url"
                     value={formData.website}
                     onChange={(e) => setFormData({ ...formData, website: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                    className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                     placeholder="https://www.example.com"
                   />
                 </div>
 
                 <div>
-                  <label htmlFor="address" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label htmlFor="address" className="block text-sm font-medium text-neutral-700 mb-1">
                     Διεύθυνση
                   </label>
                   <input
@@ -329,7 +329,7 @@ function ProducerSettingsContent() {
                     type="text"
                     value={formData.address}
                     onChange={(e) => setFormData({ ...formData, address: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                    className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                     placeholder="Οδός, αριθμός"
                   />
                 </div>
@@ -338,10 +338,10 @@ function ProducerSettingsContent() {
 
             {/* Location Details */}
             <div>
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">Στοιχεία Τοποθεσίας</h2>
+              <h2 className="text-lg font-semibold text-neutral-900 mb-4">Στοιχεία Τοποθεσίας</h2>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label htmlFor="city" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label htmlFor="city" className="block text-sm font-medium text-neutral-700 mb-1">
                     Πόλη
                   </label>
                   <input
@@ -349,13 +349,13 @@ function ProducerSettingsContent() {
                     type="text"
                     value={formData.city}
                     onChange={(e) => setFormData({ ...formData, city: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                    className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                     placeholder="π.χ. Αθήνα"
                   />
                 </div>
 
                 <div>
-                  <label htmlFor="postal_code" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label htmlFor="postal_code" className="block text-sm font-medium text-neutral-700 mb-1">
                     Τ.Κ.
                   </label>
                   <input
@@ -363,13 +363,13 @@ function ProducerSettingsContent() {
                     type="text"
                     value={formData.postal_code}
                     onChange={(e) => setFormData({ ...formData, postal_code: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                    className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                     placeholder="π.χ. 12345"
                   />
                 </div>
 
                 <div>
-                  <label htmlFor="region" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label htmlFor="region" className="block text-sm font-medium text-neutral-700 mb-1">
                     Περιφέρεια
                   </label>
                   <input
@@ -377,13 +377,13 @@ function ProducerSettingsContent() {
                     type="text"
                     value={formData.region}
                     onChange={(e) => setFormData({ ...formData, region: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                    className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                     placeholder="π.χ. Αττική"
                   />
                 </div>
 
                 <div>
-                  <label htmlFor="location" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label htmlFor="location" className="block text-sm font-medium text-neutral-700 mb-1">
                     Τοποθεσία (Εμφάνιση)
                   </label>
                   <input
@@ -391,7 +391,7 @@ function ProducerSettingsContent() {
                     type="text"
                     value={formData.location}
                     onChange={(e) => setFormData({ ...formData, location: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                    className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                     placeholder="π.χ. Κρήτη, Ελλάδα"
                   />
                 </div>
@@ -400,10 +400,10 @@ function ProducerSettingsContent() {
 
             {/* Shipping Settings - Pass PRODUCER-THRESHOLD-POSTALCODE-01 */}
             <div>
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">Ρυθμίσεις Αποστολής</h2>
+              <h2 className="text-lg font-semibold text-neutral-900 mb-4">Ρυθμίσεις Αποστολής</h2>
               <div className="space-y-4">
                 <div>
-                  <label htmlFor="free_shipping_threshold_eur" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label htmlFor="free_shipping_threshold_eur" className="block text-sm font-medium text-neutral-700 mb-1">
                     Όριο Δωρεάν Αποστολής (€)
                   </label>
                   <input
@@ -414,10 +414,10 @@ function ProducerSettingsContent() {
                     max="9999.99"
                     value={formData.free_shipping_threshold_eur}
                     onChange={(e) => setFormData({ ...formData, free_shipping_threshold_eur: e.target.value })}
-                    className="w-full md:w-1/2 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                    className="w-full md:w-1/2 px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                     placeholder="35.00"
                   />
-                  <p className="mt-1 text-sm text-gray-500">
+                  <p className="mt-1 text-sm text-neutral-500">
                     Αφήστε κενό για χρήση του προεπιλεγμένου ορίου (€35). Οι πελάτες θα έχουν δωρεάν αποστολή όταν η παραγγελία τους από εσάς ξεπερνά αυτό το ποσό.
                   </p>
                 </div>
@@ -426,11 +426,11 @@ function ProducerSettingsContent() {
 
             {/* Business Details */}
             <div>
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">Φορολογικά Στοιχεία</h2>
+              <h2 className="text-lg font-semibold text-neutral-900 mb-4">Φορολογικά Στοιχεία</h2>
               <div className="space-y-4">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
-                    <label htmlFor="tax_id" className="block text-sm font-medium text-gray-700 mb-1">
+                    <label htmlFor="tax_id" className="block text-sm font-medium text-neutral-700 mb-1">
                       ΑΦΜ
                     </label>
                     <input
@@ -438,13 +438,13 @@ function ProducerSettingsContent() {
                       type="text"
                       value={formData.tax_id}
                       onChange={(e) => setFormData({ ...formData, tax_id: e.target.value })}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                      className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                       placeholder="π.χ. 123456789"
                     />
                   </div>
 
                   <div>
-                    <label htmlFor="tax_office" className="block text-sm font-medium text-gray-700 mb-1">
+                    <label htmlFor="tax_office" className="block text-sm font-medium text-neutral-700 mb-1">
                       ΔΟΥ
                     </label>
                     <input
@@ -452,14 +452,14 @@ function ProducerSettingsContent() {
                       type="text"
                       value={formData.tax_office}
                       onChange={(e) => setFormData({ ...formData, tax_office: e.target.value })}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                      className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                       placeholder="π.χ. ΔΟΥ Αθηνών"
                     />
                   </div>
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                  <label className="block text-sm font-medium text-neutral-700 mb-2">
                     Κοινωνικά Δίκτυα
                   </label>
                   <div className="space-y-2">
@@ -469,7 +469,7 @@ function ProducerSettingsContent() {
                           type="url"
                           value={link}
                           onChange={(e) => updateSocialLink(i, e.target.value)}
-                          className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                          className="flex-1 px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                           placeholder="https://facebook.com/..."
                         />
                         {formData.social_media.length > 1 && (
@@ -486,7 +486,7 @@ function ProducerSettingsContent() {
                     <button
                       type="button"
                       onClick={addSocialLink}
-                      className="text-sm text-green-600 hover:text-green-800 font-medium"
+                      className="text-sm text-primary hover:text-primary font-medium"
                     >
                       + Προσθήκη Συνδέσμου
                     </button>
@@ -496,11 +496,11 @@ function ProducerSettingsContent() {
             </div>
 
             {/* Submit Buttons */}
-            <div className="flex gap-3 pt-4 border-t border-gray-200">
+            <div className="flex gap-3 pt-4 border-t border-neutral-200">
               <button
                 type="submit"
                 disabled={busy}
-                className="flex-1 bg-green-600 text-white py-2 px-4 rounded-lg hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-light disabled:bg-neutral-400 disabled:cursor-not-allowed transition-colors"
               >
                 {busy ? 'Αποθήκευση...' : 'Αποθήκευση Αλλαγών'}
               </button>
@@ -508,7 +508,7 @@ function ProducerSettingsContent() {
                 type="button"
                 onClick={() => router.back()}
                 disabled={busy}
-                className="flex-1 bg-gray-100 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-200 disabled:bg-gray-50 disabled:cursor-not-allowed transition-colors"
+                className="flex-1 bg-neutral-100 text-neutral-700 py-2 px-4 rounded-lg hover:bg-neutral-200 disabled:bg-neutral-50 disabled:cursor-not-allowed transition-colors"
               >
                 Ακύρωση
               </button>


### PR DESCRIPTION
## Summary
- Replace off-brand `gray-*` → `neutral-*` across 9 producer-facing pages
- Replace off-brand `green-*` → `primary`/`primary-light`/`primary-pale`
- Semantic status colors preserved (delivered green, error red, etc.)

## Files changed (9)
- `producer/onboarding/page.tsx`
- `producer/orders/page.tsx` + `[id]/page.tsx`
- `producer/settings/page.tsx`
- `producer/analytics/page.tsx`
- `my/products/page.tsx` + `create/page.tsx` + `[id]/edit/page.tsx`
- `my/error.tsx`

## Verification
- `tsc --noEmit` — 0 errors
- `npm run build` — clean pass
- 237 insertions / 237 deletions (pure class-name swaps)

## Test plan
- [x] TypeScript compilation passes
- [x] Production build succeeds
- [ ] Visual check: producer pages use neutral/primary palette
- [ ] Visual check: order status badges retain semantic colors