### PR TITLE
feat: show star ratings on product cards (PRODUCT-CARD-RATINGS-01)

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -23,6 +23,8 @@ type ApiItem = {
   categorySlugs?: string[];
   stock?: number | null;
   cultivationType?: string | null;
+  reviewsCount?: number;
+  reviewsAvgRating?: number | null;
 };
 
 /**
@@ -104,6 +106,8 @@ async function getData(
       categorySlugs: p.categories?.map((c: any) => c.slug) || [],
       stock: typeof p.stock === 'number' ? p.stock : null,
       cultivationType: p.cultivation_type || null,
+      reviewsCount: p.reviews_count ?? 0,
+      reviewsAvgRating: p.reviews_avg_rating ?? null,
     }));
 
     return { items, total: items.length, isDemo: false, apiTotal };
@@ -325,6 +329,8 @@ export default async function Page({ searchParams }: PageProps) {
                 priceCents={p.priceCents}
                 image={p.imageUrl}
                 stock={p.stock}
+                reviewsCount={p.reviewsCount}
+                reviewsAvgRating={p.reviewsAvgRating}
               />
             ))}
           </div>

--- a/frontend/src/app/producers/[slug]/page.tsx
+++ b/frontend/src/app/producers/[slug]/page.tsx
@@ -27,6 +27,8 @@ type ApiProduct = {
   images?: ApiImage[];
   category?: string;
   categories?: { id: number; name: string; slug: string }[];
+  reviews_count?: number;
+  reviews_avg_rating?: number | null;
 };
 
 type ApiProducer = {
@@ -242,6 +244,8 @@ export default async function ProducerProfilePage(
                     image={imageUrl}
                     stock={p.stock}
                     hideProducerLink
+                    reviewsCount={p.reviews_count}
+                    reviewsAvgRating={p.reviews_avg_rating}
                   />
                 );
               })}

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -3,9 +3,11 @@ import React from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import AddToCartButton from '@/components/AddToCartButton'
+import StarRating from '@/components/StarRating'
 
 /**
  * Pass FIX-STOCK-GUARD-01: Added stock prop for OOS awareness
+ * Pass PRODUCT-CARD-RATINGS-01: Added reviewsCount + reviewsAvgRating
  */
 type Props = {
   id: string | number
@@ -17,11 +19,13 @@ type Props = {
   image?: string | null
   stock?: number | null
   hideProducerLink?: boolean
+  reviewsCount?: number
+  reviewsAvgRating?: number | null
 }
 
 const fmtEUR = new Intl.NumberFormat('el-GR', { style: 'currency', currency: 'EUR' })
 
-export function ProductCard({ id, title, producer, producerId, producerSlug, priceCents, image, stock, hideProducerLink }: Props) {
+export function ProductCard({ id, title, producer, producerId, producerSlug, priceCents, image, stock, hideProducerLink, reviewsCount, reviewsAvgRating }: Props) {
   const price = typeof priceCents === 'number' ? fmtEUR.format(priceCents / 100) : '—'
   const hasImage = image && image.length > 0
   const productUrl = `/products/${id}`
@@ -72,6 +76,12 @@ export function ProductCard({ id, title, producer, producerId, producerSlug, pri
             {title}
           </h3>
         </Link>
+        {/* Pass PRODUCT-CARD-RATINGS-01: Show star rating on card */}
+        {reviewsAvgRating != null && reviewsAvgRating > 0 && (
+          <div className="mt-1" data-testid="product-card-rating">
+            <StarRating rating={reviewsAvgRating} count={reviewsCount} size="xs" />
+          </div>
+        )}
       </div>
 
       {/* Non-clickable section - price + add to cart button */}

--- a/frontend/src/components/marketing/FeaturedProducts.tsx
+++ b/frontend/src/components/marketing/FeaturedProducts.tsx
@@ -24,6 +24,8 @@ interface ApiProduct {
   images?: { id: number; url: string; is_primary: boolean }[];
   producer_id?: string | number;
   producer?: { id: string; name: string; slug: string } | null;
+  reviews_count?: number;
+  reviews_avg_rating?: number | null;
 }
 
 async function getProducts(): Promise<ApiProduct[]> {
@@ -88,6 +90,8 @@ export default async function FeaturedProducts() {
                   priceCents={Math.round(product.price * 100)}
                   image={imageUrl}
                   stock={product.stock}
+                  reviewsCount={product.reviews_count}
+                  reviewsAvgRating={product.reviews_avg_rating}
                 />
               );
             })}


### PR DESCRIPTION
## Summary
- Product cards now display star rating + review count when reviews exist
- Uses existing `StarRating` component at `xs` size below the product title
- Backend already returns `reviews_count` and `reviews_avg_rating` — this just surfaces it
- Updated all 3 ProductCard consumers: products listing, producer page, featured section

## Files Changed
- `src/components/ProductCard.tsx` — Added `reviewsCount` + `reviewsAvgRating` props, renders `StarRating`
- `src/app/(storefront)/products/page.tsx` — Added review fields to `ApiItem` type + mapping + prop passing
- `src/app/producers/[slug]/page.tsx` — Added review fields to `ApiProduct` type + prop passing
- `src/components/marketing/FeaturedProducts.tsx` — Added review fields to `ApiProduct` type + prop passing

## Test plan
- [ ] Products with reviews show stars (amber) + count on their cards
- [ ] Products without reviews show no rating row (clean display)
- [ ] Rating appears on /products page, /producers/[slug] page, and homepage featured section
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes