### PR TITLE
fix(seo): expand robots.txt to block private routes

### DIFF
--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/ops'],
+        disallow: ['/admin', '/api', '/auth', '/producer', '/account', '/ops', '/my', '/checkout', '/internal'],
       },
     ],
     sitemap: 'https://dixis.gr/sitemap.xml',


### PR DESCRIPTION
## Summary
- Expand robots.txt disallow from just `/ops` to include `/admin`, `/api`, `/auth`, `/producer`, `/account`, `/my`, `/checkout`, `/internal`
- Prevents search engine crawlers from indexing private routes and leaking URL patterns

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx next build` succeeds
- [ ] CI passes
- [ ] After deploy: `curl https://dixis.gr/robots.txt` shows all paths