### PR TITLE
feat(seo): add aggregateRating to product JSON-LD + catalog metadata

### DIFF
--- a/frontend/src/app/(storefront)/products/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/page.tsx
@@ -129,7 +129,15 @@ export default async function Page({ params }:{ params: Promise<{ id:string }> }
       'priceCurrency': 'EUR',
       'availability': Number(p.stock || 0) > 0 ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock',
       'url': `${baseUrl}/products/${id}`
-    }
+    },
+    // S1-02 SEO: Show star ratings in Google search results
+    ...(p.reviewsAvgRating ? {
+      'aggregateRating': {
+        '@type': 'AggregateRating',
+        'ratingValue': p.reviewsAvgRating,
+        'reviewCount': p.reviewsCount || 1
+      }
+    } : {})
   };
 
   return (

--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import type { Metadata } from 'next';
 import { ProductCard } from '@/components/ProductCard';
 import { CategoryStrip } from '@/components/CategoryStrip';
 import { CultivationFilter } from '@/components/CultivationFilter';
@@ -187,6 +188,29 @@ function filterDemoBySearch(items: ApiItem[], search: string): ApiItem[] {
       item.title.toLowerCase().includes(term) ||
       (item.producerName && item.producerName.toLowerCase().includes(term))
   );
+}
+
+// SEO: Dynamic metadata for filtered product views
+const cultivationLabels: Record<string, string> = {
+  organic_certified: 'Βιολογικά',
+  biodynamic: 'Βιοδυναμικά',
+  traditional_natural: 'Παραδοσιακά',
+  conventional: 'Συμβατικά',
+};
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<{ cat?: string; search?: string; cult?: string }>;
+}): Promise<Metadata> {
+  const params = await searchParams;
+  const parts: string[] = [];
+  if (params.cult && cultivationLabels[params.cult]) parts.push(cultivationLabels[params.cult]);
+  if (params.search) parts.push(`"${params.search}"`);
+  const suffix = parts.length > 0 ? ` — ${parts.join(', ')}` : '';
+  const title = `Προϊόντα${suffix} | Dixis`;
+  const description = `Ανακαλύψτε τοπικά ελληνικά προϊόντα${suffix} απευθείας από Έλληνες παραγωγούς.`;
+  return { title, description };
 }
 
 interface PageProps {


### PR DESCRIPTION
## Summary
- Product detail JSON-LD now includes `aggregateRating` schema when reviews exist → Google shows ★ ratings in search results
- Products listing page gets dynamic `<title>` and `<meta description>` based on active filters (cultivation type, search query)

## Changes
| File | Change |
|------|--------|
| `products/[id]/page.tsx` | Add `aggregateRating` to existing JSON-LD `Product` schema |
| `products/page.tsx` | Add `generateMetadata()` with filter-aware titles |

## Test plan
- [ ] CI passes (build + typecheck + e2e)
- [ ] View source on product page → JSON-LD includes `aggregateRating` (when product has reviews)
- [ ] Navigate to `/products?cult=organic_certified` → page title shows "Βιολογικά Προϊόντα | Dixis"