### PR TITLE
feat(T2-02): Per-producer shipping/delivery emails

### DIFF
--- a/backend/app/Mail/ProducerOrderShipped.php
+++ b/backend/app/Mail/ProducerOrderShipped.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Order;
+use App\Models\Producer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * T2-02: Notify producer when their items in an order are shipped/delivered.
+ * Contains ONLY items belonging to this specific producer.
+ */
+class ProducerOrderShipped extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public Collection $producerItems;
+
+    public function __construct(
+        public Order $order,
+        public Producer $producer,
+        public string $eventStatus = 'shipped'
+    ) {
+        $this->producerItems = $order->orderItems->filter(
+            fn ($item) => $item->producer_id === $producer->id
+        );
+    }
+
+    public function envelope(): Envelope
+    {
+        $verb = $this->eventStatus === 'delivered' ? 'παραδόθηκε' : 'στάλθηκε';
+        return new Envelope(
+            subject: "Η παραγγελία #{$this->order->id} {$verb} - Dixis",
+        );
+    }
+
+    public function content(): Content
+    {
+        $producerSubtotal = $this->producerItems->sum('total_price');
+
+        return new Content(
+            view: 'emails.producers.order-shipped',
+            with: [
+                'order' => $this->order,
+                'producer' => $this->producer,
+                'orderNumber' => $this->order->id,
+                'items' => $this->producerItems,
+                'itemCount' => $this->producerItems->count(),
+                'producerSubtotal' => number_format($producerSubtotal, 2),
+                'isDelivered' => $this->eventStatus === 'delivered',
+                'customerName' => $this->getCustomerName(),
+            ],
+        );
+    }
+
+    private function getCustomerName(): string
+    {
+        $address = $this->order->shipping_address;
+        if (is_array($address) && isset($address['name'])) {
+            return $address['name'];
+        }
+        return 'Πελάτης';
+    }
+}

--- a/backend/app/Services/OrderEmailService.php
+++ b/backend/app/Services/OrderEmailService.php
@@ -7,6 +7,7 @@ use App\Mail\ConsumerOrderPlaced;
 use App\Mail\OrderDelivered;
 use App\Mail\OrderShipped;
 use App\Mail\ProducerNewOrder;
+use App\Mail\ProducerOrderShipped;
 use App\Models\Order;
 use App\Models\OrderNotification;
 use App\Models\Producer;
@@ -87,6 +88,65 @@ class OrderEmailService
                 'error' => $e->getMessage(),
             ]);
             // Don't throw - graceful failure
+        }
+
+        // T2-02: Send per-producer notification for shipped/delivered
+        $this->sendProducerStatusNotifications($order, $newStatus);
+    }
+
+    /**
+     * T2-02: Send shipped/delivered notification to each producer with items in this order.
+     */
+    protected function sendProducerStatusNotifications(Order $order, string $status): void
+    {
+        $order->load('orderItems.producer');
+
+        $producerIds = $order->orderItems
+            ->pluck('producer_id')
+            ->unique()
+            ->filter();
+
+        $event = "order_{$status}";
+
+        foreach ($producerIds as $producerId) {
+            $producer = Producer::with('user')->find($producerId);
+            if (!$producer) {
+                continue;
+            }
+
+            $email = $producer->user?->email ?? $producer->email ?? null;
+            if (!$email) {
+                continue;
+            }
+
+            // Idempotency check
+            if (OrderNotification::alreadySent($order->id, 'producer', $producerId, $event)) {
+                continue;
+            }
+
+            try {
+                Mail::to($email)->send(new ProducerOrderShipped($order, $producer, $status));
+
+                OrderNotification::recordSent(
+                    $order->id,
+                    'producer',
+                    $producerId,
+                    $email,
+                    $event
+                );
+
+                Log::info("T2-02: Producer {$event} notification sent", [
+                    'order_id' => $order->id,
+                    'producer_id' => $producerId,
+                    'email' => $this->maskEmail($email),
+                ]);
+            } catch (\Exception $e) {
+                Log::error("T2-02: Failed to send producer {$event} notification", [
+                    'order_id' => $order->id,
+                    'producer_id' => $producerId,
+                    'error' => $e->getMessage(),
+                ]);
+            }
         }
     }
 

--- a/backend/resources/views/emails/producers/order-shipped.blade.php
+++ b/backend/resources/views/emails/producers/order-shipped.blade.php
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="el">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ $isDelivered ? 'Παραγγελία Παραδόθηκε' : 'Παραγγελία Στάλθηκε' }} - Dixis</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: {{ $isDelivered ? '#059669' : '#2563eb' }}; color: white; padding: 20px; text-align: center; border-radius: 8px 8px 0 0; }
+        .content { background: #f9fafb; padding: 20px; border: 1px solid #e5e7eb; }
+        .order-details { background: white; padding: 15px; border-radius: 8px; margin: 15px 0; }
+        .item { padding: 10px 0; border-bottom: 1px solid #e5e7eb; }
+        .item:last-child { border-bottom: none; }
+        .total-row { display: flex; justify-content: space-between; padding: 5px 0; font-weight: bold; }
+        .footer { text-align: center; padding: 20px; color: #6b7280; font-size: 14px; }
+        .highlight { color: #2563eb; font-weight: bold; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1 style="margin: 0;">{{ $isDelivered ? 'Παραγγελία Παραδόθηκε' : 'Παραγγελία Στάλθηκε' }}</h1>
+    </div>
+
+    <div class="content">
+        <p>Γεια σας <strong>{{ $producer->name }}</strong>,</p>
+
+        @if($isDelivered)
+            <p>Η παραγγελία <span class="highlight">#{{ $orderNumber }}</span> παραδόθηκε στον/στην <strong>{{ $customerName }}</strong>.</p>
+        @else
+            <p>Η παραγγελία <span class="highlight">#{{ $orderNumber }}</span> στάλθηκε στον/στην <strong>{{ $customerName }}</strong>.</p>
+        @endif
+
+        <div class="order-details">
+            <h3>Τα Προϊόντα σας ({{ $itemCount }})</h3>
+
+            @foreach($items as $item)
+            <div class="item">
+                <strong>{{ $item->product_name }}</strong><br>
+                Ποσότητα: {{ $item->quantity }} {{ $item->product_unit ?? 'τεμ.' }}<br>
+                Τιμή: &euro;{{ number_format($item->total_price, 2) }}
+            </div>
+            @endforeach
+
+            <div class="total-row">
+                <span>Σύνολο:</span>
+                <span>&euro;{{ $producerSubtotal }}</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="footer">
+        <p>Dixis - Φρέσκα προϊόντα από τοπικούς παραγωγούς</p>
+        <p>&copy; {{ date('Y') }} Dixis. Με επιφύλαξη παντός δικαιώματος.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Multi-producer orders now send **separate emails** to each producer when their items ship/deliver
- Previously only the consumer received a single "shipped" email — producers had no visibility
- Follows same idempotent pattern as existing `sendProducerNotifications()` (Pass 53)

## Changes
| File | Change |
|------|--------|
| `ProducerOrderShipped.php` | NEW Mailable — filters order items per producer, shipped/delivered variants |
| `order-shipped.blade.php` | NEW Blade template — blue header (shipped) or green (delivered), Greek copy |
| `OrderEmailService.php` | Added `sendProducerStatusNotifications()` + import, called after consumer email |

## How it works
1. Admin changes order status to "shipped" or "delivered"
2. Consumer gets existing OrderShipped/OrderDelivered email (unchanged)
3. **NEW**: Each producer with items in that order gets ProducerOrderShipped email
4. Idempotency via `OrderNotification::alreadySent()` prevents duplicate sends
5. Producer email only shows THEIR items (not other producers' items)

## Test plan
- Create order with items from 2 producers → mark shipped → verify BOTH producers get email
- Verify each producer email only shows their own items
- Re-trigger shipped status → verify no duplicate emails sent (idempotency)
- Verify delivered variant shows green header + "παραδόθηκε" copy