### PR TITLE
fix: add missing Category migration (fixes /api/categories 500)

### DIFF
--- a/frontend/prisma/migrations/20260216000000_add_category/migration.sql
+++ b/frontend/prisma/migrations/20260216000000_add_category/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "Category" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "nameEn" TEXT,
+    "description" TEXT,
+    "icon" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Category_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Category_slug_key" ON "Category"("slug");
+
+-- CreateIndex
+CREATE INDEX "Category_isActive_sortOrder_idx" ON "Category"("isActive", "sortOrder");


### PR DESCRIPTION
## Summary
- The Category model existed in `schema.prisma` but had no migration file
- Production uses `prisma migrate deploy` which requires migration files
- Without the migration, the Category table was never created in PostgreSQL
- This caused `/api/categories` to return 500, breaking product form category dropdowns

## Changes
- Added `20260216000000_add_category/migration.sql` with CREATE TABLE + indexes

## Post-Deploy Steps (on VPS)
```bash
cd /var/www/dixis/current/frontend
npx prisma migrate deploy
npx prisma db seed
pm2 restart dixis-frontend
```

## Test Plan
- [ ] CI passes (build + TypeScript)
- [ ] After deploy + migrate: `curl https://dixis.gr/api/categories` returns 200 with category list
- [ ] Producer product form shows category dropdown