### PR TITLE
feat(T2-01): Refund confirmation email to customer

### DIFF
--- a/backend/app/Mail/RefundConfirmation.php
+++ b/backend/app/Mail/RefundConfirmation.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Order;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * T2-01: Refund confirmation email sent to customer after
+ * a successful Stripe refund is processed.
+ */
+class RefundConfirmation extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public Order $order,
+        public float $refundedAmount
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "Επιστροφή χρημάτων — Παραγγελία #{$this->order->id} — Dixis",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.orders.refund-confirmation',
+            with: [
+                'orderId' => $this->order->id,
+                'refundedAmount' => number_format($this->refundedAmount, 2),
+                'customerName' => $this->getCustomerName(),
+            ],
+        );
+    }
+
+    private function getCustomerName(): string
+    {
+        $address = $this->order->shipping_address;
+        if (is_array($address) && isset($address['name'])) {
+            return $address['name'];
+        }
+        return $this->order->user?->name ?? 'Πελάτη';
+    }
+}

--- a/backend/app/Services/NotificationService.php
+++ b/backend/app/Services/NotificationService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Mail\RefundConfirmation;
 use App\Models\Notification;
 use App\Models\Order;
 use App\Models\User;
@@ -72,6 +73,7 @@ class NotificationService
 
     /**
      * Send notification for refund issued event
+     * T2-01: Now sends actual RefundConfirmation email (not just log)
      */
     public function sendRefundIssuedNotification(Order $order, float $refundAmount): void
     {
@@ -83,11 +85,21 @@ class NotificationService
             'message' => 'Έγινε επιστροφή €{refund_amount} για την παραγγελία #{order_id}',
         ]);
 
-        $this->sendEmail($buyer->email, 'refund_issued', [
-            'user_name' => $buyer->name,
-            'order_id' => $order->id,
-            'refund_amount' => number_format($refundAmount, 2),
-        ]);
+        // T2-01: Send actual refund confirmation email
+        try {
+            Mail::to($buyer->email)->send(new RefundConfirmation($order, $refundAmount));
+            Log::info('Refund confirmation email sent', [
+                'to' => $buyer->email,
+                'order_id' => $order->id,
+                'refund_amount' => $refundAmount,
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Failed to send refund confirmation email', [
+                'email' => $buyer->email,
+                'order_id' => $order->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/backend/resources/views/emails/orders/refund-confirmation.blade.php
+++ b/backend/resources/views/emails/orders/refund-confirmation.blade.php
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="el">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Επιστροφή Χρημάτων - Dixis</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: #059669; color: white; padding: 20px; text-align: center; border-radius: 8px 8px 0 0; }
+        .content { background: #f9fafb; padding: 20px; border: 1px solid #e5e7eb; }
+        .footer { text-align: center; padding: 20px; color: #6b7280; font-size: 14px; }
+        .refund-box { background: white; border: 1px solid #d1fae5; border-radius: 8px; padding: 20px; margin: 15px 0; text-align: center; }
+        .refund-amount { font-size: 36px; font-weight: bold; color: #059669; }
+        .refund-label { color: #065f46; font-size: 14px; margin-top: 4px; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1 style="margin: 0;">Επιστροφή Χρημάτων</h1>
+    </div>
+
+    <div class="content">
+        <p>Αγαπητέ/ή {{ $customerName }},</p>
+
+        <p>Η επιστροφή χρημάτων για την παραγγελία σας <strong>#{{ $orderId }}</strong> ολοκληρώθηκε.</p>
+
+        <div class="refund-box">
+            <div class="refund-amount">&euro;{{ $refundedAmount }}</div>
+            <div class="refund-label">Ποσό επιστροφής</div>
+        </div>
+
+        <p>Το ποσό θα εμφανιστεί στον λογαριασμό σας εντός <strong>3-5 εργάσιμων ημερών</strong>,
+        ανάλογα με την τράπεζά σας.</p>
+
+        <p>Αν έχετε οποιαδήποτε απορία, μην διστάσετε να επικοινωνήσετε μαζί μας.</p>
+    </div>
+
+    <div class="footer">
+        <p>Dixis - Φρέσκα προϊόντα από τοπικούς παραγωγούς</p>
+        <p>&copy; {{ date('Y') }} Dixis. Με επιφύλαξη παντός δικαιώματος.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- **NEW** `RefundConfirmation` Mailable — sends green-themed email with refund amount, order number, and 3-5 business day notice
- **NEW** Blade template `refund-confirmation.blade.php` — Greek copy, mobile-friendly
- **UPD** `NotificationService::sendRefundIssuedNotification()` — replaces `Log::info` stub with actual `Mail::to()->send()`. Error handling preserves order flow (failed email ≠ failed refund)

## Acceptance Criteria
- [x] RefundConfirmation Mailable created with Order + refundedAmount
- [x] Blade template with Greek copy, refund amount display, order reference
- [x] NotificationService sends actual email on refund (not just log)
- [x] Error handling: email failure doesn't break refund flow
- [x] In-app notification still created (unchanged)

## Test plan
- Admin issues refund via Refund UI → customer receives email
- Verify email subject: "Επιστροφή χρημάτων — Παραγγελία #X — Dixis"
- Verify email body shows correct refund amount and order ID
- Verify failed email is logged but doesn't break refund API response

## Dependencies
- T0-03 (Admin Refund UI) — already deployed (PR #2989)