### PR TITLE
feat: order status history with timestamps (T1-05)

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/AdminOrderController.php
+++ b/backend/app/Http/Controllers/Api/Admin/AdminOrderController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\Order;
+use App\Models\OrderStatusHistory;
 use App\Services\OrderEmailService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -127,14 +128,21 @@ class AdminOrderController extends Controller
             'status' => $newStatus,
         ]);
 
-        // Optional: Log the status change with note
-        // (Could extend with order_status_history table in future)
+        // T1-05: Persist status change to history table for timeline
+        OrderStatusHistory::create([
+            'order_id' => $order->id,
+            'old_status' => $oldStatus,
+            'new_status' => $newStatus,
+            'changed_by' => $request->user()->id,
+            'note' => $validated['note'] ?? null,
+            'changed_at' => now(),
+        ]);
+
         \Log::info("Order status updated", [
             'order_id' => $order->id,
             'old_status' => $oldStatus,
             'new_status' => $newStatus,
             'admin_id' => $request->user()->id,
-            'note' => $validated['note'] ?? null,
         ]);
 
         // Pass 54: Send status update email notification

--- a/backend/app/Http/Controllers/Api/V1/OrderTrackingController.php
+++ b/backend/app/Http/Controllers/Api/V1/OrderTrackingController.php
@@ -35,7 +35,7 @@ class OrderTrackingController extends Controller
             ], 400);
         }
 
-        $order = Order::with(['shipment', 'orderItems'])
+        $order = Order::with(['shipment', 'orderItems', 'statusHistory'])
             ->where('public_token', $token)
             ->first();
 
@@ -71,6 +71,13 @@ class OrderTrackingController extends Controller
                 'estimated_delivery' => $order->shipment->estimated_delivery?->toISOString(),
             ];
         }
+
+        // T1-05: Include status history for timeline display (no PII)
+        $response['status_history'] = $order->statusHistory->map(fn ($h) => [
+            'status' => $h->new_status,
+            'changed_at' => $h->changed_at?->toISOString(),
+            'note' => $h->note,
+        ])->values()->toArray();
 
         return response()->json([
             'ok' => true,

--- a/backend/app/Models/Order.php
+++ b/backend/app/Models/Order.php
@@ -123,6 +123,14 @@ class Order extends Model
     }
 
     /**
+     * T1-05: Get status change history for timeline display.
+     */
+    public function statusHistory()
+    {
+        return $this->hasMany(OrderStatusHistory::class)->orderBy('changed_at', 'asc');
+    }
+
+    /**
      * Get the shipping lines for multi-producer orders.
      * Pass MP-ORDERS-SHIPPING-V1: Per-producer shipping breakdown.
      */

--- a/backend/app/Models/OrderStatusHistory.php
+++ b/backend/app/Models/OrderStatusHistory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * T1-05: Tracks every order status transition for timeline display.
+ */
+class OrderStatusHistory extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'order_status_history';
+
+    protected $fillable = [
+        'order_id',
+        'old_status',
+        'new_status',
+        'changed_by',
+        'note',
+        'changed_at',
+    ];
+
+    protected $casts = [
+        'changed_at' => 'datetime',
+    ];
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function admin(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'changed_by');
+    }
+}

--- a/backend/database/migrations/2026_02_17_100000_create_order_status_history_table.php
+++ b/backend/database/migrations/2026_02_17_100000_create_order_status_history_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * T1-05: Order status history for tracking timestamps.
+ * Stores every status transition with timestamp and admin/note metadata.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('order_status_history', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('order_id');
+            $table->string('old_status', 20)->nullable(); // null for initial status
+            $table->string('new_status', 20);
+            $table->unsignedBigInteger('changed_by')->nullable(); // admin user id
+            $table->string('note', 500)->nullable();
+            $table->timestamp('changed_at')->useCurrent();
+
+            $table->foreign('order_id')->references('id')->on('orders')->onDelete('cascade');
+            $table->foreign('changed_by')->references('id')->on('users')->onDelete('set null');
+            $table->index(['order_id', 'changed_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('order_status_history');
+    }
+};

--- a/frontend/src/app/track/[token]/components/Timeline.tsx
+++ b/frontend/src/app/track/[token]/components/Timeline.tsx
@@ -1,67 +1,126 @@
 'use client'
-import { OrderStatus, STATUS_ORDER, EL_LABEL, getStatusIndex } from '@/lib/tracking/status'
+import { OrderStatus, STATUS_ORDER, EL_LABEL, getStatusIndex, normalizeStatus } from '@/lib/tracking/status'
+
+interface StatusHistoryEntry {
+  status: string
+  changed_at: string
+  note: string | null
+}
 
 interface TimelineProps {
   currentStatus: OrderStatus
+  history?: StatusHistoryEntry[]
+  orderCreatedAt?: string
 }
 
-export default function Timeline({ currentStatus }: TimelineProps) {
+/**
+ * Backend statuses → frontend status mapping.
+ * Backend uses: pending, confirmed, processing, shipped, delivered, cancelled
+ * Frontend uses: PAID, PACKING, SHIPPED, DELIVERED, CANCELLED
+ */
+function mapBackendStatus(s: string): OrderStatus {
+  const map: Record<string, OrderStatus> = {
+    pending: 'PAID',
+    confirmed: 'PACKING',
+    processing: 'PACKING',
+    shipped: 'SHIPPED',
+    delivered: 'DELIVERED',
+    cancelled: 'CANCELLED',
+  }
+  return map[s.toLowerCase()] ?? normalizeStatus(s)
+}
+
+/**
+ * Format ISO date to short Greek display: "17/02 14:30"
+ */
+function fmtDate(iso: string): string {
+  const d = new Date(iso)
+  const day = String(d.getDate()).padStart(2, '0')
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const hours = String(d.getHours()).padStart(2, '0')
+  const mins = String(d.getMinutes()).padStart(2, '0')
+  return `${day}/${month} ${hours}:${mins}`
+}
+
+export default function Timeline({ currentStatus, history, orderCreatedAt }: TimelineProps) {
   const currentIdx = getStatusIndex(currentStatus)
   const isCancelled = currentStatus === 'CANCELLED'
 
+  // Build a map: frontend status → timestamp (from history)
+  const statusTimestamps: Partial<Record<OrderStatus, string>> = {}
+
+  // Order creation = PAID timestamp
+  if (orderCreatedAt) {
+    statusTimestamps.PAID = orderCreatedAt
+  }
+
+  // Map history entries to frontend statuses
+  if (history && history.length > 0) {
+    for (const entry of history) {
+      const frontendStatus = mapBackendStatus(entry.status)
+      // Keep earliest timestamp for each status
+      if (!statusTimestamps[frontendStatus]) {
+        statusTimestamps[frontendStatus] = entry.changed_at
+      }
+    }
+  }
+
   return (
-    <div style={{ padding: '20px 0' }}>
-      <ol role="list" style={{ display: 'flex', alignItems: 'center', position: 'relative', listStyle: 'none', margin: 0, padding: 0 }}>
+    <div className="py-5">
+      <ol role="list" className="flex items-start relative" style={{ listStyle: 'none', margin: 0, padding: 0 }}>
         {STATUS_ORDER.map((status, idx) => {
           const isCompleted = !isCancelled && idx <= currentIdx
           const isCurrent = status === currentStatus && !isCancelled
+          const timestamp = statusTimestamps[status]
 
           return (
-            <li key={status} role="listitem" aria-current={isCurrent ? "step" : undefined} style={{ flex: 1, position: 'relative', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <li key={status} role="listitem" aria-current={isCurrent ? 'step' : undefined} className="flex-1 relative flex flex-col items-center">
               {/* Connecting line */}
               {idx < STATUS_ORDER.length - 1 && (
-                <div style={{
-                  position: 'absolute',
-                  top: '16px',
-                  left: '50%',
-                  width: '100%',
-                  height: '2px',
-                  backgroundColor: isCompleted ? '#16a34a' : '#e5e7eb',
-                  zIndex: 0
-                }} />
+                <div
+                  className="absolute top-4 left-1/2 w-full h-0.5"
+                  style={{ backgroundColor: isCompleted ? '#16a34a' : '#e5e7eb', zIndex: 0 }}
+                />
               )}
 
               {/* Status node */}
-              <div style={{
-                width: '32px',
-                height: '32px',
-                borderRadius: '50%',
-                backgroundColor: isCompleted ? '#16a34a' : '#e5e7eb',
-                border: isCurrent ? '3px solid #16a34a' : 'none',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                zIndex: 1,
-                position: 'relative'
-              }}>
+              <div
+                className="flex items-center justify-center relative"
+                style={{
+                  width: '32px',
+                  height: '32px',
+                  borderRadius: '50%',
+                  backgroundColor: isCompleted ? '#16a34a' : '#e5e7eb',
+                  border: isCurrent ? '3px solid #16a34a' : 'none',
+                  zIndex: 1,
+                }}
+              >
                 {isCompleted && (
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                    <path d="M13.3 4.3L6 11.6L2.7 8.3" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M13.3 4.3L6 11.6L2.7 8.3" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
                   </svg>
                 )}
               </div>
 
               {/* Label */}
-              <div style={{
-                marginTop: '8px',
-                fontSize: '12px',
-                color: isCompleted ? '#16a34a' : '#6b7280',
-                fontWeight: isCurrent ? 'bold' : 'normal',
-                textAlign: 'center',
-                maxWidth: '80px'
-              }}>
+              <div
+                className="mt-2 text-center"
+                style={{
+                  fontSize: '12px',
+                  color: isCompleted ? '#16a34a' : '#6b7280',
+                  fontWeight: isCurrent ? 'bold' : 'normal',
+                  maxWidth: '80px',
+                }}
+              >
                 {EL_LABEL[status]}
               </div>
+
+              {/* T1-05: Timestamp below label */}
+              {timestamp && (
+                <div className="mt-1 text-center" style={{ fontSize: '10px', color: '#9ca3af', maxWidth: '80px' }}>
+                  {fmtDate(timestamp)}
+                </div>
+              )}
             </li>
           )
         })}
@@ -69,16 +128,16 @@ export default function Timeline({ currentStatus }: TimelineProps) {
 
       {/* Cancelled status indicator */}
       {isCancelled && (
-        <div role="alert" style={{
-          marginTop: '20px',
-          padding: '12px',
-          backgroundColor: '#fef2f2',
-          border: '1px solid #fecaca',
-          borderRadius: '6px',
-          color: '#dc2626',
-          textAlign: 'center',
-          fontWeight: 'bold'
-        }}>
+        <div
+          role="alert"
+          className="mt-5 p-3 text-center font-bold"
+          style={{
+            backgroundColor: '#fef2f2',
+            border: '1px solid #fecaca',
+            borderRadius: '6px',
+            color: '#dc2626',
+          }}
+        >
           {EL_LABEL.CANCELLED}
         </div>
       )}

--- a/frontend/src/app/track/[token]/page.tsx
+++ b/frontend/src/app/track/[token]/page.tsx
@@ -1,5 +1,7 @@
 import StatusBadge from '@/components/admin/StatusBadge'
 import { getServerApiUrl } from '@/env'
+import Timeline from './components/Timeline'
+import { normalizeStatus } from '@/lib/tracking/status'
 
 /**
  * Pass TRACKING-DISPLAY-01: Public order tracking page using Laravel API
@@ -17,6 +19,12 @@ function formatDateStable(date: string | Date | null): string {
   return d.toISOString().slice(0, 16).replace('T', ' ')
 }
 
+interface StatusHistoryEntry {
+  status: string
+  changed_at: string
+  note: string | null
+}
+
 interface TrackingOrder {
   id: number
   status: string
@@ -25,6 +33,7 @@ interface TrackingOrder {
   updated_at: string
   items_count: number
   total: number
+  status_history?: StatusHistoryEntry[]
   shipment?: {
     status: string
     carrier_code: string | null
@@ -120,6 +129,16 @@ export default async function TrackPage({ params }: { params: { token: string } 
               <span className="text-neutral-600">Σύνολο:</span>
               <span className="font-semibold text-primary">{fmt(order.total)}</span>
             </div>
+          </div>
+
+          {/* T1-05: Status Timeline */}
+          <div className="mt-6 pt-6 border-t">
+            <h2 className="text-lg font-semibold text-neutral-900 mb-2">Πρόοδος Παραγγελίας</h2>
+            <Timeline
+              currentStatus={normalizeStatus(order.status)}
+              history={order.status_history}
+              orderCreatedAt={order.created_at}
+            />
           </div>
 
           {/* Shipment Info */}


### PR DESCRIPTION
## Summary
- New `order_status_history` table to record every order status transition
- `OrderStatusHistory` model with Order + User relationships
- `AdminOrderController.updateStatus()` now persists history to DB (was log-only)
- Public tracking API includes `status_history` array (timestamps, no PII)
- `Timeline` component enhanced to display timestamps under each status step
- Backend → frontend status mapping (pending→PAID, confirmed/processing→PACKING, etc.)

## Context
The tracking page showed a linear timeline (PAID → PACKING → SHIPPED → DELIVERED) but with no timestamps. Customers asked "when was it shipped?" and only saw a status dot. Now each completed step shows a date/time below it.

The `order_status_history` table also enables future features: admin audit trail, SLA tracking, customer notifications per status.

## Acceptance Criteria
- [x] Migration creates `order_status_history` table with proper indexes
- [x] `OrderStatusHistory` model created with Order relationship
- [x] `Order` model has `statusHistory()` hasMany relationship
- [x] `AdminOrderController.updateStatus()` writes to history table
- [x] `OrderTrackingController.show()` includes `status_history` in response
- [x] Timeline component shows date/time under completed steps
- [x] Backend statuses correctly mapped to frontend display statuses
- [x] TypeScript compiles clean

## Test Plan
- [ ] Run migration on production: `php artisan migrate`
- [ ] Change order status via admin → verify history record in DB
- [ ] Visit tracking page → verify timestamps under completed steps
- [ ] Order with no history (legacy) → timeline still works (graceful fallback)