### PR TITLE
fix: load shared env vars via PM2 for standalone mode

### DIFF
--- a/frontend/ecosystem.config.js
+++ b/frontend/ecosystem.config.js
@@ -4,10 +4,38 @@
  * Used by: scripts/prod-deploy-clean.sh (line ~229)
  * Runs on: VPS at /var/www/dixis/current/frontend/
  *
- * Env vars: PORT, HOSTNAME, NODE_ENV are set here.
- * All other vars (DATABASE_URL, STRIPE keys, etc.) are loaded
- * by Next.js from the .env symlink → /var/www/dixis/shared/frontend.env
+ * Env loading strategy:
+ * - PORT, HOSTNAME, NODE_ENV are always set here.
+ * - Server-side env vars (DATABASE_URL, STRIPE keys, etc.) are loaded
+ *   from /var/www/dixis/shared/frontend.env at startup.
+ *   Next.js standalone mode does NOT reliably load .env files,
+ *   so we parse them here and inject via PM2 env.
  */
+const fs = require('fs');
+const path = require('path');
+
+// Load env vars from shared env file (production VPS)
+function loadEnvFile(filePath) {
+  const vars = {};
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) continue;
+      const key = trimmed.substring(0, eqIndex).trim();
+      const value = trimmed.substring(eqIndex + 1).trim();
+      vars[key] = value;
+    }
+  } catch {
+    // File not found — local dev, CI, etc. Just skip.
+  }
+  return vars;
+}
+
+const sharedEnv = loadEnvFile('/var/www/dixis/shared/frontend.env');
+
 module.exports = {
   apps: [{
     name: 'dixis-frontend',
@@ -16,6 +44,7 @@ module.exports = {
       NODE_ENV: 'production',
       PORT: 3000,
       HOSTNAME: '127.0.0.1', // Critical: prevents Next.js 15 IPv6 bind
+      ...sharedEnv,
     },
     max_memory_restart: '350M',
     restart_delay: 5000,


### PR DESCRIPTION
## Summary
- Next.js standalone mode does not reliably load `.env` files at runtime
- The Prisma client couldn't connect to Neon PostgreSQL because `DATABASE_URL` was missing
- Fix: `ecosystem.config.js` now parses `/var/www/dixis/shared/frontend.env` and injects all vars via PM2 env

## Root Cause
The standalone `server.js` runs in `.next/standalone/` which has a symlinked `.env` file, but Next.js standalone doesn't load it for server-side runtime code (only for build-time `NEXT_PUBLIC_*` vars). This meant `DATABASE_URL`, `STRIPE_SECRET_KEY`, etc. were invisible to API routes.

## Changes
- `ecosystem.config.js` — Added `loadEnvFile()` helper that reads the shared env file and spreads its vars into PM2's `env` block
- Graceful fallback: if file doesn't exist (local dev, CI), no vars are added

## Post-Deploy
```bash
cd /var/www/dixis/current && git pull origin main
cd frontend && pm2 delete dixis-frontend && pm2 start ecosystem.config.js && pm2 save
```

## Test Plan
- [x] Verified on production: `curl https://dixis.gr/api/public/categories` returns 200 with 13 categories
- [ ] CI passes (no production-only code paths affected)