### PR TITLE
feat(T3-03): BreadcrumbList JSON-LD + Inter font with Greek subset

### DIFF
--- a/frontend/src/app/(storefront)/products/[id]/page.tsx
+++ b/frontend/src/app/(storefront)/products/[id]/page.tsx
@@ -156,6 +156,19 @@ export default async function Page({ params }:{ params: Promise<{ id:string }> }
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
+      {/* T3-03: BreadcrumbList JSON-LD for Google rich results */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'BreadcrumbList',
+          'itemListElement': [
+            { '@type': 'ListItem', 'position': 1, 'name': 'Αρχική', 'item': baseUrl },
+            { '@type': 'ListItem', 'position': 2, 'name': 'Προϊόντα', 'item': `${baseUrl}/products` },
+            { '@type': 'ListItem', 'position': 3, 'name': p.title, 'item': `${baseUrl}/products/${id}` },
+          ],
+        }) }}
+      />
       <main className="container mx-auto px-4 py-6">
       {/* Breadcrumb */}
       <nav className="mb-6 text-sm" aria-label="Breadcrumb">

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ToastProvider } from "@/contexts/ToastContext";
@@ -12,9 +12,11 @@ import Footer from '@/components/layout/Footer';
 import IOSGuard from './IOSGuard';
 import Analytics from '@/components/Analytics';
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+// T3-03: Inter has full Greek subset support (Geist only has latin)
+const inter = Inter({
+  variable: "--font-geist-sans",  // Keep same CSS var for zero Tailwind breakage
+  subsets: ["latin", "greek", "greek-ext"],
+  display: "swap",
 });
 
 const geistMono = Geist_Mono({
@@ -105,7 +107,7 @@ export default function RootLayout({
   return (
     <html lang="el-GR" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${inter.variable} ${geistMono.variable} antialiased`}
         suppressHydrationWarning
       >
         <IOSGuard />


### PR DESCRIPTION
## Summary
- **BreadcrumbList JSON-LD**: Product detail pages now include structured `BreadcrumbList` schema (Αρχική → Προϊόντα → Product Name). This enables Google rich search result breadcrumbs.
- **Inter font with Greek subset**: Swap from Geist (latin-only) to Inter (latin + greek + greek-ext). Greek characters now render in Inter instead of falling back to system fonts. Same CSS variable (`--font-geist-sans`) ensures zero Tailwind config changes.

## Changes
| File | Change |
|------|--------|
| `products/[id]/page.tsx` | +BreadcrumbList `<script type="application/ld+json">` after Product schema |
| `layout.tsx` | Geist → Inter import, add `greek`/`greek-ext` subsets, add `display: "swap"` |

## Test plan
- [ ] View source on product page → BreadcrumbList JSON-LD present with 3 items
- [ ] Google Rich Results Test validates Product + BreadcrumbList schemas
- [ ] Greek text renders in Inter font (check DevTools > Computed > font-family)
- [ ] No layout shifts (Inter metrics similar to Geist)
- [ ] CI E2E tests pass