### PR TITLE
perf(T3-01): enable ISR on product detail pages

### DIFF
--- a/frontend/src/app/(storefront)/products/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/page.tsx
@@ -11,8 +11,8 @@ import { getBaseUrl } from '@/lib/site';
 import { getServerApiUrl } from '@/env';
 import { getCategoryBySlug } from '@/data/categories';
 
-export const dynamic = 'force-dynamic';
-export const revalidate = 0;
+// T3-01: ISR — regenerate every 5 minutes (was force-dynamic + revalidate=0)
+export const revalidate = 300;
 
 // Helper to fetch product from API
 async function getProductById(id: string) {
@@ -37,7 +37,7 @@ async function getProductById(id: string) {
   }
 
   try {
-    const res = await fetch(`${base}/public/products/${id}`, { cache: 'no-store' });
+    const res = await fetch(`${base}/public/products/${id}`, { next: { revalidate: 300 } });
     if (!res.ok) return null;
     const json = await res.json();
     const raw = json?.data ?? json;


### PR DESCRIPTION
## Summary
- Replace `force-dynamic` + `revalidate=0` with `revalidate=300` (5-min ISR) on product detail pages
- Change `cache: 'no-store'` to `next: { revalidate: 300 }` on the product API fetch
- Previously every product page request hit the Laravel API; now pages are cached and regenerated incrementally
- Catalog page already uses `revalidate: 60` — this aligns the product detail page with ISR

## Test plan
- [ ] Product page renders correctly with `npm run build && npm start`
- [ ] Second visit within 5 minutes serves cached page (check Network tab)
- [ ] Product data refreshes after 5 minutes
- [ ] CI E2E tests pass (CI uses its own test server, ISR doesn't affect test behavior)