### PR TITLE
feat: add cultivation type filter to products page

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import { ProductCard } from '@/components/ProductCard';
 import { CategoryStrip } from '@/components/CategoryStrip';
+import { CultivationFilter } from '@/components/CultivationFilter';
 import { ProductSearchInput } from '@/components/ProductSearchInput';
 import { DEMO_PRODUCTS } from '@/data/demoProducts';
 import { getServerApiUrl } from '@/env';
@@ -20,6 +21,7 @@ type ApiItem = {
   categorySlug?: string;
   categorySlugs?: string[];
   stock?: number | null;
+  cultivationType?: string | null;
 };
 
 /**
@@ -34,7 +36,8 @@ type ApiItem = {
  */
 async function getData(
   search?: string,
-  category?: string
+  category?: string,
+  cultivationType?: string
 ): Promise<{ items: ApiItem[]; total: number; isDemo: boolean; apiTotal: number }> {
   const isServer = typeof window === 'undefined';
   const base = isServer
@@ -50,6 +53,9 @@ async function getData(
     }
     if (category) {
       params.set('category', category);
+    }
+    if (cultivationType) {
+      params.set('cultivation_type', cultivationType);
     }
 
     const res = await fetch(`${base}/public/products?${params.toString()}`, {
@@ -88,6 +94,7 @@ async function getData(
       categorySlug: p.categories?.[0]?.slug || p.category || null,
       categorySlugs: p.categories?.map((c: any) => c.slug) || [],
       stock: typeof p.stock === 'number' ? p.stock : null,
+      cultivationType: p.cultivation_type || null,
     }));
 
     return { items, total: items.length, isDemo: false, apiTotal };
@@ -168,20 +175,34 @@ function filterDemoBySearch(items: ApiItem[], search: string): ApiItem[] {
 }
 
 interface PageProps {
-  searchParams: Promise<{ cat?: string; search?: string }>;
+  searchParams: Promise<{ cat?: string; search?: string; cult?: string }>;
 }
 
 export default async function Page({ searchParams }: PageProps) {
   const params = await searchParams;
   const categoryFilter = params.cat || null;
   const searchQuery = params.search || null;
+  const cultivationFilter = params.cult || null;
 
-  // Fetch products (server-side filtering for category + search)
+  // Fetch products (server-side filtering for category + search + cultivation)
   const { items, isDemo, apiTotal } = await getData(
     searchQuery || undefined,
-    categoryFilter || undefined
+    categoryFilter || undefined,
+    cultivationFilter || undefined
   );
   const total = items.length;
+
+  // Fetch ALL products (without cult filter) to build cultivation counts for the strip
+  const allForCounts = cultivationFilter
+    ? await getData(searchQuery || undefined, categoryFilter || undefined)
+    : { items };
+  const cultivationCounts: Record<string, number> = {};
+  for (const item of allForCounts.items) {
+    if (item.cultivationType) {
+      cultivationCounts[item.cultivationType] = (cultivationCounts[item.cultivationType] || 0) + 1;
+    }
+  }
+  const hasCultivationData = Object.keys(cultivationCounts).length > 0;
 
   // Fetch active categories from real data (for the strip)
   const activeCategories = await getActiveCategories();
@@ -193,6 +214,9 @@ export default async function Page({ searchParams }: PageProps) {
     }
     if (searchQuery) {
       return `Δεν βρέθηκαν προϊόντα για "${searchQuery}".`;
+    }
+    if (cultivationFilter) {
+      return 'Δεν υπάρχουν προϊόντα με αυτόν τον τρόπο καλλιέργειας.';
     }
     if (categoryFilter) {
       return 'Δεν υπάρχουν προϊόντα σε αυτή την κατηγορία.';
@@ -227,7 +251,7 @@ export default async function Page({ searchParams }: PageProps) {
         </div>
 
         {/* Category Strip */}
-        <div className="mb-6">
+        <div className="mb-4">
           <Suspense fallback={<div className="h-10 bg-neutral-100 rounded animate-pulse" />}>
             <CategoryStrip
               selectedCategory={categoryFilter}
@@ -235,6 +259,18 @@ export default async function Page({ searchParams }: PageProps) {
             />
           </Suspense>
         </div>
+
+        {/* Cultivation Type Filter — only shown when products have cultivation data */}
+        {hasCultivationData && (
+          <div className="mb-6">
+            <Suspense fallback={null}>
+              <CultivationFilter
+                selectedCultivation={cultivationFilter}
+                availableCounts={cultivationCounts}
+              />
+            </Suspense>
+          </div>
+        )}
 
         {items.length > 0 ? (
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">

--- a/frontend/src/components/CultivationFilter.tsx
+++ b/frontend/src/components/CultivationFilter.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Leaf, Sprout, Sparkles, Wheat, FlaskConical, LayoutGrid } from 'lucide-react';
+
+export type CultivationType =
+  | 'conventional'
+  | 'organic_certified'
+  | 'organic_transitional'
+  | 'biodynamic'
+  | 'traditional_natural'
+  | 'other';
+
+interface CultivationOption {
+  value: CultivationType;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  color: string; // active bg + text color classes
+}
+
+const CULTIVATION_OPTIONS: CultivationOption[] = [
+  {
+    value: 'organic_certified',
+    label: 'Βιολογική',
+    icon: Leaf,
+    color: 'bg-green-600 text-white',
+  },
+  {
+    value: 'organic_transitional',
+    label: 'Μεταβατική',
+    icon: Sprout,
+    color: 'bg-lime-600 text-white',
+  },
+  {
+    value: 'biodynamic',
+    label: 'Βιοδυναμική',
+    icon: Sparkles,
+    color: 'bg-purple-600 text-white',
+  },
+  {
+    value: 'traditional_natural',
+    label: 'Παραδοσιακή',
+    icon: Wheat,
+    color: 'bg-amber-600 text-white',
+  },
+  {
+    value: 'conventional',
+    label: 'Συμβατική',
+    icon: FlaskConical,
+    color: 'bg-neutral-600 text-white',
+  },
+];
+
+interface CultivationFilterProps {
+  selectedCultivation?: string | null;
+  /** Map of cultivation_type -> count of products */
+  availableCounts?: Record<string, number>;
+}
+
+export function CultivationFilter({
+  selectedCultivation,
+  availableCounts,
+}: CultivationFilterProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const current = selectedCultivation ?? searchParams.get('cult');
+
+  // Only show options that have at least 1 product
+  const visibleOptions = availableCounts
+    ? CULTIVATION_OPTIONS.filter((opt) => (availableCounts[opt.value] || 0) > 0)
+    : CULTIVATION_OPTIONS;
+
+  // If no products have cultivation_type at all, don't render the filter
+  if (visibleOptions.length === 0) return null;
+
+  const handleClick = (value: string | null) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set('cult', value);
+    } else {
+      params.delete('cult');
+    }
+    router.push(`/products?${params.toString()}`);
+  };
+
+  return (
+    <div className="w-full">
+      <div className="flex items-center gap-2 mb-2">
+        <Leaf className="w-4 h-4 text-primary" />
+        <span className="text-xs font-semibold text-neutral-500 uppercase tracking-wider">
+          Τρόπος Καλλιέργειας
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {/* "All" option */}
+        <button
+          onClick={() => handleClick(null)}
+          className={`
+            flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
+            transition-all duration-200
+            ${
+              !current
+                ? 'bg-primary text-white shadow-sm'
+                : 'bg-white text-neutral-600 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale'
+            }
+          `}
+        >
+          <LayoutGrid className="w-3.5 h-3.5" />
+          <span>Όλοι</span>
+        </button>
+
+        {visibleOptions.map((opt) => {
+          const Icon = opt.icon;
+          const isSelected = current === opt.value;
+          const count = availableCounts?.[opt.value] || 0;
+
+          return (
+            <button
+              key={opt.value}
+              onClick={() => handleClick(opt.value)}
+              className={`
+                flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
+                transition-all duration-200
+                ${
+                  isSelected
+                    ? `${opt.color} shadow-sm`
+                    : 'bg-white text-neutral-600 border border-neutral-200 hover:border-neutral-300 hover:bg-neutral-50'
+                }
+              `}
+            >
+              <Icon className="w-3.5 h-3.5" />
+              <span>{opt.label}</span>
+              {count > 0 && (
+                <span
+                  className={`ml-0.5 text-[10px] ${
+                    isSelected ? 'opacity-80' : 'text-neutral-400'
+                  }`}
+                >
+                  ({count})
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `CultivationFilter` component with pill-style buttons (Βιολογική, Μεταβατική, Βιοδυναμική, Παραδοσιακή, Συμβατική)
- Server-side filtering via `?cultivation_type=` param (Laravel backend already supports this)
- Counts shown per cultivation type; filter auto-hides when no products have data
- Empty state message for "no products with this cultivation method"
- Production data updated: 17 products now have cultivation_type values

## Test plan
- [ ] Visit `/products` — cultivation filter strip visible below category strip
- [ ] Click "Βιολογική" — shows 8 products with `organic_certified`
- [ ] Click "Παραδοσιακή" — shows 4 products with `traditional_natural`
- [ ] Click "Συμβατική" — shows 5 products with `conventional`
- [ ] Click "Όλοι" — resets to show all 17 products
- [ ] Filter works in combination with category filter
- [ ] `tsc --noEmit` — 0 errors
- [ ] `npm run build` — passes