### PR TITLE
feat: settlement generation command + model (PAYOUT-02)

### DIFF
--- a/backend/app/Console/Commands/GenerateSettlements.php
+++ b/backend/app/Console/Commands/GenerateSettlements.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Commission;
+use App\Models\CommissionSettlement;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Pass PAYOUT-02: Monthly settlement generation for producer payouts.
+ *
+ * Aggregates unsettled Commission records per producer into a
+ * CommissionSettlement batch. Designed to run monthly (1st of month)
+ * via scheduler, or manually via artisan.
+ *
+ * Eligibility: Commission must be linked to a delivered order AND
+ * the order must have been delivered >= $holdDays ago (default 14).
+ *
+ * Owner decisions applied:
+ * - Frequency: Monthly (1st of each month)
+ * - Minimum payout: €20
+ * - Hold period: 14 days after delivery
+ */
+class GenerateSettlements extends Command
+{
+    protected $signature = 'dixis:generate-settlements
+        {--period= : Settlement period end date (YYYY-MM-DD), defaults to last day of previous month}
+        {--hold-days=14 : Days after delivery before commission is eligible}
+        {--min-payout=20 : Minimum payout in EUR (below this, deferred to next period)}
+        {--dry-run : Preview without creating records}';
+
+    protected $description = 'Generate monthly settlement batches for producer payouts';
+
+    public function handle(): int
+    {
+        $holdDays = (int) $this->option('hold-days');
+        $minPayoutEur = (float) $this->option('min-payout');
+        $dryRun = (bool) $this->option('dry-run');
+
+        // Determine settlement period
+        $periodEnd = $this->option('period')
+            ? \Carbon\Carbon::parse($this->option('period'))
+            : now()->subMonth()->endOfMonth();
+        $periodStart = $periodEnd->copy()->startOfMonth();
+
+        // Eligibility cutoff: orders delivered at least $holdDays ago
+        $eligibleBefore = now()->subDays($holdDays);
+
+        $this->info("Settlement period: {$periodStart->toDateString()} → {$periodEnd->toDateString()}");
+        $this->info("Hold period: {$holdDays} days (eligible if delivered before {$eligibleBefore->toDateString()})");
+        $this->info("Min payout: €{$minPayoutEur}");
+        if ($dryRun) {
+            $this->warn('DRY RUN — no records will be created');
+        }
+        $this->newLine();
+
+        // Find unsettled commissions with delivered orders within the hold window
+        $eligibleCommissions = Commission::unsettled()
+            ->whereHas('order', function ($q) use ($eligibleBefore) {
+                $q->where('status', 'delivered')
+                  ->where('updated_at', '<=', $eligibleBefore);
+            })
+            ->get();
+
+        if ($eligibleCommissions->isEmpty()) {
+            $this->info('No eligible commissions found for this period.');
+            return 0;
+        }
+
+        // Group by producer
+        $byProducer = $eligibleCommissions->groupBy('producer_id');
+
+        $this->info("Found {$eligibleCommissions->count()} eligible commissions across {$byProducer->count()} producers");
+        $this->newLine();
+
+        $created = 0;
+        $deferred = 0;
+
+        foreach ($byProducer as $producerId => $commissions) {
+            $totalSalesCents = (int) round($commissions->sum('order_gross') * 100);
+            $commissionCents = (int) round($commissions->sum('platform_fee') * 100);
+            $netPayoutCents = (int) round($commissions->sum('producer_payout') * 100);
+            $orderCount = $commissions->count();
+            $netPayoutEur = $netPayoutCents / 100;
+
+            // Check minimum payout threshold
+            if ($netPayoutEur < $minPayoutEur) {
+                $this->line("  Producer #{$producerId}: €{$netPayoutEur} ({$orderCount} orders) — <comment>DEFERRED (below €{$minPayoutEur} minimum)</comment>");
+                $deferred++;
+                continue;
+            }
+
+            $this->line("  Producer #{$producerId}: €{$netPayoutEur} payout ({$orderCount} orders, €" . ($commissionCents / 100) . " commission)");
+
+            if (!$dryRun) {
+                DB::transaction(function () use ($producerId, $periodStart, $periodEnd, $totalSalesCents, $commissionCents, $netPayoutCents, $orderCount, $commissions) {
+                    $settlement = CommissionSettlement::create([
+                        'producer_id' => $producerId,
+                        'period_start' => $periodStart,
+                        'period_end' => $periodEnd,
+                        'total_sales_cents' => $totalSalesCents,
+                        'commission_cents' => $commissionCents,
+                        'net_payout_cents' => $netPayoutCents,
+                        'order_count' => $orderCount,
+                        'status' => CommissionSettlement::STATUS_PENDING,
+                    ]);
+
+                    // Link commissions to this settlement
+                    Commission::whereIn('id', $commissions->pluck('id'))
+                        ->update(['settlement_id' => $settlement->id]);
+                });
+            }
+
+            $created++;
+        }
+
+        $this->newLine();
+        $this->info("Done! Created: {$created} settlements, Deferred: {$deferred} (below minimum)");
+
+        if ($dryRun) {
+            $this->warn('This was a dry run — run without --dry-run to create records.');
+        }
+
+        return 0;
+    }
+}

--- a/backend/app/Models/Commission.php
+++ b/backend/app/Models/Commission.php
@@ -15,6 +15,7 @@ class Commission extends Model
         'platform_fee_vat',
         'producer_payout',
         'currency',
+        'settlement_id', // Pass PAYOUT-02: link to settlement batch
     ];
 
     protected $casts = [
@@ -30,5 +31,21 @@ class Commission extends Model
     public function order()
     {
         return $this->belongsTo(Order::class);
+    }
+
+    /**
+     * Pass PAYOUT-02: Get the settlement this commission belongs to.
+     */
+    public function settlement()
+    {
+        return $this->belongsTo(CommissionSettlement::class, 'settlement_id');
+    }
+
+    /**
+     * Scope: unsettled commissions (not yet assigned to a settlement).
+     */
+    public function scopeUnsettled($query)
+    {
+        return $query->whereNull('settlement_id');
     }
 }

--- a/backend/app/Models/CommissionSettlement.php
+++ b/backend/app/Models/CommissionSettlement.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Pass PAYOUT-02: Settlement model for producer payout batches.
+ *
+ * Each record represents one settlement period for one producer.
+ * Aggregates all eligible Commission records within (period_start, period_end].
+ */
+class CommissionSettlement extends Model
+{
+    protected $fillable = [
+        'producer_id',
+        'period_start',
+        'period_end',
+        'total_sales_cents',
+        'commission_cents',
+        'net_payout_cents',
+        'order_count',
+        'status',
+        'paid_at',
+        'notes',
+    ];
+
+    protected $casts = [
+        'period_start' => 'date',
+        'period_end' => 'date',
+        'total_sales_cents' => 'integer',
+        'commission_cents' => 'integer',
+        'net_payout_cents' => 'integer',
+        'order_count' => 'integer',
+        'paid_at' => 'datetime',
+    ];
+
+    /* --- Constants --- */
+
+    const STATUS_PENDING = 'PENDING';
+    const STATUS_PAID = 'PAID';
+    const STATUS_CANCELLED = 'CANCELLED';
+
+    /* --- Relationships --- */
+
+    public function producer()
+    {
+        return $this->belongsTo(Producer::class);
+    }
+
+    public function commissions()
+    {
+        return $this->hasMany(Commission::class, 'settlement_id');
+    }
+
+    /* --- Scopes --- */
+
+    public function scopePending($query)
+    {
+        return $query->where('status', self::STATUS_PENDING);
+    }
+
+    public function scopePaid($query)
+    {
+        return $query->where('status', self::STATUS_PAID);
+    }
+
+    /* --- Accessors (EUR from cents) --- */
+
+    public function getTotalSalesAttribute(): float
+    {
+        return $this->total_sales_cents / 100;
+    }
+
+    public function getCommissionAmountAttribute(): float
+    {
+        return $this->commission_cents / 100;
+    }
+
+    public function getNetPayoutAttribute(): float
+    {
+        return $this->net_payout_cents / 100;
+    }
+
+    /* --- Helpers --- */
+
+    public function markAsPaid(?string $notes = null): void
+    {
+        $this->update([
+            'status' => self::STATUS_PAID,
+            'paid_at' => now(),
+            'notes' => $notes,
+        ]);
+    }
+
+    public function markAsCancelled(?string $notes = null): void
+    {
+        $this->update([
+            'status' => self::STATUS_CANCELLED,
+            'notes' => $notes,
+        ]);
+    }
+}

--- a/backend/app/Models/Producer.php
+++ b/backend/app/Models/Producer.php
@@ -82,4 +82,20 @@ class Producer extends Model
     {
         return $this->hasMany(Product::class);
     }
+
+    /**
+     * Pass PAYOUT-02: Get commissions for this producer.
+     */
+    public function commissions()
+    {
+        return $this->hasMany(Commission::class);
+    }
+
+    /**
+     * Pass PAYOUT-02: Get settlement batches for this producer.
+     */
+    public function settlements()
+    {
+        return $this->hasMany(CommissionSettlement::class);
+    }
 }

--- a/backend/database/migrations/2026_02_16_400000_add_settlement_fields.php
+++ b/backend/database/migrations/2026_02_16_400000_add_settlement_fields.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Pass PAYOUT-02: Add settlement linking + extra fields.
+ *
+ * 1. commissions.settlement_id — FK to link commission records to settlements
+ * 2. commission_settlements.net_payout_cents — explicit payout amount
+ * 3. commission_settlements.order_count — number of orders in settlement
+ * 4. commission_settlements.paid_at — timestamp when marked as paid
+ * 5. commission_settlements.notes — admin notes (e.g., bank transfer ref)
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Add settlement_id to commissions (links each commission to a settlement batch)
+        Schema::table('commissions', function (Blueprint $table) {
+            if (! Schema::hasColumn('commissions', 'settlement_id')) {
+                $table->unsignedBigInteger('settlement_id')->nullable()->after('currency');
+                $table->index('settlement_id');
+            }
+        });
+
+        // Add extra fields to commission_settlements
+        Schema::table('commission_settlements', function (Blueprint $table) {
+            if (! Schema::hasColumn('commission_settlements', 'net_payout_cents')) {
+                $table->bigInteger('net_payout_cents')->default(0)->after('commission_cents');
+            }
+            if (! Schema::hasColumn('commission_settlements', 'order_count')) {
+                $table->unsignedInteger('order_count')->default(0)->after('net_payout_cents');
+            }
+            if (! Schema::hasColumn('commission_settlements', 'paid_at')) {
+                $table->timestamp('paid_at')->nullable()->after('status');
+            }
+            if (! Schema::hasColumn('commission_settlements', 'notes')) {
+                $table->text('notes')->nullable()->after('paid_at');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('commissions', function (Blueprint $table) {
+            $table->dropColumn('settlement_id');
+        });
+
+        Schema::table('commission_settlements', function (Blueprint $table) {
+            $table->dropColumn(['net_payout_cents', 'order_count', 'paid_at', 'notes']);
+        });
+    }
+};

--- a/backend/routes/console.php
+++ b/backend/routes/console.php
@@ -25,3 +25,19 @@ Schedule::command('producers:digest-weekly')
     ->timezone('Europe/Athens')
     ->withoutOverlapping()
     ->runInBackground();
+
+/*
+|--------------------------------------------------------------------------
+| Pass PAYOUT-02: Monthly Settlement Generation
+|--------------------------------------------------------------------------
+|
+| Runs on the 1st of each month at 06:00 Europe/Athens.
+| Aggregates delivered orders with 14-day hold into settlements.
+| Min payout: €20 (below deferred to next period).
+|
+*/
+Schedule::command('dixis:generate-settlements')
+    ->monthlyOn(1, '06:00')  // 1st of month at 06:00
+    ->timezone('Europe/Athens')
+    ->withoutOverlapping()
+    ->runInBackground();


### PR DESCRIPTION
## Summary
Monthly settlement batch system for producer payouts. Aggregates eligible Commission records per producer into `CommissionSettlement` batches.

- **CommissionSettlement model**: status tracking (PENDING/PAID/CANCELLED), EUR accessors, markAsPaid/markAsCancelled helpers
- **Migration**: `settlement_id` FK on commissions + `net_payout_cents`, `order_count`, `paid_at`, `notes` on settlements
- **Artisan command** `dixis:generate-settlements`: `--dry-run`, `--hold-days=14`, `--min-payout=20`
- **Scheduled**: monthly on 1st at 06:00 Europe/Athens

## Settlement Logic
1. Find unsettled commissions where order status = `delivered` AND delivered ≥14 days ago
2. Group by producer → aggregate totals
3. Skip if net payout < €20 (deferred to next period)
4. Create `CommissionSettlement` record + link commissions via `settlement_id`

## Owner Decisions Applied
| Parameter | Value |
|-----------|-------|
| Frequency | Monthly (1st of month) |
| Hold period | 14 days after delivery |
| Min payout | €20 |

## Depends on
- PR #2952 (PAYOUT-01: IBAN field) — for producer bank details

## Note
334 LOC (slightly over 300 guideline) — model is 103 lines of mostly declarative code.

## Test plan
- [ ] `php artisan migrate` — new columns + settlement_id FK
- [ ] `php artisan dixis:generate-settlements --dry-run` — no errors, shows "No eligible commissions"
- [ ] With test data: creates settlement records correctly
- [ ] Below-minimum settlements correctly deferred
- [ ] Commission records linked to settlement via settlement_id
- [ ] `php artisan schedule:list` — shows monthly settlement job