### PR TITLE
fix: route categories API via nginx-compatible paths

### DIFF
--- a/frontend/src/app/admin/categories/page.tsx
+++ b/frontend/src/app/admin/categories/page.tsx
@@ -46,12 +46,12 @@ function AdminCategoriesContent() {
   async function loadCategories() {
     setLoading(true);
     try {
-      const response = await fetch('/api/categories');
+      const response = await fetch('/api/public/categories');
       if (!response.ok) throw new Error('Failed to load categories');
 
       const data = await response.json();
       // Fetch ALL categories (not just active) for admin view
-      const allCategoriesResponse = await fetch('/api/categories?includeInactive=true');
+      const allCategoriesResponse = await fetch('/api/public/categories?includeInactive=true');
       const allData = allCategoriesResponse.ok
         ? await allCategoriesResponse.json()
         : data;
@@ -70,7 +70,7 @@ function AdminCategoriesContent() {
     setProcessingIds(prev => new Set(prev).add(category.id));
 
     try {
-      const response = await fetch(`/api/categories/${category.id}`, {
+      const response = await fetch(`/api/admin/categories/${category.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ isActive: !category.isActive })
@@ -116,7 +116,7 @@ function AdminCategoriesContent() {
     setSubmitting(true);
 
     try {
-      const response = await fetch(`/api/categories/${categoryToEdit.id}`, {
+      const response = await fetch(`/api/admin/categories/${categoryToEdit.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/src/app/api/admin/categories/[id]/route.ts
+++ b/frontend/src/app/api/admin/categories/[id]/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db/client';
+import { requireAdmin } from '@/lib/auth/admin';
+import { logAdminAction } from '@/lib/audit/logger';
+
+/**
+ * PATCH /api/admin/categories/[id]
+ * Update a category (admin only)
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    // Require admin authentication
+    const admin = await requireAdmin();
+    const categoryId = params.id;
+    const body = await request.json();
+
+    // Extract and validate fields
+    const { name, icon, isActive, sortOrder } = body;
+
+    // Validation
+    if (name !== undefined && (typeof name !== 'string' || name.trim().length < 2)) {
+      return NextResponse.json(
+        { error: 'Το όνομα πρέπει να έχει τουλάχιστον 2 χαρακτήρες' },
+        { status: 400 }
+      );
+    }
+
+    if (sortOrder !== undefined && (typeof sortOrder !== 'number' || sortOrder < 0)) {
+      return NextResponse.json(
+        { error: 'Η σειρά ταξινόμησης πρέπει να είναι θετικός αριθμός' },
+        { status: 400 }
+      );
+    }
+
+    // Fetch current category for audit log
+    const currentCategory = await prisma.category.findUnique({
+      where: { id: categoryId }
+    });
+
+    if (!currentCategory) {
+      return NextResponse.json(
+        { error: 'Η κατηγορία δεν βρέθηκε' },
+        { status: 404 }
+      );
+    }
+
+    // Build update data
+    const updateData: Record<string, unknown> = {};
+
+    if (name !== undefined) {
+      updateData.name = name.trim();
+    }
+
+    if (icon !== undefined) {
+      updateData.icon = icon || null;
+    }
+
+    if (isActive !== undefined) {
+      updateData.isActive = Boolean(isActive);
+    }
+
+    if (sortOrder !== undefined) {
+      updateData.sortOrder = sortOrder;
+    }
+
+    // Update category
+    const updatedCategory = await prisma.category.update({
+      where: { id: categoryId },
+      data: updateData
+    });
+
+    // Log admin action
+    await logAdminAction({
+      admin,
+      action: 'CATEGORY_UPDATE',
+      entityType: 'category',
+      entityId: categoryId,
+      oldValue: {
+        name: currentCategory.name,
+        icon: currentCategory.icon,
+        isActive: currentCategory.isActive,
+        sortOrder: currentCategory.sortOrder
+      },
+      newValue: {
+        name: updatedCategory.name,
+        icon: updatedCategory.icon,
+        isActive: updatedCategory.isActive,
+        sortOrder: updatedCategory.sortOrder
+      }
+    });
+
+    return NextResponse.json({
+      success: true,
+      category: updatedCategory
+    });
+
+  } catch (error: unknown) {
+    // Handle admin auth errors
+    if (error instanceof Error && error.name === 'AdminError') {
+      return NextResponse.json(
+        { error: 'Απαιτείται πρόσβαση διαχειριστή' },
+        { status: 403 }
+      );
+    }
+
+    console.error('Update category error:', error);
+    return NextResponse.json(
+      { error: 'Σφάλμα κατά την ενημέρωση κατηγορίας' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/public/categories/route.ts
+++ b/frontend/src/app/api/public/categories/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/db/client';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/public/categories
+ * Returns categories sorted by sortOrder
+ * Query params:
+ * - includeInactive=true: Include inactive categories (for admin)
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const includeInactive = searchParams.get('includeInactive') === 'true';
+
+    const categories = await prisma.category.findMany({
+      where: includeInactive ? {} : { isActive: true },
+      orderBy: { sortOrder: 'asc' },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        nameEn: true,
+        icon: true,
+        sortOrder: true,
+        isActive: true
+      }
+    });
+
+    return NextResponse.json({ categories });
+  } catch (error) {
+    console.error('Failed to fetch categories:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch categories' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/my/products/[id]/edit/page.tsx
+++ b/frontend/src/app/my/products/[id]/edit/page.tsx
@@ -52,7 +52,7 @@ function EditProductContent() {
 
   useEffect(() => {
     // Fetch dynamic categories
-    fetch('/api/categories')
+    fetch('/api/public/categories')
       .then((r) => r.json())
       .then((data) => {
         setCategories(data.categories || []);

--- a/frontend/src/app/my/products/create/page.tsx
+++ b/frontend/src/app/my/products/create/page.tsx
@@ -31,7 +31,7 @@ function CreateProductContent() {
   const [categoriesLoading, setCategoriesLoading] = useState(true);
 
   useEffect(() => {
-    fetch('/api/categories')
+    fetch('/api/public/categories')
       .then((r) => r.json())
       .then((data) => {
         setCategories(data.categories || []);

--- a/frontend/src/app/my/products/page.tsx
+++ b/frontend/src/app/my/products/page.tsx
@@ -78,7 +78,7 @@ function ProducerProductsContent() {
 
   // Fetch categories from API
   useEffect(() => {
-    fetch('/api/categories')
+    fetch('/api/public/categories')
       .then((r) => r.json())
       .then((data) => {
         setCategories(data.categories || []);


### PR DESCRIPTION
## Summary
- `/api/categories` was unreachable on production because nginx routes all `/api/*` to Laravel
- Created new routes under nginx-routed prefixes that already proxy to Next.js:
  - `GET /api/public/categories` (nginx already routes `/api/public/*` → Next.js)
  - `PATCH /api/admin/categories/[id]` (nginx already routes `/api/admin/*` → Next.js)
- Updated all frontend fetch calls to use the new paths
- Original `/api/categories` routes kept as fallback for local dev

## Files Changed (6)
- `api/public/categories/route.ts` — new public GET endpoint
- `api/admin/categories/[id]/route.ts` — new admin PATCH endpoint  
- `admin/categories/page.tsx` — updated fetch paths
- `my/products/create/page.tsx` — updated fetch path
- `my/products/[id]/edit/page.tsx` — updated fetch path
- `my/products/page.tsx` — updated fetch path

## Test Plan
- [ ] CI passes (TypeScript + build)
- [ ] `curl https://dixis.gr/api/public/categories` returns 200 with 13 categories
- [ ] Producer product form shows category dropdown
- [ ] Admin categories page loads and can edit categories