### PR TITLE
feat: settlement CSV export (PAYOUT-05)

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/SettlementExportController.php
+++ b/backend/app/Http/Controllers/Api/Admin/SettlementExportController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\CommissionSettlement;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Pass PAYOUT-05: CSV export of settlements for bank transfer batch.
+ *
+ * Exports pending settlements as CSV with IBAN, amount, producer name.
+ * Admin downloads this → uploads to bank portal → marks settlements as paid.
+ */
+class SettlementExportController extends Controller
+{
+    public function exportCsv(Request $request): StreamedResponse
+    {
+        if (!$request->user() || $request->user()->role !== 'admin') {
+            abort(403, 'Unauthorized');
+        }
+
+        $status = strtoupper($request->query('status', 'PENDING'));
+
+        $settlements = CommissionSettlement::with('producer:id,name,iban,bank_account_holder')
+            ->where('status', $status)
+            ->orderBy('producer_id')
+            ->get();
+
+        $filename = 'dixis-settlements-' . strtolower($status) . '-' . now()->format('Y-m-d') . '.csv';
+
+        return new StreamedResponse(function () use ($settlements) {
+            $handle = fopen('php://output', 'w');
+
+            // BOM for Excel UTF-8 compatibility
+            fwrite($handle, "\xEF\xBB\xBF");
+
+            // Header row
+            fputcsv($handle, [
+                'Settlement ID',
+                'Producer ID',
+                'Producer Name',
+                'IBAN',
+                'Account Holder',
+                'Period Start',
+                'Period End',
+                'Orders',
+                'Total Sales (EUR)',
+                'Commission (EUR)',
+                'Net Payout (EUR)',
+                'Status',
+            ], ';'); // Semicolon delimiter for EU Excel
+
+            foreach ($settlements as $s) {
+                fputcsv($handle, [
+                    $s->id,
+                    $s->producer_id,
+                    $s->producer?->name ?? '',
+                    $s->producer?->iban ?? '',
+                    $s->producer?->bank_account_holder ?? '',
+                    $s->period_start->toDateString(),
+                    $s->period_end->toDateString(),
+                    $s->order_count,
+                    number_format($s->total_sales_cents / 100, 2, '.', ''),
+                    number_format($s->commission_cents / 100, 2, '.', ''),
+                    number_format($s->net_payout_cents / 100, 2, '.', ''),
+                    $s->status,
+                ], ';');
+            }
+
+            fclose($handle);
+        }, 200, [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+            'Content-Disposition' => "attachment; filename=\"{$filename}\"",
+            'Cache-Control' => 'no-cache, no-store',
+        ]);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -415,10 +415,12 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:60,1');
     });
 
-    // Pass PAYOUT-03: Admin Settlement Dashboard
+    // Pass PAYOUT-03 + PAYOUT-05: Admin Settlement Dashboard + CSV Export
     Route::middleware('auth:sanctum')->prefix('admin/settlements')->group(function () {
         Route::get('summary', [App\Http\Controllers\Api\Admin\AdminSettlementController::class, 'summary'])
             ->middleware('throttle:60,1');
+        Route::get('export', [App\Http\Controllers\Api\Admin\SettlementExportController::class, 'exportCsv'])
+            ->middleware('throttle:10,1'); // 10 exports per minute
         Route::get('/', [App\Http\Controllers\Api\Admin\AdminSettlementController::class, 'index'])
             ->middleware('throttle:60,1');
         Route::get('{id}', [App\Http\Controllers\Api\Admin\AdminSettlementController::class, 'show'])

--- a/frontend/src/app/api/admin/settlements/export/route.ts
+++ b/frontend/src/app/api/admin/settlements/export/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8001/api/v1';
+
+async function getToken(req: NextRequest): Promise<string | undefined> {
+  const cookieStore = await cookies();
+  return cookieStore.get('auth_token')?.value || req.headers.get('authorization')?.replace('Bearer ', '') || undefined;
+}
+
+/**
+ * Pass PAYOUT-05: Proxy CSV export — streams binary CSV from Laravel to browser.
+ */
+export async function GET(req: NextRequest) {
+  const token = await getToken(req);
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const status = searchParams.get('status') || 'PENDING';
+
+  const res = await fetch(`${API_BASE}/admin/settlements/export?status=${status}`, {
+    headers: { Authorization: `Bearer ${token}`, Accept: 'text/csv' },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Export failed' }, { status: res.status });
+  }
+
+  // Stream the CSV response through
+  const csvBody = await res.arrayBuffer();
+  const contentDisposition = res.headers.get('content-disposition') || 'attachment; filename="settlements.csv"';
+
+  return new NextResponse(csvBody, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=UTF-8',
+      'Content-Disposition': contentDisposition,
+      'Cache-Control': 'no-cache, no-store',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Admin-only CSV export of settlements for bank transfer batch
- Exports IBAN, amounts, producer name for bank portal upload
- BOM for Excel UTF-8 compatibility, semicolon delimiter for EU Excel
- Filterable by status (default: PENDING)
- Next.js proxy route streams CSV binary through to browser

## Files (127 LOC)
- `backend/app/Http/Controllers/Api/Admin/SettlementExportController.php` — NEW (79 LOC)
- `backend/routes/api.php` — Add export route under admin/settlements
- `frontend/src/app/api/admin/settlements/export/route.ts` — NEW (42 LOC)

## Depends On
- PR #2954 (PAYOUT-02: CommissionSettlement model)
- PR #2955 (PAYOUT-03: Admin settlements page — export button will be added there)

## Test plan
- [ ] `GET /api/v1/admin/settlements/export` returns CSV with BOM
- [ ] CSV opens correctly in Excel with semicolon delimiter
- [ ] Non-admin gets 403
- [ ] Status filter works (PENDING/PAID/CANCELLED)
- [ ] IBAN and producer info included in export
- [ ] Frontend proxy at `/api/admin/settlements/export` triggers download