### PR TITLE
fix: stabilize E2E — add CI fallback to /products SSR fetch

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -39,10 +39,18 @@ async function getData(
   category?: string,
   cultivationType?: string
 ): Promise<{ items: ApiItem[]; total: number; isDemo: boolean; apiTotal: number }> {
+  // Pass CI-SMOKE-STABILIZE-002: In CI mode, use internal Next.js API
+  // which reads from Prisma DB (seeded with ci:seed) — same pattern as products/[id]/page.tsx
+  const isCI = process.env.CI === 'true' || process.env.NODE_ENV === 'test';
   const isServer = typeof window === 'undefined';
-  const base = isServer
-    ? getServerApiUrl()
-    : (process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1');
+  let base: string;
+  if (isCI && isServer) {
+    base = 'http://127.0.0.1:3001/api/v1';
+  } else if (isServer) {
+    base = getServerApiUrl();
+  } else {
+    base = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+  }
 
   try {
     // Build URL with all params — let the backend handle filtering
@@ -111,10 +119,17 @@ async function getData(
  * Cached at the same 60s interval.
  */
 async function getActiveCategories(): Promise<{ slug: string; name: string; count: number }[]> {
+  // Pass CI-SMOKE-STABILIZE-002: CI fallback (same as getData above)
+  const isCI = process.env.CI === 'true' || process.env.NODE_ENV === 'test';
   const isServer = typeof window === 'undefined';
-  const base = isServer
-    ? getServerApiUrl()
-    : (process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1');
+  let base: string;
+  if (isCI && isServer) {
+    base = 'http://127.0.0.1:3001/api/v1';
+  } else if (isServer) {
+    base = getServerApiUrl();
+  } else {
+    base = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+  }
 
   try {
     const res = await fetch(`${base}/public/products?per_page=100`, {


### PR DESCRIPTION
## Summary
- Fixes the **auth-nav-regression** E2E test that times out on **every** CI run
- Root cause: `/products` page SSR fetches hit Laravel (not running in CI), causing 120s timeout
- Fix: Add CI detection + fallback to Next.js internal API (same pattern as `/products/[id]`)

## Root Cause Analysis
1. E2E test navigates to `/products` via `page.goto()`
2. Next.js SSR calls `getServerApiUrl()` → Laravel backend
3. **Laravel doesn't exist in CI** → Node.js fetch hangs indefinitely
4. Playwright's `page.route()` only intercepts **client-side** requests, not SSR
5. Test hits 120s timeout → **fails every CI run**

The `/products/[id]` page already had this CI fallback (added in CI-SMOKE-STABILIZE-001), but `/products` was missed.

## Changes
- Add `isCI` detection to `getData()` and `getActiveCategories()` in `/products/page.tsx`
- In CI: route SSR fetch to `127.0.0.1:3001/api/v1` (Next.js internal API → Prisma/SQLite)
- 21 insertions, 6 deletions — 1 file

## Impact
- **Before**: auth-nav-regression fails → `--admin` bypass needed → 86 tests never run
- **After**: SSR resolves fast in CI → test passes → all 106 smoke tests can run

## Test Plan
- [ ] CI E2E (PostgreSQL) workflow passes ← **this is THE verification**
- [ ] TypeScript clean ✅
- [ ] Next.js build ✅
- [ ] No production impact (CI-only code path, guarded by `process.env.CI`)