### PR TITLE
feat(T3-02): checkout trust signals + delivery estimate

### DIFF
--- a/frontend/src/app/(storefront)/checkout/OrderSummary.tsx
+++ b/frontend/src/app/(storefront)/checkout/OrderSummary.tsx
@@ -87,6 +87,16 @@ export default function OrderSummary({
           </div>
         )}
 
+        {/* T3-02: Estimated delivery time */}
+        {(cartShippingQuote || shippingQuote) && !cartShippingError && (
+          <div className="flex items-center gap-1.5 text-xs text-neutral-500 pt-1" data-testid="delivery-estimate">
+            <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span>Εκτιμώμενη παράδοση: 2–5 εργάσιμες ημέρες</span>
+          </div>
+        )}
+
         {/* Total with shipping + COD fee */}
         <div className="flex justify-between font-bold text-lg pt-2 border-t" data-testid="total-line">
           <span>{t('checkoutPage.total')}:</span>

--- a/frontend/src/app/(storefront)/checkout/page.tsx
+++ b/frontend/src/app/(storefront)/checkout/page.tsx
@@ -173,6 +173,14 @@ function CheckoutContent() {
                   ? t('checkoutPage.continueToPayment')
                   : t('checkoutPage.completeOrder')}
           </button>
+
+          {/* T3-02: Trust signals for Greek market */}
+          <div className="mt-3 flex items-center justify-center gap-2 text-xs text-neutral-500">
+            <svg className="w-3.5 h-3.5 text-neutral-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+            <span>Ασφαλής πληρωμή · Τα στοιχεία σας προστατεύονται</span>
+          </div>
         </form>
       </div>
 

--- a/frontend/src/components/checkout/PaymentMethodSelector.tsx
+++ b/frontend/src/components/checkout/PaymentMethodSelector.tsx
@@ -100,6 +100,13 @@ export default function PaymentMethodSelector({
         </label>
       )}
 
+      {/* T3-02: Stripe trust text — payment data is not stored on Dixis */}
+      {cardEnabled && (
+        <p className="text-xs text-neutral-500 mt-1 pl-7">
+          Τα στοιχεία πληρωμής δεν αποθηκεύονται στο Dixis
+        </p>
+      )}
+
       {/* Pass PAY-GUEST-CARD-GATE-01: Message for guests when card flag is enabled but user not logged in */}
       {/* Only render after auth loading completes to avoid hydration mismatch */}
       {!authLoading && !isAuthenticated && process.env.NEXT_PUBLIC_PAYMENTS_CARD_FLAG === 'true' && (


### PR DESCRIPTION
## Summary
- 🔒 Lock icon + "Ασφαλής πληρωμή · Τα στοιχεία σας προστατεύονται" below checkout submit button
- 💳 "Τα στοιχεία πληρωμής δεν αποθηκεύονται στο Dixis" under card payment option (only shows when card enabled)
- 🕐 "Εκτιμώμενη παράδοση: 2–5 εργάσιμες ημέρες" in order summary after shipping quote loads

Greek customers are skeptical of new platforms — trust signals at checkout are critical for reducing cart abandonment. Static "2-5 days" covers typical zones (Attica 1-2d, Mainland 3d, Islands up to 5d).

## Test plan
- [ ] Checkout page: lock icon + trust text visible below submit button
- [ ] Card payment option: Stripe trust text appears when card option is enabled (logged in)
- [ ] Order summary: delivery estimate appears after postal code triggers shipping quote
- [ ] All elements hidden when shipping quote not loaded
- [ ] CI E2E tests pass