### PR TITLE
feat: multi-producer separate shipments notice [T0-02]

### DIFF
--- a/frontend/src/app/(storefront)/checkout/OrderSummary.tsx
+++ b/frontend/src/app/(storefront)/checkout/OrderSummary.tsx
@@ -50,6 +50,19 @@ export default function OrderSummary({
           <span>{fmt.format(subtotal)}</span>
         </div>
 
+        {/* Multi-producer separate shipments notice */}
+        {cartShippingQuote && cartShippingQuote.producers.length > 1 && (
+          <div className="flex items-start gap-2 rounded-lg bg-amber-50 border border-amber-200 p-3 text-sm" data-testid="multi-producer-notice">
+            <svg className="w-4 h-4 mt-0.5 text-amber-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <p className="text-amber-800">
+              Η παραγγελία σας περιλαμβάνει προϊόντα από {cartShippingQuote.producers.length} παραγωγούς.
+              Θα λάβετε <strong>ξεχωριστά δέματα</strong> από κάθε παραγωγό.
+            </p>
+          </div>
+        )}
+
         {/* Per-producer shipping breakdown */}
         <ShippingBreakdownDisplay
           producers={cartShippingQuote?.producers ?? null}

--- a/frontend/src/app/(storefront)/thank-you/page.tsx
+++ b/frontend/src/app/(storefront)/thank-you/page.tsx
@@ -153,6 +153,14 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
                 {/* Pass MP-SHIPPING-BREAKDOWN-TRUTH-01: Show per-producer shipping for multi-producer orders */}
                 {order.isMultiProducer && order.shippingLines && order.shippingLines.length > 1 ? (
                   <>
+                    <div className="flex items-start gap-2 rounded-lg bg-amber-50 border border-amber-200 p-2.5 my-2" data-testid="multi-producer-notice">
+                      <svg className="w-4 h-4 mt-0.5 text-amber-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      <p className="text-xs text-amber-800">
+                        Θα λάβετε <strong>ξεχωριστά δέματα</strong> από κάθε παραγωγό.
+                      </p>
+                    </div>
                     <div className="text-neutral-600 font-medium pt-1">Μεταφορικά ανά παραγωγό:</div>
                     {order.shippingLines.map((line, idx) => (
                       <div key={idx} className="flex justify-between pl-3 text-neutral-600">


### PR DESCRIPTION
## Summary
- Add amber info banner on checkout when cart has 2+ producers
- Add same notice on thank-you page for multi-producer orders
- Text: "Θα λάβετε ξεχωριστά δέματα από κάθε παραγωγό"

## Why
Customers with multi-producer orders currently see per-producer shipping costs but no explanation that they'll receive separate packages. This causes confusion and support requests.

## Backlog ref
T0-02 from Operational Readiness Backlog (Tier 0 — Critical)

## Test plan
- [ ] Add items from 2 different producers to cart
- [ ] Go to checkout → amber banner shows with producer count + "ξεχωριστά δέματα"
- [ ] Complete order → thank-you page shows same notice above per-producer shipping lines
- [ ] Single producer cart → no banner shown
- [ ] TypeScript clean, build passes