### PR TITLE
feat: low stock email alerts to producers (T1-03)

### DIFF
--- a/backend/app/Mail/LowStockAlert.php
+++ b/backend/app/Mail/LowStockAlert.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Producer;
+use App\Models\Product;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * T1-03: Low stock alert email sent to producers when product stock
+ * drops to or below the LOW_STOCK_THRESHOLD (5 units).
+ */
+class LowStockAlert extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public Product $product,
+        public Producer $producer
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "Χαμηλό απόθεμα: {$this->product->name} - Dixis",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.producers.low-stock-alert',
+            with: [
+                'productName' => $this->product->name,
+                'currentStock' => $this->product->stock,
+                'producerName' => $this->producer->business_name ?? $this->producer->name,
+            ],
+        );
+    }
+}

--- a/backend/app/Services/InventoryService.php
+++ b/backend/app/Services/InventoryService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Notification;
 use App\Models\Producer;
 use App\Models\Product;
+use App\Mail\LowStockAlert;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
@@ -63,21 +64,17 @@ class InventoryService
             ],
         ]);
 
-        // Send email notification
+        // T1-03: Send email notification to producer
         try {
-            // For now, we'll just log the email that would be sent
-            // In a real implementation, you'd create a Mail class and send it
-            Log::info('Low stock email notification', [
+            Mail::to($user->email)->send(new LowStockAlert($product, $producer));
+
+            Log::info('Low stock email sent', [
                 'to' => $user->email,
                 'product_name' => $product->name,
                 'stock' => $product->stock,
-                'producer_name' => $producer->name,
             ]);
-
-            // Uncomment when email implementation is ready:
-            // Mail::to($user->email)->send(new LowStockAlert($product, $producer));
         } catch (\Exception $e) {
-            Log::error('Failed to send low stock email notification', [
+            Log::error('Failed to send low stock email', [
                 'user_id' => $user->id,
                 'product_id' => $product->id,
                 'error' => $e->getMessage(),

--- a/backend/resources/views/emails/producers/low-stock-alert.blade.php
+++ b/backend/resources/views/emails/producers/low-stock-alert.blade.php
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="el">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Χαμηλό Απόθεμα - Dixis</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: #d97706; color: white; padding: 20px; text-align: center; border-radius: 8px 8px 0 0; }
+        .content { background: #f9fafb; padding: 20px; border: 1px solid #e5e7eb; }
+        .footer { text-align: center; padding: 20px; color: #6b7280; font-size: 14px; }
+        .alert-box { background: #fffbeb; border: 1px solid #fbbf24; border-radius: 8px; padding: 20px; margin: 15px 0; text-align: center; }
+        .stock-value { font-size: 36px; font-weight: bold; color: #d97706; }
+        .stock-label { color: #92400e; font-size: 14px; margin-top: 4px; }
+        .product-name { font-size: 18px; font-weight: 600; color: #1f2937; margin-bottom: 4px; }
+        .cta-button { display: inline-block; background: #059669; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600; margin-top: 15px; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1 style="margin: 0;">Ειδοποίηση Αποθέματος</h1>
+        <p style="margin: 5px 0 0; opacity: 0.9;">{{ $producerName }}</p>
+    </div>
+
+    <div class="content">
+        <p>Το απόθεμα ενός προϊόντος σας είναι χαμηλό:</p>
+
+        <div class="alert-box">
+            <div class="product-name">{{ $productName }}</div>
+            <div class="stock-value">{{ $currentStock }}</div>
+            <div class="stock-label">τεμάχια απομένουν</div>
+        </div>
+
+        <p>Ανανεώστε το απόθεμά σας για να αποφύγετε ελλείψεις.</p>
+
+        <div style="text-align: center;">
+            <a href="{{ config('app.url') }}/producer/products" class="cta-button">
+                Διαχείριση Αποθέματος
+            </a>
+        </div>
+    </div>
+
+    <div class="footer">
+        <p>Dixis - Φρέσκα προϊόντα από τοπικούς παραγωγούς</p>
+        <p>&copy; {{ date('Y') }} Dixis. Με επιφύλαξη παντός δικαιώματος.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Created `LowStockAlert` Mailable class (amber-themed, Greek copy)
- Created `low-stock-alert.blade.php` Blade template with product name, stock count, and CTA button
- Activated email sending in `InventoryService::sendLowStockAlert()` — replaced `Log::info` placeholder with actual `Mail::to()`

## Context
InventoryService already handled low stock detection (threshold: 5 units) and created in-app notifications. Email sending was stubbed out with a log message and a commented `Mail::to()` line. This PR completes the circuit.

## Acceptance Criteria
- [x] `LowStockAlert` Mailable created with `Product` + `Producer` constructor
- [x] Blade template follows existing email style (matches `weekly-digest.blade.php`)
- [x] `InventoryService` uses `Mail::to()` instead of `Log::info` placeholder
- [x] Error handling preserved — failed emails don't break order flow
- [x] Greek language throughout

## Test Plan
- [ ] Place test order that reduces product stock below 5
- [ ] Verify email sent to producer's user email
- [ ] Verify in-app notification still created
- [ ] Verify failed email doesn't break order processing