### PR TITLE
feat(T2-03): Checkout progress stepper

### DIFF
--- a/frontend/src/app/(storefront)/checkout/page.tsx
+++ b/frontend/src/app/(storefront)/checkout/page.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from '@/contexts/LocaleContext'
 import StripeProvider from '@/components/payment/StripeProvider'
 import StripePaymentForm from '@/components/payment/StripePaymentForm'
 import ShippingChangedModal from '@/components/checkout/ShippingChangedModal'
+import CheckoutStepper from '@/components/checkout/CheckoutStepper'
 import OrderSummary from './OrderSummary'
 import CustomerDetailsForm from './CustomerDetailsForm'
 import { useCheckout } from './useCheckout'
@@ -76,6 +77,7 @@ function CheckoutContent() {
       <main className="min-h-screen bg-neutral-50 py-8 px-4" data-testid="checkout-page">
         <div className="max-w-2xl mx-auto">
           <h1 className="text-xl sm:text-2xl font-bold mb-6">{t('checkout.title')}</h1>
+          <CheckoutStepper currentStep={3} />
 
           <div className="bg-white border rounded-xl p-6 mb-6">
             <h2 className="font-semibold mb-4">{t('checkoutPage.cardPayment') || 'Card Payment'}</h2>
@@ -116,6 +118,7 @@ function CheckoutContent() {
     <main className="min-h-screen bg-neutral-50 py-8 px-4" data-testid="checkout-page">
       <div className="max-w-2xl mx-auto">
         <h1 className="text-xl sm:text-2xl font-bold mb-6" data-testid="checkout-title">{t('checkout.title')}</h1>
+        <CheckoutStepper currentStep={1} />
 
         <OrderSummary
           cartItems={cartItems}

--- a/frontend/src/components/checkout/CheckoutStepper.tsx
+++ b/frontend/src/components/checkout/CheckoutStepper.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+/**
+ * T2-03: Visual checkout progress stepper.
+ * Shows 3 steps: Παραγγελία → Στοιχεία → Πληρωμή
+ * Reduces cart abandonment by showing progress, especially on mobile.
+ */
+
+interface Step {
+  label: string
+  icon: string
+}
+
+const steps: Step[] = [
+  { label: 'Παραγγελία', icon: '🛒' },
+  { label: 'Στοιχεία', icon: '📋' },
+  { label: 'Πληρωμή', icon: '💳' },
+]
+
+interface CheckoutStepperProps {
+  /** 1-indexed current step (1 = order, 2 = details, 3 = payment) */
+  currentStep: number
+}
+
+export default function CheckoutStepper({ currentStep }: CheckoutStepperProps) {
+  return (
+    <div className="flex items-center justify-between mb-6" data-testid="checkout-stepper">
+      {steps.map((step, i) => {
+        const stepNum = i + 1
+        const isCompleted = stepNum < currentStep
+        const isCurrent = stepNum === currentStep
+
+        return (
+          <div key={step.label} className="flex items-center flex-1 last:flex-initial">
+            {/* Step circle + label */}
+            <div className="flex flex-col items-center">
+              <div
+                className={`w-9 h-9 rounded-full flex items-center justify-center text-sm font-semibold transition-colors ${
+                  isCompleted
+                    ? 'bg-primary text-white'
+                    : isCurrent
+                      ? 'bg-primary text-white ring-2 ring-primary/30 ring-offset-2'
+                      : 'bg-neutral-200 text-neutral-500'
+                }`}
+              >
+                {isCompleted ? '✓' : step.icon}
+              </div>
+              <span
+                className={`text-xs mt-1.5 whitespace-nowrap ${
+                  isCurrent ? 'font-semibold text-primary' : 'text-neutral-500'
+                }`}
+              >
+                {step.label}
+              </span>
+            </div>
+
+            {/* Connecting line */}
+            {stepNum < steps.length && (
+              <div className="flex-1 mx-2 mb-5">
+                <div
+                  className={`h-0.5 w-full transition-colors ${
+                    isCompleted ? 'bg-primary' : 'bg-neutral-200'
+                  }`}
+                />
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Visual 3-step progress indicator at checkout top
- Steps: Παραγγελία (Order) → Στοιχεία (Details) → Πληρωμή (Payment)
- Green completed circles, ring-highlighted current step, connecting lines
- Reduces cart abandonment by showing clear progress, especially on mobile

## Changes
| File | Change |
|------|--------|
| `CheckoutStepper.tsx` | NEW — reusable stepper component (70 LOC) |
| `checkout/page.tsx` | Import + render stepper (step 1 main view, step 3 Stripe view) |

## Test plan
- Visit /checkout with items in cart → stepper shows step 1 highlighted
- Select card payment and proceed → stepper shows step 3 highlighted
- Verify responsive layout on mobile (320px+)
- Verify stepper doesn't appear on empty cart or loading states