### PR TITLE
docs: update AGENT-STATE + PRIORITY-PLAN after C1/C2/A3 completion

### DIFF
--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -1,6 +1,6 @@
 # AGENT-STATE — Dixis Canonical Entry Point
 
-**Updated**: 2026-02-16 (Infra fixes + Cultivation Filter deployed)
+**Updated**: 2026-02-16 (Producer Launch Prep C1/C2/A3 complete + deployed)
 
 > **This is THE entry point.** Read this first on every agent session. Single source of truth.
 
@@ -39,7 +39,7 @@
 
 ## WIP (max 1)
 
-**Producer Launch Prep** — See `docs/PRIORITY-PLAN.md`
+**None** — All code tasks from Producer Launch Prep complete (Phases A3, B, C done). Remaining items are owner tasks: A1 (Plausible analytics), C3 (Quick start guide), D (Post-launch monitoring). See `docs/PRIORITY-PLAN.md`.
 
 ---
 
@@ -75,6 +75,7 @@
 
 ## Recently Done (last 10)
 
+- **PRODUCER-LAUNCH-PREP-C2** — Phase C complete: (C1) Full producer registration flow tested E2E on production (register→onboard→approve→create product→visible in catalog). (C2) Auto-slug from Greek titles (greekToSlug transliteration), image upload auth fixed for producers (Sanctum Bearer token support), storage path fixed for standalone mode, leaflet dependency fixed. (A3) Seed data verified, Unsplash images added to all 17 products. (PR #2937, deployed 2026-02-16) ✅
 - **CULTIVATION-FILTER-UI** — Pill-style cultivation type filter on /products page (Βιολογική, Παραδοσιακή, Συμβατική). Server-side filtering via Laravel ?cultivation_type= param. Counts per type, auto-hidden when no data. All 17 products now have cultivation_type values. (PR #2930, deployed 2026-02-16) ✅
 - **FAVICON-FIX** — Standalone build missing public/ files (favicons, hero images). Fixed postbuild to copy public/. to standalone output. (PR #2929, deployed 2026-02-16) ✅
 - **PM2-ENV-FIX** — Next.js standalone mode doesn't load .env at runtime. Fixed ecosystem.config.js to parse shared env file and inject vars via PM2 env block. (PR #2927, deployed 2026-02-16) ✅

--- a/docs/PRIORITY-PLAN.md
+++ b/docs/PRIORITY-PLAN.md
@@ -53,7 +53,7 @@ We have a technically solid MVP+ with working:
 - Ensure categories make sense for real Greek products
 - Verify product images aren't broken
 **Effort:** S (1 PR, ~50 LOC)
-**Status:** `[ ]`
+**Status:** `[x]` Done — PR #2937. Reviewed all 5 seed producers + 17 products. Added Unsplash images to 10 products that were missing them. All 17 products now have images.
 
 ---
 
@@ -107,7 +107,7 @@ We have a technically solid MVP+ with working:
 - Error messages clear and in Greek
 - Mobile-friendly forms
 **Effort:** Testing + fixes
-**Status:** `[ ]`
+**Status:** `[x]` Done — PR #2937. Full flow tested on production: register → onboarding → admin approval → product creation → visible in catalog. All steps verified via API. Test data cleaned up after.
 
 ### C2: Product Upload UX
 **Why:** Producers will add products. This must be straightforward.
@@ -117,7 +117,7 @@ We have a technically solid MVP+ with working:
 - Image upload: works? reasonable file size limits?
 - Preview before publish?
 **Effort:** S-M (fixes if needed)
-**Status:** `[ ]`
+**Status:** `[x]` Done — PR #2937. Fixed 3 issues: (1) Slug field confusing for Greek producers → auto-generate from title via greekToSlug() transliteration, hidden by default. (2) Image upload 401 for producers → added Laravel Sanctum Bearer token support to upload route. (3) Storage path wrong in standalone mode → smart CWD detection. Also fixed pre-existing leaflet build blocker.
 
 ### C3: Quick Start Guide Content
 **Why:** Producers need a "what do I do first?" guide.
@@ -177,7 +177,7 @@ By end of Day 3:
 - [ ] 3-5 real producers invited and onboarded
 - [ ] At least 1 producer has added real products with real photos
 - [x] Platform visually polished enough to not embarrass us (6 PRs deployed)
-- [~] Zero critical bugs in producer/consumer flows — pages load, APIs work, manual flow test pending
+- [x] Zero critical bugs in producer/consumer flows — C1 full flow tested, C2 upload/slug/auth fixed, all pages 200 OK
 - [ ] Quick start guide ready for producers (owner task)
 
 ---
@@ -186,8 +186,8 @@ By end of Day 3:
 
 ```
 Day 1: ✅ Analytics CSP + UI Polish (homepage, dashboard, all producer pages, all consumer pages)
-Day 2: Manual flow testing + Seed cleanup + Plausible activation (owner)
-Day 3: Producer onboarding testing + fixes + INVITE REAL PRODUCERS
+Day 2: ✅ Manual flow testing + Seed cleanup + C1/C2/A3 all done (PR #2937 deployed)
+Day 3: INVITE REAL PRODUCERS + Plausible activation (owner) + Quick start guide (owner)
 Day 3+: Monitor, collect feedback, fix what breaks
 ```
 
@@ -200,5 +200,7 @@ Day 3+: Monitor, collect feedback, fix what breaks
 | #2918 | Producer dashboard brand palette | 94 |
 | #2920 | All producer/my pages brand palette (9 files) | 474 |
 | #2921 | All consumer pages brand palette (10 files) | 278 |
+| #2930 | Cultivation filter UI | ~100 |
+| #2937 | Producer launch prep C2: auto-slug, upload auth fix, seed images | 178 |
 
 **The next feature we build should be the one our first real producer asks for.**


### PR DESCRIPTION
## Summary
- Mark Phase C tasks (C1 registration flow test, C2 product upload UX, A3 seed data) as done in PRIORITY-PLAN.md
- Clear WIP in AGENT-STATE.md — remaining items are owner tasks (analytics, quick start guide)
- Add PR #2937 to delivered PRs table

## Test plan
- [x] Docs-only change, no code impact