### PR TITLE
fix: producer product UX — auto-slug, image upload auth, storage path

### DIFF
--- a/frontend/src/app/api/me/uploads/route.ts
+++ b/frontend/src/app/api/me/uploads/route.ts
@@ -6,9 +6,36 @@ export const runtime = 'nodejs';
 const ALLOWED = ['image/jpeg', 'image/png', 'image/webp'];
 const MAX = 5 * 1024 * 1024; // 5MB limit
 
+/**
+ * Validate Laravel Sanctum Bearer token by calling Laravel /api/v1/user.
+ * Returns true if the token is valid (any authenticated role).
+ */
+async function validateLaravelToken(req: Request): Promise<boolean> {
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) return false;
+
+  const laravelBase = process.env.NEXT_PUBLIC_API_BASE_URL || process.env.LARAVEL_API_URL || 'http://127.0.0.1:8001/api/v1';
+  try {
+    const resp = await fetch(`${laravelBase}/user`, {
+      headers: {
+        'Authorization': authHeader,
+        'Accept': 'application/json',
+      },
+    });
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
+
 export async function POST(req: Request) {
+  // Auth: Support both admin phone-session AND Laravel Sanctum Bearer token
   const phone = await getSessionPhone();
-  if (!phone) return new NextResponse('Auth required', { status: 401 });
+  const hasLaravelAuth = !phone ? await validateLaravelToken(req) : false;
+
+  if (!phone && !hasLaravelAuth) {
+    return new NextResponse('Auth required', { status: 401 });
+  }
 
   const form = await (req as any).formData().catch((): null => null);
   if (!form) return NextResponse.json({ error: 'No formdata' }, { status: 400 });

--- a/frontend/src/app/my/products/[id]/edit/page.tsx
+++ b/frontend/src/app/my/products/[id]/edit/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useParams } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
 import UploadImage from '@/components/UploadImage.client';
 import { apiClient } from '@/lib/api';
+import { greekToSlug } from '@/lib/slugify';
 
 type Category = {
   id: string;
@@ -40,6 +41,7 @@ function EditProductContent() {
   // Form state
   const [title, setTitle] = useState('');
   const [slug, setSlug] = useState('');
+  const [showSlug, setShowSlug] = useState(false);
   const [category, setCategory] = useState('');
   const [unit, setUnit] = useState('');
   const [description, setDescription] = useState('');
@@ -173,33 +175,46 @@ function EditProductContent() {
                 placeholder="π.χ. Βιολογικές Ντομάτες Κρήτης"
                 data-testid="title-input"
               />
+              {slug && (
+                <p className="mt-1 text-sm text-neutral-500">
+                  URL: /products/<span className="font-mono text-neutral-700">{slug}</span>
+                  {' '}
+                  <button
+                    type="button"
+                    onClick={() => setShowSlug(!showSlug)}
+                    className="text-primary hover:text-primary-light underline"
+                  >
+                    {showSlug ? 'Απόκρυψη' : 'Επεξεργασία'}
+                  </button>
+                </p>
+              )}
             </div>
 
-            <div>
-              <label htmlFor="slug" className="block text-sm font-medium text-neutral-700 mb-1">
-                Όνομα (slug) *
-              </label>
-              <input
-                id="slug"
-                type="text"
-                value={slug}
-                onChange={(e) => {
-                  // Auto-normalize: lowercase, replace spaces with dashes, remove invalid chars
-                  const normalized = e.target.value
-                    .toLowerCase()
-                    .replace(/\s+/g, '-')
-                    .replace(/[^a-z0-9-]/g, '');
-                  setSlug(normalized);
-                }}
-                required
-                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
-                placeholder="π.χ. biologikes-tomates"
-                data-testid="slug-input"
-              />
-              <p className="mt-1 text-sm text-neutral-500">
-                Χρησιμοποιείται στο URL (μόνο λατινικά, παύλες)
-              </p>
-            </div>
+            {showSlug && (
+              <div>
+                <label htmlFor="slug" className="block text-sm font-medium text-neutral-700 mb-1">
+                  URL Προϊόντος (slug)
+                </label>
+                <input
+                  id="slug"
+                  type="text"
+                  value={slug}
+                  onChange={(e) => {
+                    const normalized = e.target.value
+                      .toLowerCase()
+                      .replace(/\s+/g, '-')
+                      .replace(/[^a-z0-9-]/g, '');
+                    setSlug(normalized);
+                  }}
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                  placeholder="π.χ. biologikes-tomates"
+                  data-testid="slug-input"
+                />
+                <p className="mt-1 text-sm text-neutral-500">
+                  Χρησιμοποιείται στο URL (μόνο λατινικά, παύλες)
+                </p>
+              </div>
+            )}
 
             <div className="grid grid-cols-2 gap-4">
               <div>

--- a/frontend/src/app/my/products/create/page.tsx
+++ b/frontend/src/app/my/products/create/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
 import UploadImage from '@/components/UploadImage.client';
 import { apiClient } from '@/lib/api';
+import { greekToSlug } from '@/lib/slugify';
 
 type Category = {
   id: string;
@@ -46,6 +47,8 @@ function CreateProductContent() {
   // Form state
   const [title, setTitle] = useState('');
   const [slug, setSlug] = useState('');
+  const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
+  const [showSlug, setShowSlug] = useState(false);
   const [category, setCategory] = useState('');
   const [unit, setUnit] = useState('');
   const [description, setDescription] = useState('');
@@ -113,39 +116,58 @@ function CreateProductContent() {
                 id="title"
                 type="text"
                 value={title}
-                onChange={(e) => setTitle(e.target.value)}
+                onChange={(e) => {
+                  setTitle(e.target.value);
+                  if (!slugManuallyEdited) {
+                    setSlug(greekToSlug(e.target.value));
+                  }
+                }}
                 required
                 className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="π.χ. Βιολογικές Ντομάτες Κρήτης"
                 data-testid="title-input"
               />
+              {slug && (
+                <p className="mt-1 text-sm text-neutral-500">
+                  URL: /products/<span className="font-mono text-neutral-700">{slug}</span>
+                  {' '}
+                  <button
+                    type="button"
+                    onClick={() => setShowSlug(!showSlug)}
+                    className="text-primary hover:text-primary-light underline"
+                  >
+                    {showSlug ? 'Απόκρυψη' : 'Επεξεργασία'}
+                  </button>
+                </p>
+              )}
             </div>
 
-            <div>
-              <label htmlFor="slug" className="block text-sm font-medium text-neutral-700 mb-1">
-                Όνομα (slug) *
-              </label>
-              <input
-                id="slug"
-                type="text"
-                value={slug}
-                onChange={(e) => {
-                  // Auto-normalize: lowercase, replace spaces with dashes, remove invalid chars
-                  const normalized = e.target.value
-                    .toLowerCase()
-                    .replace(/\s+/g, '-')
-                    .replace(/[^a-z0-9-]/g, '');
-                  setSlug(normalized);
-                }}
-                required
-                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
-                placeholder="π.χ. biologikes-tomates"
-                data-testid="slug-input"
-              />
-              <p className="mt-1 text-sm text-neutral-500">
-                Χρησιμοποιείται στο URL (μόνο λατινικά, παύλες)
-              </p>
-            </div>
+            {showSlug && (
+              <div>
+                <label htmlFor="slug" className="block text-sm font-medium text-neutral-700 mb-1">
+                  URL Προϊόντος (slug)
+                </label>
+                <input
+                  id="slug"
+                  type="text"
+                  value={slug}
+                  onChange={(e) => {
+                    const normalized = e.target.value
+                      .toLowerCase()
+                      .replace(/\s+/g, '-')
+                      .replace(/[^a-z0-9-]/g, '');
+                    setSlug(normalized);
+                    setSlugManuallyEdited(true);
+                  }}
+                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                  placeholder="π.χ. biologikes-tomates"
+                  data-testid="slug-input"
+                />
+                <p className="mt-1 text-sm text-neutral-500">
+                  Χρησιμοποιείται στο URL (μόνο λατινικά, παύλες). Αφήστε κενό για αυτόματη δημιουργία.
+                </p>
+              </div>
+            )}
 
             <div className="grid grid-cols-2 gap-4">
               <div>

--- a/frontend/src/components/UploadImage.client.tsx
+++ b/frontend/src/components/UploadImage.client.tsx
@@ -21,7 +21,13 @@ export default function UploadImage({ value, onChange, accept='image/*', maxMB=5
     try{
       const fd = new FormData();
       fd.append('file', file);
-      const r = await fetch('/api/me/uploads', { method:'POST', body: fd });
+      // Include Bearer token for producer/consumer auth (Laravel Sanctum)
+      const headers: Record<string, string> = {};
+      if (typeof window !== 'undefined') {
+        const token = localStorage.getItem('auth_token');
+        if (token) headers['Authorization'] = `Bearer ${token}`;
+      }
+      const r = await fetch('/api/me/uploads', { method:'POST', body: fd, headers });
       const j = await r.json();
       if(!r.ok){ setErr(j?.error||'Σφάλμα ανεβάσματος'); return; }
       onChange(j.url);

--- a/frontend/src/lib/media/storage.ts
+++ b/frontend/src/lib/media/storage.ts
@@ -23,15 +23,28 @@ async function maybeProcess(buf: Uint8Array, mime: string): Promise<Uint8Array>{
 export async function putObjectFs(data: Buf, mime: string): Promise<PutResult>{
   const { writeFile, mkdir } = await import('fs/promises');
   const { join } = await import('path');
+  const { existsSync } = await import('fs');
   const raw = data instanceof Uint8Array ? data : Buffer.from(data as ArrayBuffer);
   const processed = await maybeProcess(raw, mime);
   const hash = sha16(processed);
   const ext = extFromMime(mime);
   const folder = yyyymm();
   const key = `${hash}.${ext}`;
-  const dir = join(process.cwd(), 'frontend', 'public', 'uploads', folder);
-  await mkdir(dir, { recursive: true });
-  await writeFile(join(dir, key), processed);
+  // Smart path detection: works in dev (repo root or frontend/), standalone mode, or production
+  const cwd = process.cwd();
+  let publicDir: string;
+  if (existsSync(join(cwd, 'public'))) {
+    // CWD has public/ — use it directly (standalone mode, or frontend/ cwd)
+    publicDir = join(cwd, 'public', 'uploads', folder);
+  } else if (existsSync(join(cwd, 'frontend', 'public'))) {
+    // Repo root — prefix with frontend/
+    publicDir = join(cwd, 'frontend', 'public', 'uploads', folder);
+  } else {
+    // Fallback — try cwd/public anyway
+    publicDir = join(cwd, 'public', 'uploads', folder);
+  }
+  await mkdir(publicDir, { recursive: true });
+  await writeFile(join(publicDir, key), processed);
   return { url: `/uploads/${folder}/${key}`, key: `uploads/${folder}/${key}` };
 }
 

--- a/frontend/src/lib/slugify.ts
+++ b/frontend/src/lib/slugify.ts
@@ -1,0 +1,39 @@
+/**
+ * Greek-to-Latin transliteration map for URL slug generation.
+ * Covers all Greek letters including accented forms.
+ */
+const GREEK_TO_LATIN: Record<string, string> = {
+  // Lowercase
+  'α': 'a', 'β': 'v', 'γ': 'g', 'δ': 'd', 'ε': 'e', 'ζ': 'z',
+  'η': 'i', 'θ': 'th', 'ι': 'i', 'κ': 'k', 'λ': 'l', 'μ': 'm',
+  'ν': 'n', 'ξ': 'x', 'ο': 'o', 'π': 'p', 'ρ': 'r', 'σ': 's',
+  'ς': 's', 'τ': 't', 'υ': 'y', 'φ': 'f', 'χ': 'ch', 'ψ': 'ps',
+  'ω': 'o',
+  // Uppercase
+  'Α': 'a', 'Β': 'v', 'Γ': 'g', 'Δ': 'd', 'Ε': 'e', 'Ζ': 'z',
+  'Η': 'i', 'Θ': 'th', 'Ι': 'i', 'Κ': 'k', 'Λ': 'l', 'Μ': 'm',
+  'Ν': 'n', 'Ξ': 'x', 'Ο': 'o', 'Π': 'p', 'Ρ': 'r', 'Σ': 's',
+  'Τ': 't', 'Υ': 'y', 'Φ': 'f', 'Χ': 'ch', 'Ψ': 'ps', 'Ω': 'o',
+  // Accented lowercase
+  'ά': 'a', 'έ': 'e', 'ή': 'i', 'ί': 'i', 'ό': 'o', 'ύ': 'y',
+  'ώ': 'o', 'ϊ': 'i', 'ϋ': 'y', 'ΐ': 'i', 'ΰ': 'y',
+  // Accented uppercase
+  'Ά': 'a', 'Έ': 'e', 'Ή': 'i', 'Ί': 'i', 'Ό': 'o', 'Ύ': 'y',
+  'Ώ': 'o', 'Ϊ': 'i', 'Ϋ': 'y',
+};
+
+/**
+ * Convert a Greek (or mixed) string to a URL-safe slug.
+ * "Βιολογικές Ντομάτες Κρήτης" → "viologikes-ntomates-kritis"
+ */
+export function greekToSlug(text: string): string {
+  return text
+    .split('')
+    .map((char) => GREEK_TO_LATIN[char] ?? char)
+    .join('')
+    .toLowerCase()
+    .replace(/\s+/g, '-')       // spaces → dashes
+    .replace(/[^a-z0-9-]/g, '') // remove non-alphanumeric
+    .replace(/-+/g, '-')        // collapse multiple dashes
+    .replace(/^-|-$/g, '');     // trim leading/trailing dashes
+}


### PR DESCRIPTION
## Summary
- **Auto-slug generation**: Greek producers no longer need to manually type Latin URL slugs. The `greekToSlug()` transliteration function auto-converts Greek titles (e.g., "Βιολογικές Ντομάτες" → "viologikes-ntomates"). Slug field is hidden by default with an edit option for advanced users.
- **Image upload auth fix**: The `/api/me/uploads` endpoint only supported admin phone-session auth. Producers using Laravel Sanctum Bearer tokens got 401 errors when uploading product images. Now supports both auth methods.
- **Storage path fix**: `putObjectFs()` incorrectly double-prefixed with `frontend/` on production standalone mode. Now auto-detects whether cwd has `public/` or needs `frontend/public/` prefix.

## Files Changed (6 files, ~180 LOC)
| File | Change |
|------|--------|
| `frontend/src/lib/slugify.ts` | NEW — Greek→Latin transliteration utility |
| `frontend/src/app/my/products/create/page.tsx` | Auto-slug from title, hide slug field |
| `frontend/src/app/my/products/[id]/edit/page.tsx` | Same slug UX as create page |
| `frontend/src/app/api/me/uploads/route.ts` | Support Sanctum Bearer token auth |
| `frontend/src/components/UploadImage.client.tsx` | Send auth token with upload requests |
| `frontend/src/lib/media/storage.ts` | Smart cwd detection for upload path |

## Test Plan
- [ ] Greek title auto-generates Latin slug on product create page
- [ ] Slug field hidden by default, "Επεξεργασία" reveals it
- [ ] Producer can upload product image (was 401 before this fix)
- [ ] Build succeeds with no new TypeScript errors
- [ ] Existing admin image upload still works

## Context
Part of **PRIORITY-PLAN Phase C2** — Producer Product Upload UX.
Also includes A3 seed data cleanup (product images added via production tinker).