### PR TITLE
feat: add IBAN + bank details to Producer (PAYOUT-01)

### DIFF
--- a/backend/app/Http/Requests/UpdateProducerRequest.php
+++ b/backend/app/Http/Requests/UpdateProducerRequest.php
@@ -33,6 +33,9 @@ class UpdateProducerRequest extends FormRequest
             'business_name' => 'nullable|string|max:255',
             'tax_id' => 'nullable|string|max:20',
             'tax_office' => 'nullable|string|max:255',
+            // Pass PAYOUT-01: IBAN for producer settlements (any EU IBAN format)
+            'iban' => ['nullable', 'string', 'max:34', 'regex:/^[A-Z]{2}\d{2}[A-Z0-9]{4,30}$/'],
+            'bank_account_holder' => 'nullable|string|max:255',
             'description' => 'nullable|string',
             'location' => 'nullable|string|max:255',
             'address' => 'nullable|string|max:500',

--- a/backend/app/Http/Resources/ProducerResource.php
+++ b/backend/app/Http/Resources/ProducerResource.php
@@ -14,7 +14,14 @@ class ProducerResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return [
+        // Pass PAYOUT-01: IBAN visible only to the producer themselves or admin
+        $user = $request->user();
+        $isOwnerOrAdmin = $user && (
+            ($user->producer && $user->producer->id === $this->id) ||
+            !empty($user->is_admin)
+        );
+
+        return array_merge([
             'id' => $this->id,
             'name' => $this->name,
             'slug' => $this->slug,
@@ -42,6 +49,10 @@ class ProducerResource extends JsonResource
             'is_active' => $this->is_active,
             'created_at' => $this->created_at?->toISOString(),
             'updated_at' => $this->updated_at?->toISOString(),
-        ];
+        ], $isOwnerOrAdmin ? [
+            // Pass PAYOUT-01: Banking details (owner/admin only)
+            'iban' => $this->iban,
+            'bank_account_holder' => $this->bank_account_holder,
+        ] : []);
     }
 }

--- a/backend/app/Models/Producer.php
+++ b/backend/app/Models/Producer.php
@@ -16,6 +16,8 @@ class Producer extends Model
         'business_name',
         'tax_id',
         'tax_office',
+        'iban',
+        'bank_account_holder',
         'description',
         'location',
         'address',

--- a/backend/database/migrations/2026_02_16_300000_add_iban_to_producers_table.php
+++ b/backend/database/migrations/2026_02_16_300000_add_iban_to_producers_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Pass PAYOUT-01: Add IBAN + bank account holder to producers for payout settlements.
+ * Greek IBAN: GR + 25 digits = 27 chars total. Max 34 chars covers all EU IBANs.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('producers', function (Blueprint $table) {
+            if (! Schema::hasColumn('producers', 'iban')) {
+                $table->string('iban', 34)->nullable()->after('tax_office');
+            }
+            if (! Schema::hasColumn('producers', 'bank_account_holder')) {
+                $table->string('bank_account_holder', 255)->nullable()->after('iban');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('producers', function (Blueprint $table) {
+            $table->dropColumn(['iban', 'bank_account_holder']);
+        });
+    }
+};

--- a/frontend/src/app/producer/settings/page.tsx
+++ b/frontend/src/app/producer/settings/page.tsx
@@ -20,6 +20,9 @@ interface SettingsFormData {
   location: string;
   tax_id: string;
   tax_office: string;
+  // Pass PAYOUT-01: Banking details for settlements
+  iban: string;
+  bank_account_holder: string;
   social_media: string[];
   // Pass PRODUCER-THRESHOLD-POSTALCODE-01: Per-producer free shipping threshold
   free_shipping_threshold_eur: string; // String for form input, converted on submit
@@ -56,6 +59,8 @@ function ProducerSettingsContent() {
     location: '',
     tax_id: '',
     tax_office: '',
+    iban: '',
+    bank_account_holder: '',
     social_media: [''],
     free_shipping_threshold_eur: '', // Empty means use system default
   });
@@ -86,6 +91,9 @@ function ProducerSettingsContent() {
           location: producer.location || '',
           tax_id: (producer as any).tax_id || '',
           tax_office: (producer as any).tax_office || '',
+          // Pass PAYOUT-01: Banking details
+          iban: (producer as any).iban || '',
+          bank_account_holder: (producer as any).bank_account_holder || '',
           social_media: (producer as any).social_media && (producer as any).social_media.length > 0
             ? (producer as any).social_media
             : [''],
@@ -491,6 +499,51 @@ function ProducerSettingsContent() {
                       + Προσθήκη Συνδέσμου
                     </button>
                   </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Banking Details — Pass PAYOUT-01 */}
+            <div>
+              <h2 className="text-lg font-semibold text-neutral-900 mb-4">Τραπεζικά Στοιχεία</h2>
+              <p className="text-sm text-neutral-500 mb-4">
+                Απαιτείται για τις εκκαθαρίσεις πωλήσεων. Τα στοιχεία αυτά είναι ορατά μόνο σε εσάς και τη διαχείριση.
+              </p>
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor="iban" className="block text-sm font-medium text-neutral-700 mb-1">
+                    IBAN
+                  </label>
+                  <input
+                    id="iban"
+                    type="text"
+                    value={formData.iban}
+                    onChange={(e) => {
+                      // Auto-format: uppercase, remove spaces
+                      const cleaned = e.target.value.toUpperCase().replace(/\s/g, '');
+                      setFormData({ ...formData, iban: cleaned });
+                    }}
+                    maxLength={34}
+                    className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary font-mono"
+                    placeholder="GR1601101250000000012300695"
+                  />
+                  <p className="mt-1 text-sm text-neutral-500">
+                    Ελληνικό IBAN (27 χαρακτήρες, ξεκινά με GR)
+                  </p>
+                </div>
+
+                <div>
+                  <label htmlFor="bank_account_holder" className="block text-sm font-medium text-neutral-700 mb-1">
+                    Δικαιούχος Λογαριασμού
+                  </label>
+                  <input
+                    id="bank_account_holder"
+                    type="text"
+                    value={formData.bank_account_holder}
+                    onChange={(e) => setFormData({ ...formData, bank_account_holder: e.target.value })}
+                    className="w-full md:w-1/2 px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                    placeholder="Ονοματεπώνυμο ή Επωνυμία"
+                  />
                 </div>
               </div>
             </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -76,6 +76,9 @@ export interface Producer {
   phone?: string;
   email?: string;
   website?: string;
+  // Pass PAYOUT-01: Banking details (visible to owner/admin only)
+  iban?: string;
+  bank_account_holder?: string;
 }
 
 export interface CartItem {


### PR DESCRIPTION
## Summary
- Add `iban` (max 34 chars) and `bank_account_holder` to producers table
- IBAN validated with EU format regex (`^[A-Z]{2}\d{2}[A-Z0-9]{4,30}$`)
- Banking details visible **only** to the producer themselves and admins (not in public profile)
- New "Τραπεζικά Στοιχεία" section in producer settings form with auto-uppercase IBAN input
- Fields are optional — collected when producer is ready for payouts

## Why
Prerequisite for payout settlements (PAYOUT-02 through PAYOUT-05). Every payout mechanism (manual bank transfer or Stripe Connect) needs the producer's IBAN.

## Files changed (105 LOC)
| File | Change |
|------|--------|
| `backend/database/migrations/…_add_iban_to_producers_table.php` | **New** — adds columns |
| `backend/app/Models/Producer.php` | Add to `$fillable` |
| `backend/app/Http/Requests/UpdateProducerRequest.php` | IBAN validation rules |
| `backend/app/Http/Resources/ProducerResource.php` | Conditional visibility |
| `frontend/src/app/producer/settings/page.tsx` | Banking details UI section |
| `frontend/src/lib/api.ts` | Add fields to Producer interface |

## Test plan
- [ ] `php artisan migrate` — columns created
- [ ] Producer settings → "Τραπεζικά Στοιχεία" section visible
- [ ] Enter IBAN (e.g. GR1601101250000000012300695) → saves correctly
- [ ] Public producer profile (`/producers/{slug}`) → IBAN NOT visible
- [ ] Admin can view producer IBAN
- [ ] TypeScript build passes (`npx tsc --noEmit`)
- [ ] Next.js build passes (`npm run build`)