### PR TITLE
fix(a11y): add aria-labels to quantity input and file upload

### DIFF
--- a/frontend/src/components/UploadImage.client.tsx
+++ b/frontend/src/components/UploadImage.client.tsx
@@ -45,7 +45,7 @@ export default function UploadImage({ value, onChange, accept='image/*', maxMB=5
       <label style={{display:'block', marginBottom:6, fontWeight:600}}>{label}</label>
       {value ? (
         <div style={{display:'flex', gap:12, alignItems:'center'}}>
-          <img src={value} alt="Εικόνα προϊόντος" style={{width:96,height:96,objectFit:'cover',borderRadius:8,border:'1px solid #e5e7eb'}}/>
+          <img src={value} alt="Εικόνα προϊόντος" width={96} height={96} style={{objectFit:'cover',borderRadius:8,border:'1px solid #e5e7eb'}}/>
           <div style={{display:'flex',gap:8}}>
             <button type="button" className="btn" onClick={()=>onChange(null)}>Αφαίρεση εικόνας</button>
             <button type="button" className="btn" onClick={()=>inputRef.current?.click()} disabled={busy}>{busy?'Ανέβασμα…':'Ανέβασμα νέας'}</button>
@@ -59,7 +59,7 @@ export default function UploadImage({ value, onChange, accept='image/*', maxMB=5
           {err && <p style={{color:'#b91c1c'}}>{err}</p>}
         </div>
       )}
-      <input ref={inputRef} type="file" accept={accept} style={{display:'none'}} onChange={onPick}/>
+      <input ref={inputRef} type="file" accept={accept} style={{display:'none'}} onChange={onPick} aria-label="Επιλογή αρχείου"/>
     </div>
   );
 }

--- a/frontend/src/components/cart/BuyBox.tsx
+++ b/frontend/src/components/cart/BuyBox.tsx
@@ -7,7 +7,7 @@ export default function BuyBox({ product }:{ product: { id: string|number; title
   const title = String(product.title ?? product.name ?? 'Προϊόν');
   return (
     <div className="mt-6 flex gap-3 items-center">
-      <input type="number" min={1} value={qty} onChange={e=>setQty(Number(e.target.value||1))} className="h-10 w-20 border rounded-md px-3" />
+      <input type="number" min={1} value={qty} onChange={e=>setQty(Number(e.target.value||1))} className="h-10 w-20 border rounded-md px-3" aria-label="Ποσότητα" />
       <AddToCartButton id={product.id} title={title} price={Number(product.price ?? 0)} currency={product.currency ?? 'EUR'} qty={qty} producerId={product.producerId ? String(product.producerId) : undefined} producerName={product.producerName} />
     </div>
   );


### PR DESCRIPTION
## Summary
- BuyBox: quantity `<input type="number">` now has `aria-label="Ποσότητα"` (was unlabeled)
- UploadImage: hidden file input has `aria-label="Επιλογή αρχείου"` (was unlabeled)
- UploadImage: preview `<img>` uses explicit `width`/`height` attributes to prevent layout shift (CLS)

## Test plan
- [ ] CI passes
- [ ] Lighthouse accessibility audit shows no "Form elements without labels" warnings