### PR TITLE
fix: improve cost transparency badge copy

### DIFF
--- a/frontend/src/app/(storefront)/products/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/page.tsx
@@ -298,10 +298,10 @@ export default async function Page({ params }:{ params: Promise<{ id:string }> }
               </svg>
               <div>
                 <p className="text-sm font-medium text-emerald-900">
-                  Ο παραγωγός λαμβάνει το 88% της τιμής
+                  88¢ από κάθε €1 πάνε στον παραγωγό
                 </p>
                 <p className="text-xs text-emerald-700 mt-0.5">
-                  Μόνο 12% παρακρατείται για τη λειτουργία της πλατφόρμας
+                  Ασφαλείς πληρωμές · Υποστήριξη · Ποιοτικός έλεγχος
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Reframe the cost transparency badge to be customer-value oriented
- Old: "Ο παραγωγός λαμβάνει το 88% της τιμής / Μόνο 12% παρακρατείται"
- New: "88¢ από κάθε €1 πάνε στον παραγωγό / Ασφαλείς πληρωμές · Υποστήριξη · Ποιοτικός έλεγχος"

## Why
The old copy framed the 12% fee defensively ("only 12% is kept"). The new copy:
1. Makes the 88% concrete and relatable (cents per euro)
2. Shows what the customer GETS for the 12%: secure payments, support, quality control
3. Removes any perception of justifying a fee

## Test plan
- [ ] Visit any product detail page on dixis.gr
- [ ] Verify the emerald cost transparency badge shows updated copy
- [ ] TypeScript clean, build passes