### PR TITLE
feat(T2-04): Order cancellation with stock restoration

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/AdminOrderController.php
+++ b/backend/app/Http/Controllers/Api/Admin/AdminOrderController.php
@@ -128,6 +128,22 @@ class AdminOrderController extends Controller
             'status' => $newStatus,
         ]);
 
+        // T2-04: Restore stock when order is cancelled
+        if ($newStatus === 'cancelled') {
+            $order->load('orderItems.product');
+            foreach ($order->orderItems as $item) {
+                if ($item->product) {
+                    $item->product->increment('stock', $item->quantity);
+                    \Log::info('Stock restored on cancellation', [
+                        'order_id' => $order->id,
+                        'product_id' => $item->product_id,
+                        'quantity_restored' => $item->quantity,
+                        'new_stock' => $item->product->fresh()->stock,
+                    ]);
+                }
+            }
+        }
+
         // T1-05: Persist status change to history table for timeline
         OrderStatusHistory::create([
             'order_id' => $order->id,

--- a/frontend/src/app/admin/orders/[id]/OrderStatusQuickActions.tsx
+++ b/frontend/src/app/admin/orders/[id]/OrderStatusQuickActions.tsx
@@ -70,13 +70,17 @@ export function OrderStatusQuickActions({ orderId, currentStatus, paymentMethod,
     }
   }
 
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false)
+
   const showPacking = ['PENDING', 'PAID'].includes(status.toUpperCase())
   const showShipped = status.toUpperCase() === 'PACKING'
+  // T2-04: Show cancel button for cancellable statuses
+  const showCancel = ['PENDING', 'PAID', 'PACKING'].includes(status.toUpperCase())
   // Pass COD-COMPLETE: Show confirm payment for COD orders with pending payment
   const isCod = (paymentMethod || '').toUpperCase() === 'COD'
   const showConfirmPayment = isCod && !paidConfirmed
 
-  if (!showPacking && !showShipped && !showConfirmPayment) {
+  if (!showPacking && !showShipped && !showConfirmPayment && !showCancel) {
     return null
   }
 
@@ -118,6 +122,40 @@ export function OrderStatusQuickActions({ orderId, currentStatus, paymentMethod,
           >
             {loading ? 'Αλλαγή...' : 'Απεστάλη'}
           </button>
+        )}
+        {/* T2-04: Cancel order with confirmation */}
+        {showCancel && !showCancelConfirm && (
+          <button
+            onClick={() => setShowCancelConfirm(true)}
+            disabled={loading}
+            data-testid="qa-cancel"
+            className="w-full px-4 py-2 border-2 border-red-300 text-red-700 hover:bg-red-50 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Ακύρωση Παραγγελίας
+          </button>
+        )}
+        {showCancelConfirm && (
+          <div className="p-3 bg-red-50 border border-red-200 rounded-lg space-y-2">
+            <p className="text-sm text-red-800 font-medium">
+              Σίγουρα θέλετε να ακυρώσετε; Το απόθεμα θα επιστραφεί αυτόματα.
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => { setShowCancelConfirm(false); handleStatusChange('CANCELLED'); }}
+                disabled={loading}
+                data-testid="qa-cancel-confirm"
+                className="flex-1 px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium disabled:opacity-50"
+              >
+                {loading ? 'Ακύρωση...' : 'Ναι, ακύρωσε'}
+              </button>
+              <button
+                onClick={() => setShowCancelConfirm(false)}
+                className="flex-1 px-4 py-2 border rounded-lg text-sm"
+              >
+                Όχι
+              </button>
+            </div>
+          </div>
         )}
       </div>
       <div className="mt-3 text-sm text-gray-500">

--- a/frontend/src/app/api/admin/orders/[id]/status/route.ts
+++ b/frontend/src/app/api/admin/orders/[id]/status/route.ts
@@ -53,6 +53,23 @@ export async function POST(
       data: { status: to }
     });
 
+    // T2-04: Restore stock when order is cancelled
+    if (to === 'CANCELLED') {
+      const items = await prisma.orderItem.findMany({
+        where: { orderId: id },
+        select: { productId: true, qty: true }
+      });
+      for (const item of items) {
+        if (item.productId) {
+          await prisma.product.update({
+            where: { id: item.productId },
+            data: { stock: { increment: item.qty } }
+          });
+          console.log(`[cancel] Restored ${item.qty} stock for product ${item.productId}`);
+        }
+      }
+    }
+
     // Audit log for order status change
     await logAdminAction({
       admin,


### PR DESCRIPTION
## Summary
- **CRITICAL** data integrity fix: cancelled orders now automatically restore product stock
- Stock restored in **both** code paths (Laravel backend + Next.js Prisma proxy)
- Admin UI: cancel button with confirmation dialog for PENDING/PAID/PACKING orders
- Cancellation email already handled by existing Resend integration (no changes needed)

## What was broken
When admin cancelled an order, product stock was permanently reduced. Example: product had 10 units, customer ordered 3 → stock became 7, admin cancels → stock stays 7 instead of returning to 10. Over time this causes phantom stock loss.

## Changes
| File | Change |
|------|--------|
| `AdminOrderController.php` | Restore stock via `$product->increment('stock', qty)` on cancel |
| `status/route.ts` | Restore stock via `prisma.product.update({ stock: { increment } })` on cancel |
| `OrderStatusQuickActions.tsx` | Red cancel button + confirmation dialog (Greek copy) |

## Acceptance Criteria
- [x] Stock restored on backend cancellation path (Laravel)
- [x] Stock restored on frontend cancellation path (Prisma)
- [x] Cancel button visible for PENDING/PAID/PACKING statuses
- [x] Confirmation dialog prevents accidental cancellation
- [x] Cancellation email sent automatically (pre-existing Resend integration)
- [x] TypeScript clean (`tsc --noEmit` passes)

## Test plan
- Create test order → verify product stock decremented
- Cancel order via admin → verify stock restored to original value
- Verify cancellation email received by customer
- Verify SHIPPED/DELIVERED orders do NOT show cancel button
- Verify cancel button shows confirmation before executing