### PR TITLE
feat: admin order detail — refund UI + items + address [T0-03/T1-01/T1-02/T1-04]

### DIFF
--- a/frontend/src/app/admin/orders/[id]/page.tsx
+++ b/frontend/src/app/admin/orders/[id]/page.tsx
@@ -5,8 +5,26 @@ import { useToast } from '@/contexts/ToastContext';
 import { OrderStatusQuickActions } from './OrderStatusQuickActions';
 import { ShippingLabelManager } from '@/components/shipping';
 
+interface OrderItem {
+  id: number;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+}
+
+interface ShippingAddress {
+  name?: string;
+  phone?: string;
+  address?: string;
+  city?: string;
+  postal_code?: string;
+  notes?: string;
+}
+
 type Order = {
   id: string;
+  laravelId?: number;
   createdAt: string;
   postalCode: string;
   method: string;
@@ -15,22 +33,28 @@ type Order = {
   shippingCost?: number;
   codFee?: number | null;
   total: number;
+  totalRaw?: number;
   email?: string | null;
+  customer?: string | null;
   paymentStatus?: string;
   paymentMethod?: string | null;
   paymentRef?: string | null;
   status?: string;
+  items?: OrderItem[];
+  shippingAddress?: ShippingAddress | null;
 };
 
-export default function AdminOrderDetail({
-  params,
-}: {
-  params: { id: string };
-}) {
+const fmt = new Intl.NumberFormat('el-GR', { style: 'currency', currency: 'EUR' });
+
+export default function AdminOrderDetail({ params }: { params: { id: string } }) {
   const { id } = params;
   const { showSuccess, showError } = useToast();
   const [data, setData] = React.useState<Order | null>(null);
   const [err, setErr] = React.useState('');
+  const [refunding, setRefunding] = React.useState(false);
+  const [refundAmount, setRefundAmount] = React.useState('');
+  const [refundReason, setRefundReason] = React.useState('');
+  const [showRefundForm, setShowRefundForm] = React.useState(false);
 
   React.useEffect(() => {
     (async () => {
@@ -39,24 +63,58 @@ export default function AdminOrderDetail({
         if (!r.ok) throw new Error(String(r.status));
         const j = await r.json();
         setData(j);
-      } catch (e: any) {
+      } catch {
         setErr('Δεν είναι διαθέσιμο ή δεν βρέθηκε.');
       }
     })();
   }, [id]);
 
+  const handleRefund = async () => {
+    if (!data) return;
+    setRefunding(true);
+    try {
+      const body: Record<string, unknown> = {};
+      if (refundReason) body.reason = refundReason;
+      if (refundAmount) body.amount_cents = Math.round(parseFloat(refundAmount) * 100);
+
+      const r = await fetch(`/api/admin/orders/${id}/refund`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const result = await r.json();
+
+      if (r.ok && result.success !== false) {
+        showSuccess(`Επιστροφή ${result.amount_euros ? fmt.format(result.amount_euros) : ''} ολοκληρώθηκε`);
+        setShowRefundForm(false);
+        window.location.reload();
+      } else {
+        showError(result.error_message || result.error || 'Αποτυχία επιστροφής');
+      }
+    } catch {
+      showError('Σφάλμα κατά την επιστροφή χρημάτων');
+    } finally {
+      setRefunding(false);
+    }
+  };
+
+  const isStripe = data?.paymentMethod?.toLowerCase() === 'stripe' || data?.paymentMethod?.toLowerCase() === 'card';
+  const isCod = (data?.paymentMethod || '').toUpperCase() === 'COD';
+  const isPaid = (data?.paymentStatus || '').toLowerCase() === 'completed';
+  const addr = data?.shippingAddress;
+
   return (
-    <main style={{ maxWidth: 960, margin: '40px auto', padding: 16 }}>
-      <h2 style={{ margin: 0 }}>Διαχείριση · Παραγγελία</h2>
-      <p style={{ color: '#6b7280', marginTop: 6 }}>
-        Πλήρης σύνοψη παραγγελίας.
-      </p>
+    <main className="max-w-3xl mx-auto py-10 px-4">
+      <h2 className="text-xl font-bold mb-1">Διαχείριση · Παραγγελία</h2>
+      <p className="text-neutral-500 text-sm mb-6">Πλήρης σύνοψη παραγγελίας.</p>
+
       {err && <div className="mt-2 text-sm text-red-600">{err}</div>}
+
       {!data ? (
-        <div className="mt-4 text-sm">Φόρτωση…</div>
+        <div className="mt-4 text-sm text-neutral-500">Φόρτωση…</div>
       ) : (
-        <div className="mt-4 text-sm">
-          {/* PR-FIX-01: Wire orphaned OrderStatusQuickActions */}
+        <div className="space-y-6">
+          {/* Quick Actions */}
           {data.status && (
             <OrderStatusQuickActions
               orderId={data.id}
@@ -66,104 +124,182 @@ export default function AdminOrderDetail({
             />
           )}
 
-          {/* ADMIN-SHIPPING-UI-01: Shipping Label Manager */}
+          {/* Shipping Label Manager */}
           {data.status && ['PAID', 'PACKING'].includes(data.status.toUpperCase()) && (
-            <div className="my-6 pb-6 border-b border-gray-200">
-              <ShippingLabelManager
-                orderId={data.id}
-                className="mt-4"
-              />
+            <div className="pb-6 border-b border-neutral-200">
+              <ShippingLabelManager orderId={data.id} className="mt-4" />
             </div>
           )}
 
-          <div className="mb-2">
-            Αρ. Παραγγελίας:{' '}
-            <strong data-testid="detail-order-no">
-              {orderNumber(data.id, data.createdAt)}
-            </strong>
-          </div>
-          <div className="mb-2">
-            ID Παραγγελίας:{' '}
-            <strong data-testid="detail-order-id">{data.id}</strong>
-          </div>
-          <div className="mb-2 text-xs text-neutral-500" data-testid="customer-view-link">
-            Παρακολούθηση: /track/[token]
-          </div>
-          <table className="text-sm">
-            <tbody>
-              <tr>
-                <td className="pr-4">Ημ/νία</td>
-                <td>{new Date(data.createdAt).toLocaleString()}</td>
-              </tr>
-              <tr>
-                <td className="pr-4">Τ.Κ.</td>
-                <td data-testid="detail-pc">{data.postalCode}</td>
-              </tr>
-              <tr>
-                <td className="pr-4">Μέθοδος</td>
-                <td>{data.method}</td>
-              </tr>
-              <tr>
-                <td className="pr-4">Βάρος (g)</td>
-                <td>{data.weightGrams ?? '-'}</td>
-              </tr>
-              <tr>
-                <td className="pr-4">Υποσύνολο</td>
-                <td>{String(data.subtotal ?? '-')}</td>
-              </tr>
-              <tr>
-                <td className="pr-4">Μεταφορικά</td>
-                <td>{String(data.shippingCost ?? '-')}</td>
-              </tr>
-              {data.codFee != null && (
-                <tr>
-                  <td className="pr-4">Αντικαταβολή</td>
-                  <td>{String(data.codFee)}</td>
-                </tr>
-              )}
-              <tr>
-                <td className="pr-4">Σύνολο</td>
-                <td data-testid="detail-total">{String(data.total)}</td>
-              </tr>
-              <tr>
-                <td className="pr-4">Email</td>
-                <td>{data.email ?? '-'}</td>
-              </tr>
+          {/* Order Info Card */}
+          <div className="bg-white border rounded-xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <div className="text-sm text-neutral-500">Αρ. Παραγγελίας</div>
+                <div className="text-lg font-bold font-mono" data-testid="detail-order-no">
+                  {orderNumber(data.id, data.createdAt)}
+                </div>
+              </div>
               {data.status && (
-                <tr>
-                  <td className="pr-4">Κατάσταση</td>
-                  <td data-testid="detail-status" className="font-medium">{data.status}</td>
-                </tr>
+                <span className="px-3 py-1 rounded-full text-xs font-medium bg-neutral-100" data-testid="detail-status">
+                  {data.status}
+                </span>
               )}
-              <tr>
-                <td className="pr-4">Πληρωμή</td>
-                <td>
-                  {data.paymentStatus ?? 'PAID'}{' '}
-                  {data.paymentRef ? `(${data.paymentRef})` : ''}
-                </td>
-              </tr>
-            </tbody>
-          </table>
-          <div className="mt-4">
+            </div>
+
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div><span className="text-neutral-500">Ημ/νία:</span> {new Date(data.createdAt).toLocaleString('el-GR')}</div>
+              <div><span className="text-neutral-500">Email:</span> {data.email ?? '-'}</div>
+              <div><span className="text-neutral-500">Πληρωμή:</span> {data.paymentMethod ?? '-'} · {data.paymentStatus ?? 'PAID'}</div>
+              {data.paymentRef && <div><span className="text-neutral-500">Ref:</span> {data.paymentRef}</div>}
+            </div>
+          </div>
+
+          {/* Shipping Address Card (T1-02) */}
+          {addr && (
+            <div className="bg-white border rounded-xl p-6" data-testid="shipping-address">
+              <h3 className="font-semibold mb-3">Διεύθυνση Αποστολής</h3>
+              <div className="text-sm space-y-1">
+                {addr.name && <div className="font-medium">{addr.name}</div>}
+                {addr.address && <div>{addr.address}</div>}
+                {(addr.city || addr.postal_code) && (
+                  <div>{[addr.postal_code, addr.city].filter(Boolean).join(', ')}</div>
+                )}
+                {addr.phone && <div>Τηλ: {addr.phone}</div>}
+                {addr.notes && <div className="text-neutral-500 mt-2">Σημειώσεις: {addr.notes}</div>}
+              </div>
+            </div>
+          )}
+
+          {/* Order Items Card (T1-01) */}
+          {data.items && data.items.length > 0 && (
+            <div className="bg-white border rounded-xl p-6" data-testid="order-items">
+              <h3 className="font-semibold mb-3">Προϊόντα Παραγγελίας</h3>
+              <div className="space-y-2">
+                {data.items.map((item) => (
+                  <div key={item.id} className="flex justify-between text-sm py-1 border-b border-neutral-100 last:border-0">
+                    <div>
+                      <span className="font-medium">{item.productName}</span>
+                      <span className="text-neutral-500 ml-2">x{item.quantity}</span>
+                    </div>
+                    <span>{fmt.format(item.totalPrice)}</span>
+                  </div>
+                ))}
+              </div>
+              <div className="border-t mt-3 pt-3 space-y-1 text-sm">
+                {data.subtotal != null && (
+                  <div className="flex justify-between"><span>Υποσύνολο</span><span>{fmt.format(data.subtotal)}</span></div>
+                )}
+                {data.shippingCost != null && data.shippingCost > 0 && (
+                  <div className="flex justify-between"><span>Μεταφορικά</span><span>{fmt.format(data.shippingCost)}</span></div>
+                )}
+                {data.codFee != null && Number(data.codFee) > 0 && (
+                  <div className="flex justify-between"><span>Αντικαταβολή</span><span>{fmt.format(Number(data.codFee))}</span></div>
+                )}
+                <div className="flex justify-between font-bold pt-1 border-t">
+                  <span>Σύνολο</span>
+                  <span data-testid="detail-total">{typeof data.total === 'string' ? data.total : fmt.format(data.totalRaw ?? data.total)}</span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Refund Section (T0-03) */}
+          <div className="bg-white border rounded-xl p-6" data-testid="refund-section">
+            <h3 className="font-semibold mb-3">Επιστροφή Χρημάτων</h3>
+
+            {isCod && (
+              <div className="flex items-start gap-2 rounded-lg bg-amber-50 border border-amber-200 p-3 mb-3 text-sm" data-testid="cod-refund-notice">
+                <svg className="w-4 h-4 mt-0.5 text-amber-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div className="text-amber-800">
+                  <p className="font-medium">Παραγγελία με αντικαταβολή</p>
+                  <p className="mt-1">Η επιστροφή χρημάτων δεν γίνεται αυτόματα. Θα πρέπει να κάνετε τραπεζική μεταφορά στον πελάτη χειροκίνητα.</p>
+                </div>
+              </div>
+            )}
+
+            {isStripe && isPaid && !showRefundForm && (
+              <button
+                onClick={() => setShowRefundForm(true)}
+                className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors"
+                data-testid="refund-trigger"
+              >
+                Επιστροφή μέσω Stripe
+              </button>
+            )}
+
+            {isStripe && !isPaid && (
+              <p className="text-sm text-neutral-500">Η πληρωμή δεν έχει ολοκληρωθεί — δεν είναι δυνατή η επιστροφή.</p>
+            )}
+
+            {!isStripe && !isCod && (
+              <p className="text-sm text-neutral-500">Μέθοδος πληρωμής: {data.paymentMethod ?? 'N/A'}</p>
+            )}
+
+            {showRefundForm && (
+              <div className="mt-3 space-y-3 p-4 bg-red-50 border border-red-200 rounded-lg" data-testid="refund-form">
+                <div>
+                  <label className="block text-sm font-medium mb-1">Ποσό (€) — κενό = πλήρης επιστροφή</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    max={data.totalRaw ?? 9999}
+                    value={refundAmount}
+                    onChange={(e) => setRefundAmount(e.target.value)}
+                    placeholder={`Μέγιστο: ${fmt.format(data.totalRaw ?? 0)}`}
+                    className="w-full border rounded-lg px-3 py-2 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Αιτία (προαιρετικό)</label>
+                  <input
+                    type="text"
+                    value={refundReason}
+                    onChange={(e) => setRefundReason(e.target.value)}
+                    placeholder="π.χ. Κατεστραμμένο προϊόν"
+                    className="w-full border rounded-lg px-3 py-2 text-sm"
+                  />
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleRefund}
+                    disabled={refunding}
+                    className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium disabled:opacity-50"
+                  >
+                    {refunding ? 'Επεξεργασία...' : 'Επιβεβαίωση Επιστροφής'}
+                  </button>
+                  <button
+                    onClick={() => setShowRefundForm(false)}
+                    className="px-4 py-2 border rounded-lg text-sm"
+                  >
+                    Ακύρωση
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Navigation */}
+          <div className="flex gap-4 pt-2">
             <button
               data-testid="resend-receipt"
-              onClick={async ()=>{
+              onClick={async () => {
                 try {
-                  const r = await fetch(`/api/admin/orders/${data?.id}/resend`, { method:'POST' });
-                  if (r.ok) {
-                    showSuccess('Το email στάλθηκε ξανά.');
-                  } else {
-                    showError('Αποτυχία αποστολής.');
-                  }
+                  const r = await fetch(`/api/admin/orders/${data?.id}/resend`, { method: 'POST' });
+                  if (r.ok) showSuccess('Το email στάλθηκε ξανά.');
+                  else showError('Αποτυχία αποστολής.');
                 } catch {
                   showError('Σφάλμα αποστολής.');
                 }
               }}
-              className="border px-3 py-1 rounded"
-            >Επαναποστολή απόδειξης</button>
-          </div>
-          <div className="mt-4">
-            <a href="/admin/orders" className="underline">
+              className="border px-4 py-2 rounded-lg text-sm hover:bg-neutral-50"
+            >
+              Επαναποστολή απόδειξης
+            </button>
+            <a href="/admin/orders" className="text-sm text-primary hover:underline py-2">
               ← Πίσω στη λίστα
             </a>
           </div>

--- a/frontend/src/app/api/admin/orders/[id]/refund/route.ts
+++ b/frontend/src/app/api/admin/orders/[id]/refund/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { requireAdmin, AdminError } from '@/lib/auth/admin';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * T0-03: Admin refund proxy — POST creates refund, GET returns refund info.
+ * Proxies to Laravel RefundController endpoints.
+ */
+
+async function getToken(req: Request): Promise<string | null> {
+  const cookieStore = await cookies();
+  return cookieStore.get('auth_token')?.value
+    || new Headers(req.headers).get('authorization')?.replace('Bearer ', '')
+    || null;
+}
+
+function getLaravelId(rawId: string): string {
+  return rawId.startsWith('A-') ? rawId.slice(2) : rawId;
+}
+
+export async function GET(req: Request, ctx: { params: { id: string } }): Promise<NextResponse> {
+  try { await requireAdmin(); } catch (e) {
+    return NextResponse.json({ error: e instanceof AdminError ? e.message : 'Unauthorized' }, { status: 401 });
+  }
+
+  const laravelId = getLaravelId(ctx.params.id);
+  const token = await getToken(req);
+  if (!token) return NextResponse.json({ error: 'No token' }, { status: 401 });
+
+  const apiBase = process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+  const res = await fetch(`${apiBase}/refunds/orders/${laravelId}`, {
+    headers: { 'Authorization': `Bearer ${token}`, 'Accept': 'application/json' },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) return NextResponse.json({ error: 'Failed to fetch refund info' }, { status: res.status });
+  return NextResponse.json(await res.json());
+}
+
+export async function POST(req: Request, ctx: { params: { id: string } }): Promise<NextResponse> {
+  try { await requireAdmin(); } catch (e) {
+    return NextResponse.json({ error: e instanceof AdminError ? e.message : 'Unauthorized' }, { status: 401 });
+  }
+
+  const laravelId = getLaravelId(ctx.params.id);
+  const token = await getToken(req);
+  if (!token) return NextResponse.json({ error: 'No token' }, { status: 401 });
+
+  const body = await req.json();
+  const apiBase = process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
+  const res = await fetch(`${apiBase}/refunds/orders/${laravelId}`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await res.json();
+  if (!res.ok) return NextResponse.json(data, { status: res.status });
+  return NextResponse.json(data);
+}

--- a/frontend/src/app/api/admin/orders/[id]/route.ts
+++ b/frontend/src/app/api/admin/orders/[id]/route.ts
@@ -55,24 +55,39 @@ export async function GET(
         const match = orders.find((o: any) => String(o.id) === laravelId);
 
         if (match) {
+          // Parse shipping_address JSON safely
+          let shippingAddress = null;
+          try {
+            shippingAddress = typeof match.shipping_address === 'string'
+              ? JSON.parse(match.shipping_address)
+              : match.shipping_address || null;
+          } catch { /* ignore parse errors */ }
+
           return NextResponse.json({
             id: `A-${match.id}`,
+            laravelId: match.id,
             customer: match.user?.name || match.user?.email || 'N/A',
             email: match.user?.email || null,
             total: `€${Number(match.total_amount || 0).toFixed(2)}`,
             totalRaw: Number(match.total_amount || 0),
+            subtotal: Number(match.subtotal || 0),
+            shippingCost: Number(match.shipping_cost || match.shipping_amount || 0),
+            codFee: Number(match.cod_fee || 0),
             status: match.status,
             paymentStatus: match.payment_status,
             paymentMethod: match.payment_method,
+            paymentRef: match.payment_reference || null,
             shippingMethod: match.shipping_method,
+            shippingAddress,
+            postalCode: shippingAddress?.postal_code || match.postal_code || null,
             createdAt: match.created_at,
             updatedAt: match.updated_at,
             items: (match.order_items || match.orderItems || []).map((item: any) => ({
               id: item.id,
               productName: item.product_name || item.product?.name || 'N/A',
               quantity: item.quantity,
-              unitPrice: item.unit_price,
-              totalPrice: item.total_price,
+              unitPrice: Number(item.unit_price || 0),
+              totalPrice: Number(item.total_price || 0),
             })),
           });
         }


### PR DESCRIPTION
## Summary
- **T0-03**: Add Stripe refund button with amount, reason, confirmation flow
- **T1-01**: Show order line items (product name, qty, unit price, total)
- **T1-02**: Show full shipping address (name, phone, street, city, postal code)
- **T1-04**: COD refund notice (manual bank transfer instructions)
- Enrich proxy route with financial fields + shipping address JSON
- New refund proxy route for secure admin refund API calls

## Why
Admin currently sees only totals — cannot see what was ordered, where to ship, or issue refunds. These are critical operational needs before real orders start.

## Backlog ref
T0-03, T1-01, T1-02, T1-04 from Operational Readiness Backlog

## Test plan
- [ ] Navigate to /admin/orders/[id] → see order items with names, quantities, prices
- [ ] See full shipping address card (name, street, city, postal code, phone)
- [ ] Stripe order: "Επιστροφή μέσω Stripe" button visible
- [ ] Click refund → form appears with amount + reason fields
- [ ] COD order: amber notice explains manual bank transfer
- [ ] TypeScript clean, build passes