### PR TITLE
feat(T2.5-01+02): Admin middleware + stock lock race fix

### DIFF
--- a/backend/app/Http/Controllers/Api/OrderController.php
+++ b/backend/app/Http/Controllers/Api/OrderController.php
@@ -100,11 +100,16 @@ class OrderController extends Controller
             $insufficientStock = [];
 
             foreach ($cartItems as $cartItem) {
-                $product = $cartItem->product;
+                // T2.5-02: Re-fetch with row-level lock to prevent race conditions.
+                // Without lockForUpdate(), two concurrent checkouts could both pass
+                // the stock check and oversell. Matches V1 OrderController pattern.
+                $product = Product::where('id', $cartItem->product_id)
+                    ->lockForUpdate()
+                    ->first();
 
                 // Check if product is still active
-                if (! $product->is_active) {
-                    $unavailableProducts[] = $product->name;
+                if (! $product || ! $product->is_active) {
+                    $unavailableProducts[] = $cartItem->product->name ?? "Product #{$cartItem->product_id}";
 
                     continue;
                 }

--- a/backend/app/Http/Middleware/EnsureAdmin.php
+++ b/backend/app/Http/Middleware/EnsureAdmin.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * T2.5-01: Centralized admin role gate.
+ *
+ * Applied to all admin/* and refunds/* route groups so that
+ * a customer or producer token can never reach admin endpoints.
+ * Individual controllers may still contain inline checks as
+ * defense-in-depth — this middleware is the first barrier.
+ */
+class EnsureAdmin
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->user() || $request->user()->role !== 'admin') {
+            return response()->json([
+                'error' => 'forbidden',
+                'message' => 'Admin access required.',
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -26,6 +26,7 @@ return Application::configure(basePath: dirname(__DIR__))
         // Register custom middleware aliases
         $middleware->alias([
             'auth.optional' => \App\Http\Middleware\OptionalSanctumAuth::class,
+            'admin' => \App\Http\Middleware\EnsureAdmin::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -324,8 +324,8 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:30,1'); // 30 status checks per minute
     });
 
-    // Refunds (admin only - simplified auth for now)
-    Route::middleware('auth:sanctum')->prefix('refunds')->group(function () {
+    // Refunds (admin only) — T2.5-01: added 'admin' middleware
+    Route::middleware(['auth:sanctum', 'admin'])->prefix('refunds')->group(function () {
         Route::get('orders', [App\Http\Controllers\Api\RefundController::class, 'index'])
             ->middleware('throttle:60,1'); // 60 requests per minute
         Route::post('orders/{order}', [App\Http\Controllers\Api\RefundController::class, 'create'])
@@ -348,8 +348,8 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:10,1'); // 10 requests per minute
     });
 
-    // Admin Analytics (simplified auth for now - should be admin middleware in production)
-    Route::middleware('auth:sanctum')->prefix('admin/analytics')->group(function () {
+    // Admin Analytics — T2.5-01: added 'admin' middleware
+    Route::middleware(['auth:sanctum', 'admin'])->prefix('admin/analytics')->group(function () {
         Route::get('sales', [App\Http\Controllers\Api\Admin\AnalyticsController::class, 'sales'])
             ->middleware('throttle:60,1'); // 60 requests per minute
         Route::get('orders', [App\Http\Controllers\Api\Admin\AnalyticsController::class, 'orders'])
@@ -362,16 +362,16 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:120,1'); // 120 requests per minute for dashboard
     });
 
-    // Admin Product Moderation (Pass 24)
-    Route::middleware('auth:sanctum')->prefix('admin/products')->group(function () {
+    // Admin Product Moderation (Pass 24) — T2.5-01: added 'admin' middleware
+    Route::middleware(['auth:sanctum', 'admin'])->prefix('admin/products')->group(function () {
         Route::get('pending', [App\Http\Controllers\Api\Admin\AdminProductController::class, 'pending'])
             ->middleware('throttle:60,1'); // 60 requests per minute
         Route::patch('{product}/moderate', [App\Http\Controllers\Api\Admin\AdminProductController::class, 'moderate'])
             ->middleware('throttle:30,1'); // 30 moderation actions per minute
     });
 
-    // Admin Order Management (Pass 25 + Pass 61)
-    Route::middleware('auth:sanctum')->prefix('admin/orders')->group(function () {
+    // Admin Order Management (Pass 25 + Pass 61) — T2.5-01: added 'admin' middleware
+    Route::middleware(['auth:sanctum', 'admin'])->prefix('admin/orders')->group(function () {
         Route::get('/', [App\Http\Controllers\Api\Admin\AdminOrderController::class, 'index'])
             ->middleware('throttle:60,1'); // 60 requests per minute (Pass 61)
         Route::patch('{order}/status', [App\Http\Controllers\Api\Admin\AdminOrderController::class, 'updateStatus'])
@@ -381,8 +381,8 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:30,1'); // 30 payment confirms per minute
     });
 
-    // Admin Shipping (read-only rate tables interface)
-    Route::middleware('auth:sanctum')->prefix('admin/shipping')->group(function () {
+    // Admin Shipping (read-only rate tables interface) — T2.5-01: added 'admin' middleware
+    Route::middleware(['auth:sanctum', 'admin'])->prefix('admin/shipping')->group(function () {
         Route::get('rates', [App\Http\Controllers\Api\Admin\ShippingController::class, 'getRates'])
             ->middleware('throttle:60,1'); // 60 requests per minute
         Route::get('zones', [App\Http\Controllers\Api\Admin\ShippingController::class, 'getZoneInfo'])
@@ -391,8 +391,8 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:30,1'); // 30 simulations per minute
     });
 
-    // PRODUCER-ONBOARD-01: Admin Producer Management
-    Route::middleware('auth:sanctum')->prefix('admin/producers')->group(function () {
+    // PRODUCER-ONBOARD-01: Admin Producer Management — T2.5-01: added 'admin' middleware
+    Route::middleware(['auth:sanctum', 'admin'])->prefix('admin/producers')->group(function () {
         Route::get('/', [App\Http\Controllers\Api\Admin\AdminProducerController::class, 'index'])
             ->middleware('throttle:60,1');
         Route::patch('{producer}/approve', [App\Http\Controllers\Api\Admin\AdminProducerController::class, 'approve'])
@@ -401,8 +401,8 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:30,1');
     });
 
-    // Admin Commission Rules CRUD
-    Route::middleware('auth:sanctum')->prefix('admin/commission-rules')->group(function () {
+    // Admin Commission Rules CRUD — T2.5-01: added 'admin' middleware
+    Route::middleware(['auth:sanctum', 'admin'])->prefix('admin/commission-rules')->group(function () {
         Route::get('/', [App\Http\Controllers\Api\Admin\AdminCommissionController::class, 'index'])
             ->middleware('throttle:60,1');
         Route::post('/', [App\Http\Controllers\Api\Admin\AdminCommissionController::class, 'store'])
@@ -415,8 +415,8 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:60,1');
     });
 
-    // Pass PAYOUT-03 + PAYOUT-05: Admin Settlement Dashboard + CSV Export
-    Route::middleware('auth:sanctum')->prefix('admin/settlements')->group(function () {
+    // Pass PAYOUT-03 + PAYOUT-05: Admin Settlement Dashboard + CSV Export — T2.5-01: added 'admin' middleware
+    Route::middleware(['auth:sanctum', 'admin'])->prefix('admin/settlements')->group(function () {
         Route::get('summary', [App\Http\Controllers\Api\Admin\AdminSettlementController::class, 'summary'])
             ->middleware('throttle:60,1');
         Route::get('export', [App\Http\Controllers\Api\Admin\SettlementExportController::class, 'exportCsv'])
@@ -431,8 +431,8 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:30,1');
     });
 
-    // Pass COMM-ENGINE-TOGGLE-01: Admin toggle for commission feature flag
-    Route::middleware('auth:sanctum')->prefix('admin/settings')->group(function () {
+    // Pass COMM-ENGINE-TOGGLE-01: Admin toggle for commission feature flag — T2.5-01: added 'admin' middleware
+    Route::middleware(['auth:sanctum', 'admin'])->prefix('admin/settings')->group(function () {
         Route::get('commission-engine', function (Illuminate\Http\Request $request) {
             if ($request->user()?->role !== 'admin') {
                 return response()->json(['error' => 'Forbidden'], 403);


### PR DESCRIPTION
## Summary
- **T2.5-01**: Add centralized `EnsureAdmin` middleware checking `role === 'admin'` and apply to all 9 admin route groups. Previously refunds, analytics, and shipping endpoints had **NO admin check** — any authenticated user (customer, producer) could access them.
- **T2.5-02**: Add `lockForUpdate()` to cart checkout product fetch inside DB transaction. Prevents two concurrent checkouts from overselling the same product. Matches existing V1 OrderController pattern (line 131).

## Files Changed
- NEW: `backend/app/Http/Middleware/EnsureAdmin.php` — middleware class
- `backend/bootstrap/app.php` — register `'admin'` alias
- `backend/routes/api.php` — apply `['auth:sanctum', 'admin']` to all admin groups
- `backend/app/Http/Controllers/Api/OrderController.php` — `lockForUpdate()` in checkout

## Test plan
- [ ] Non-admin user calling `GET /api/admin/analytics/sales` → 403
- [ ] Non-admin user calling `POST /api/refunds/orders/{id}` → 403
- [ ] Admin user calling same endpoints → works as before
- [ ] Two concurrent checkouts for stock=1 product → only 1 succeeds
- [ ] Regular checkout flow still works