### PR TITLE
feat(T2.5-03/04): queue emails + consistent JSON exception handler

### DIFF
--- a/backend/app/Services/InventoryService.php
+++ b/backend/app/Services/InventoryService.php
@@ -66,7 +66,7 @@ class InventoryService
 
         // T1-03: Send email notification to producer
         try {
-            Mail::to($user->email)->send(new LowStockAlert($product, $producer));
+            Mail::to($user->email)->queue(new LowStockAlert($product, $producer));
 
             Log::info('Low stock email sent', [
                 'to' => $user->email,

--- a/backend/app/Services/NotificationService.php
+++ b/backend/app/Services/NotificationService.php
@@ -87,7 +87,7 @@ class NotificationService
 
         // T2-01: Send actual refund confirmation email
         try {
-            Mail::to($buyer->email)->send(new RefundConfirmation($order, $refundAmount));
+            Mail::to($buyer->email)->queue(new RefundConfirmation($order, $refundAmount));
             Log::info('Refund confirmation email sent', [
                 'to' => $buyer->email,
                 'order_id' => $order->id,

--- a/backend/app/Services/OrderEmailService.php
+++ b/backend/app/Services/OrderEmailService.php
@@ -68,7 +68,7 @@ class OrderEmailService
                 ? new OrderShipped($order)
                 : new OrderDelivered($order);
 
-            Mail::to($email)->send($mailable);
+            Mail::to($email)->queue($mailable);
 
             OrderNotification::recordSent(
                 $order->id,
@@ -125,7 +125,7 @@ class OrderEmailService
             }
 
             try {
-                Mail::to($email)->send(new ProducerOrderShipped($order, $producer, $status));
+                Mail::to($email)->queue(new ProducerOrderShipped($order, $producer, $status));
 
                 OrderNotification::recordSent(
                     $order->id,
@@ -198,7 +198,7 @@ class OrderEmailService
         }
 
         try {
-            Mail::to($email)->send(new ConsumerOrderPlaced($order));
+            Mail::to($email)->queue(new ConsumerOrderPlaced($order));
 
             OrderNotification::recordSent(
                 $order->id,
@@ -261,7 +261,7 @@ class OrderEmailService
             }
 
             try {
-                Mail::to($email)->send(new ProducerNewOrder($order, $producer));
+                Mail::to($email)->queue(new ProducerNewOrder($order, $producer));
 
                 OrderNotification::recordSent(
                     $order->id,
@@ -309,7 +309,7 @@ class OrderEmailService
         }
 
         try {
-            Mail::to($email)->send(new AdminNewOrder($order));
+            Mail::to($email)->queue(new AdminNewOrder($order));
 
             OrderNotification::recordSent(
                 $order->id,

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -33,8 +33,38 @@ return Application::configure(basePath: dirname(__DIR__))
         $exceptions->render(function (\Illuminate\Auth\AuthenticationException $e, $request) {
             if ($request->is('api/*')) {
                 return response()->json([
-                    'message' => 'Unauthenticated.'
+                    'error' => 'unauthenticated',
+                    'message' => 'Unauthenticated.',
                 ], 401);
+            }
+        });
+
+        // T2.5-04: Consistent JSON error responses for API routes
+        $exceptions->render(function (\Illuminate\Database\Eloquent\ModelNotFoundException $e, $request) {
+            if ($request->is('api/*')) {
+                $model = class_basename($e->getModel());
+                return response()->json([
+                    'error' => 'not_found',
+                    'message' => "{$model} not found.",
+                ], 404);
+            }
+        });
+
+        $exceptions->render(function (\Illuminate\Auth\Access\AuthorizationException $e, $request) {
+            if ($request->is('api/*')) {
+                return response()->json([
+                    'error' => 'forbidden',
+                    'message' => 'Forbidden.',
+                ], 403);
+            }
+        });
+
+        $exceptions->render(function (\Symfony\Component\HttpKernel\Exception\NotFoundHttpException $e, $request) {
+            if ($request->is('api/*')) {
+                return response()->json([
+                    'error' => 'not_found',
+                    'message' => 'Route not found.',
+                ], 404);
             }
         });
     })->create();


### PR DESCRIPTION
## Summary
- **T2.5-03**: Convert all `Mail::to()->send()` to `Mail::to()->queue()` across 3 services (OrderEmailService, InventoryService, NotificationService) — 7 call sites total. Prevents checkout response from hanging if mail provider is slow.
- **T2.5-04**: Expand exception handler in `bootstrap/app.php` with consistent JSON responses for API routes: `ModelNotFoundException` → 404, `AuthorizationException` → 403, `NotFoundHttpException` → 404.

## Changes
| File | Change |
|------|--------|
| `backend/app/Services/OrderEmailService.php` | 5× `send()` → `queue()` |
| `backend/app/Services/InventoryService.php` | 1× `send()` → `queue()` |
| `backend/app/Services/NotificationService.php` | 1× `send()` → `queue()` |
| `backend/bootstrap/app.php` | +3 exception handlers for API routes |

## Test plan
- [ ] `GET /api/orders/999999` → `{"error":"not_found","message":"Order not found."}` (404)
- [ ] `GET /api/nonexistent-route` → `{"error":"not_found","message":"Route not found."}` (404)
- [ ] Checkout with email → response returns fast (email queued, not blocking)
- [ ] Non-admin hitting admin route → `{"error":"forbidden","message":"Forbidden."}` (403)

## Owner task
⚠️ Queue worker must be running on production for emails to actually send:
```bash
pm2 start "php artisan queue:work --sleep=3 --tries=3 --max-time=3600" --name dixis-queue
```