### PR TITLE
fix(T4): skip link + branded global error + cart clear confirmation

### DIFF
--- a/frontend/src/app/(storefront)/cart/page.tsx
+++ b/frontend/src/app/(storefront)/cart/page.tsx
@@ -90,12 +90,16 @@ export default function CartPage() {
                 <span className="text-lg font-bold" data-testid="total">Σύνολο: {fmt.format(totalCents / 100)}</span>
               </div>
               <p className="text-xs text-neutral-500 mt-2">Οι τελικές χρεώσεις (μεταφορικά/ΦΠΑ) υπολογίζονται κατά την ολοκλήρωση.</p>
-              <button onClick={clear} className="mt-2 w-full inline-flex justify-center border border-red-300 text-red-600 px-4 py-2 rounded-lg hover:bg-red-50">
+              <button
+                onClick={() => { if (window.confirm('Είστε σίγουροι ότι θέλετε να αδειάσετε το καλάθι;')) clear() }}
+                className="mt-2 w-full inline-flex justify-center border border-red-300 text-red-600 px-4 py-2 rounded-lg hover:bg-red-50"
+                data-testid="clear-cart"
+              >
                 Καθαρισμός
               </button>
               <button
                 onClick={handleCheckout}
-                className="mt-4 w-full inline-flex justify-center bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light"
+                className="mt-4 w-full inline-flex justify-center bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-light active:opacity-90 touch-manipulation"
                 data-testid="go-checkout"
               >
                 Ολοκλήρωση παραγγελίας

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -2,18 +2,84 @@
 import { useEffect } from 'react';
 import * as Sentry from '@sentry/nextjs';
 
-export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
     try {
       Sentry.captureException(error);
     } catch {}
   }, [error]);
 
+  // T4: Branded error page with inline styles (CSS/Tailwind may not load in global-error)
   return (
-    <html>
-      <body className="p-4">
-        <h1>Κάτι πήγε στραβά</h1>
-        <p>Παρακαλούμε δοκιμάστε ξανά.</p>
+    <html lang="el-GR">
+      <body style={{
+        margin: 0,
+        fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
+        backgroundColor: '#fafafa',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        padding: '1rem',
+      }}>
+        <div style={{
+          maxWidth: '420px',
+          textAlign: 'center',
+          backgroundColor: '#fff',
+          borderRadius: '12px',
+          border: '1px solid #e5e5e5',
+          padding: '2.5rem 2rem',
+        }}>
+          <div style={{ fontSize: '3rem', marginBottom: '0.75rem' }} aria-hidden="true">
+            🍊
+          </div>
+          <h1 style={{ fontSize: '1.25rem', fontWeight: 700, color: '#171717', margin: '0 0 0.5rem' }}>
+            Κάτι πήγε στραβά
+          </h1>
+          <p style={{ fontSize: '0.875rem', color: '#737373', lineHeight: 1.6, margin: '0 0 1.5rem' }}>
+            Ζητούμε συγγνώμη. Παρουσιάστηκε ένα απρόσμενο σφάλμα.
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+            <button
+              onClick={() => reset()}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                height: '44px',
+                backgroundColor: '#16a34a',
+                color: '#fff',
+                border: 'none',
+                borderRadius: '8px',
+                fontSize: '0.875rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+                padding: '0 1.5rem',
+              }}
+            >
+              Δοκιμάστε ξανά
+            </button>
+            <a
+              href="/"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                height: '44px',
+                backgroundColor: 'transparent',
+                color: '#525252',
+                border: '1px solid #d4d4d4',
+                borderRadius: '8px',
+                fontSize: '0.875rem',
+                fontWeight: 500,
+                textDecoration: 'none',
+                padding: '0 1.5rem',
+              }}
+            >
+              Αρχική σελίδα
+            </a>
+          </div>
+        </div>
       </body>
     </html>
   );

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -174,7 +174,7 @@ export default function RootLayout({
               <AuthProvider>
                 <Header />
                 <div className="max-w-6xl mx-auto px-4 py-8">
-                  <main data-testid="page-root">
+                  <main id="main-content" data-testid="page-root">
                     {children}
                   </main>
                 </div>


### PR DESCRIPTION
## Summary
- **Skip link fix**: Added `id="main-content"` to `<main>` in root layout — SkipLink was pointing to non-existent anchor on every non-home page (HIGH accessibility fix)
- **Global error branding**: Replaced bare `<h1>` + `<p>` with Dixis-branded error page including retry button and home link (uses inline styles since CSS may not load in global-error boundary)
- **Cart clear confirmation**: Added `window.confirm()` before emptying cart — prevents accidental data loss on mobile (irreversible action, no undo)
- **Cart checkout button**: Added `touch-manipulation` + `active:opacity-90` for mobile tap feedback

## Test plan
- [ ] Tab through any page → SkipLink focuses `#main-content`
- [ ] Trigger global error (remove ErrorBoundary temporarily) → see branded error page with retry + home buttons
- [ ] Cart page → click "Καθαρισμός" → see Greek confirm dialog → cancel preserves cart
- [ ] Mobile: Cart "Ολοκλήρωση παραγγελίας" button has no double-tap zoom delay