### PR TITLE
fix: copy public/ files to standalone output (favicons, images)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf .next && rimraf node_modules/.cache || true",
     "dev:clean": "npm run clean:cache && npm run dev",
     "build": "prisma generate && next build",
-    "postbuild": "if [ -d .next/standalone ]; then mkdir -p .next/standalone/.next && cp -r .next/static .next/standalone/.next/ && echo 'Standalone static files copied'; fi && bash scripts/no-localhost-in-bundle.sh",
+    "postbuild": "if [ -d .next/standalone ]; then mkdir -p .next/standalone/.next && cp -r .next/static .next/standalone/.next/ && cp -rn public/. .next/standalone/public/ && echo 'Standalone static + public files copied'; fi && bash scripts/no-localhost-in-bundle.sh",
     "start": "next start",
     "start:ci": "next start -p 3001",
     "mock:api": "node ../scripts/mock-api/lhci-mock.cjs",


### PR DESCRIPTION
## Summary
- Favicons, apple-touch-icon, hero images, and OG images returned 404 in production
- Root cause: postbuild script copied `.next/static` but NOT `public/` to standalone output
- Fix: Added `cp -rn public/. .next/standalone/public/` to postbuild

## Impact
- Favicons now show correctly in browser tabs
- OG/Twitter images work for social sharing
- Apple touch icon works for iOS home screen
- Hero LCP image served correctly

## Test Plan
- [x] Local build: verified all files present in `.next/standalone/public/`
- [ ] CI passes
- [ ] After deploy: `curl -sI https://dixis.gr/favicon-32.png` returns 200