### PR TITLE
feat(T4): checkout form validation + ARIA accessibility

### DIFF
--- a/frontend/src/app/(storefront)/checkout/CustomerDetailsForm.tsx
+++ b/frontend/src/app/(storefront)/checkout/CustomerDetailsForm.tsx
@@ -1,8 +1,13 @@
 'use client'
 
-import { useRef } from 'react'
+/**
+ * T4: Enhanced with per-field validation on blur + ARIA attributes.
+ * Validates: name, phone (Greek format), email, address, city, postcode.
+ * Shows inline Greek error messages with role="alert" for screen readers.
+ */
+
+import { useRef, useState, useCallback } from 'react'
 import { useTranslations } from '@/contexts/LocaleContext'
-import type { CartShippingQuote, ShippingQuote } from './types'
 
 interface SavedAddress {
   name?: string
@@ -22,6 +27,34 @@ interface CustomerDetailsFormProps {
   onClearShipping: () => void
 }
 
+/** Validate a single field; returns error message or empty string */
+function validateField(name: string, value: string, isGuest: boolean): string {
+  const v = value.trim()
+  switch (name) {
+    case 'name':
+      return v.length < 2 ? 'Παρακαλώ εισάγετε το ονοματεπώνυμό σας' : ''
+    case 'phone': {
+      const digits = v.replace(/[\s\-()]/g, '')
+      return !/^\+?\d{10,14}$/.test(digits)
+        ? 'Εισάγετε έγκυρο τηλέφωνο (π.χ. 6971234567)'
+        : ''
+    }
+    case 'email':
+      if (!isGuest && !v) return '' // optional for logged-in users
+      return !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)
+        ? 'Εισάγετε έγκυρη διεύθυνση email'
+        : ''
+    case 'address':
+      return v.length < 3 ? 'Παρακαλώ εισάγετε τη διεύθυνσή σας' : ''
+    case 'city':
+      return v.length < 2 ? 'Παρακαλώ εισάγετε την πόλη σας' : ''
+    case 'postcode':
+      return !/^\d{5}$/.test(v) ? 'Ο ΤΚ πρέπει να είναι 5 ψηφία' : ''
+    default:
+      return ''
+  }
+}
+
 export default function CustomerDetailsForm({
   isGuest,
   savedAddress,
@@ -33,6 +66,28 @@ export default function CustomerDetailsForm({
 }: CustomerDetailsFormProps) {
   const t = useTranslations()
   const postalDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Per-field error tracking
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+  const [touched, setTouched] = useState<Record<string, boolean>>({})
+
+  const handleBlur = useCallback(
+    (e: React.FocusEvent<HTMLInputElement>) => {
+      const { name, value } = e.target
+      setTouched((prev) => ({ ...prev, [name]: true }))
+      const error = validateField(name, value, isGuest)
+      setFieldErrors((prev) => ({ ...prev, [name]: error }))
+    },
+    [isGuest]
+  )
+
+  /** Dynamic class for inputs — red border when invalid + touched */
+  const inputClass = (name: string) =>
+    `w-full h-11 px-4 border rounded-lg text-base ${
+      touched[name] && fieldErrors[name]
+        ? 'border-red-400 focus:ring-red-300'
+        : 'border-neutral-300'
+    }`
 
   return (
     <>
@@ -53,6 +108,7 @@ export default function CustomerDetailsForm({
       )}
 
       <div className="space-y-4">
+        {/* Full name */}
         <div>
           <label htmlFor="checkout-name" className="block text-sm font-medium mb-1">{t('checkoutPage.fullName')}</label>
           <input
@@ -60,12 +116,20 @@ export default function CustomerDetailsForm({
             name="name"
             required
             autoComplete="name"
+            aria-required="true"
+            aria-invalid={touched.name && !!fieldErrors.name}
+            aria-describedby={touched.name && fieldErrors.name ? 'error-name' : undefined}
             defaultValue={savedAddress?.name || user?.name || ''}
-            className="w-full h-11 px-4 border rounded-lg text-base"
+            onBlur={handleBlur}
+            className={inputClass('name')}
             data-testid="checkout-name"
           />
+          {touched.name && fieldErrors.name && (
+            <p id="error-name" role="alert" className="text-xs text-red-600 mt-1">{fieldErrors.name}</p>
+          )}
         </div>
 
+        {/* Phone */}
         <div>
           <label htmlFor="checkout-phone" className="block text-sm font-medium mb-1">{t('checkoutPage.phone')}</label>
           <input
@@ -75,13 +139,21 @@ export default function CustomerDetailsForm({
             inputMode="tel"
             required
             autoComplete="tel"
+            aria-required="true"
+            aria-invalid={touched.phone && !!fieldErrors.phone}
+            aria-describedby={touched.phone && fieldErrors.phone ? 'error-phone' : undefined}
             placeholder="+30 210 1234567"
             defaultValue={savedAddress?.phone || ''}
-            className="w-full h-11 px-4 border rounded-lg text-base"
+            onBlur={handleBlur}
+            className={inputClass('phone')}
             data-testid="checkout-phone"
           />
+          {touched.phone && fieldErrors.phone && (
+            <p id="error-phone" role="alert" className="text-xs text-red-600 mt-1">{fieldErrors.phone}</p>
+          )}
         </div>
 
+        {/* Email */}
         <div>
           <label htmlFor="checkout-email" className="block text-sm font-medium mb-1">
             Email{isGuest && <span className="text-red-500 ml-1">*</span>}
@@ -93,17 +165,28 @@ export default function CustomerDetailsForm({
             inputMode="email"
             required={isGuest}
             autoComplete="email"
+            aria-required={isGuest}
+            aria-invalid={touched.email && !!fieldErrors.email}
+            aria-describedby={
+              (touched.email && fieldErrors.email ? 'error-email' : '') +
+              (isGuest ? ' email-hint' : '') || undefined
+            }
             defaultValue={user?.email || ''}
-            className="w-full h-11 px-4 border rounded-lg text-base"
+            onBlur={handleBlur}
+            className={inputClass('email')}
             data-testid="checkout-email"
           />
           {isGuest && (
-            <p className="text-xs text-neutral-500 mt-1">
+            <p id="email-hint" className="text-xs text-neutral-500 mt-1">
               {t('checkoutPage.emailRequired')}
             </p>
           )}
+          {touched.email && fieldErrors.email && (
+            <p id="error-email" role="alert" className="text-xs text-red-600 mt-1">{fieldErrors.email}</p>
+          )}
         </div>
 
+        {/* Address */}
         <div>
           <label htmlFor="checkout-address" className="block text-sm font-medium mb-1">{t('checkoutPage.address')}</label>
           <input
@@ -111,12 +194,20 @@ export default function CustomerDetailsForm({
             name="address"
             required
             autoComplete="street-address"
+            aria-required="true"
+            aria-invalid={touched.address && !!fieldErrors.address}
+            aria-describedby={touched.address && fieldErrors.address ? 'error-address' : undefined}
             defaultValue={savedAddress?.line1 || ''}
-            className="w-full h-11 px-4 border rounded-lg text-base"
+            onBlur={handleBlur}
+            className={inputClass('address')}
             data-testid="checkout-address"
           />
+          {touched.address && fieldErrors.address && (
+            <p id="error-address" role="alert" className="text-xs text-red-600 mt-1">{fieldErrors.address}</p>
+          )}
         </div>
 
+        {/* City */}
         <div>
           <label htmlFor="checkout-city" className="block text-sm font-medium mb-1">{t('checkoutPage.city')}</label>
           <input
@@ -124,12 +215,20 @@ export default function CustomerDetailsForm({
             name="city"
             required
             autoComplete="address-level2"
+            aria-required="true"
+            aria-invalid={touched.city && !!fieldErrors.city}
+            aria-describedby={touched.city && fieldErrors.city ? 'error-city' : undefined}
             defaultValue={savedAddress?.city || ''}
-            className="w-full h-11 px-4 border rounded-lg text-base"
+            onBlur={handleBlur}
+            className={inputClass('city')}
             data-testid="checkout-city"
           />
+          {touched.city && fieldErrors.city && (
+            <p id="error-city" role="alert" className="text-xs text-red-600 mt-1">{fieldErrors.city}</p>
+          )}
         </div>
 
+        {/* Postal code */}
         <div>
           <label htmlFor="checkout-postcode" className="block text-sm font-medium mb-1">{t('checkoutPage.postalCode')}</label>
           <input
@@ -139,6 +238,9 @@ export default function CustomerDetailsForm({
             inputMode="numeric"
             pattern="[0-9]{5}"
             autoComplete="postal-code"
+            aria-required="true"
+            aria-invalid={touched.postcode && !!fieldErrors.postcode}
+            aria-describedby={touched.postcode && fieldErrors.postcode ? 'error-postcode' : undefined}
             placeholder="10671"
             value={postalCode}
             onChange={(e) => {
@@ -156,9 +258,13 @@ export default function CustomerDetailsForm({
                 onClearShipping()
               }
             }}
-            className="w-full h-11 px-4 border rounded-lg text-base"
+            onBlur={handleBlur}
+            className={inputClass('postcode')}
             data-testid="checkout-postal"
           />
+          {touched.postcode && fieldErrors.postcode && (
+            <p id="error-postcode" role="alert" className="text-xs text-red-600 mt-1">{fieldErrors.postcode}</p>
+          )}
         </div>
       </div>
     </>

--- a/frontend/src/components/checkout/CheckoutStepper.tsx
+++ b/frontend/src/components/checkout/CheckoutStepper.tsx
@@ -4,6 +4,8 @@
  * T2-03: Visual checkout progress stepper.
  * Shows 3 steps: Παραγγελία → Στοιχεία → Πληρωμή
  * Reduces cart abandonment by showing progress, especially on mobile.
+ *
+ * T4: Added ARIA semantics (role="list", aria-current="step", aria-label)
  */
 
 interface Step {
@@ -24,49 +26,56 @@ interface CheckoutStepperProps {
 
 export default function CheckoutStepper({ currentStep }: CheckoutStepperProps) {
   return (
-    <div className="flex items-center justify-between mb-6" data-testid="checkout-stepper">
-      {steps.map((step, i) => {
-        const stepNum = i + 1
-        const isCompleted = stepNum < currentStep
-        const isCurrent = stepNum === currentStep
+    <nav aria-label="Βήματα ολοκλήρωσης παραγγελίας" data-testid="checkout-stepper">
+      <ol className="flex items-center justify-between mb-6" role="list">
+        {steps.map((step, i) => {
+          const stepNum = i + 1
+          const isCompleted = stepNum < currentStep
+          const isCurrent = stepNum === currentStep
 
-        return (
-          <div key={step.label} className="flex items-center flex-1 last:flex-initial">
-            {/* Step circle + label */}
-            <div className="flex flex-col items-center">
-              <div
-                className={`w-9 h-9 rounded-full flex items-center justify-center text-sm font-semibold transition-colors ${
-                  isCompleted
-                    ? 'bg-primary text-white'
-                    : isCurrent
-                      ? 'bg-primary text-white ring-2 ring-primary/30 ring-offset-2'
-                      : 'bg-neutral-200 text-neutral-500'
-                }`}
-              >
-                {isCompleted ? '✓' : step.icon}
-              </div>
-              <span
-                className={`text-xs mt-1.5 whitespace-nowrap ${
-                  isCurrent ? 'font-semibold text-primary' : 'text-neutral-500'
-                }`}
-              >
-                {step.label}
-              </span>
-            </div>
-
-            {/* Connecting line */}
-            {stepNum < steps.length && (
-              <div className="flex-1 mx-2 mb-5">
+          return (
+            <li
+              key={step.label}
+              className="flex items-center flex-1 last:flex-initial"
+              aria-current={isCurrent ? 'step' : undefined}
+            >
+              {/* Step circle + label */}
+              <div className="flex flex-col items-center">
                 <div
-                  className={`h-0.5 w-full transition-colors ${
-                    isCompleted ? 'bg-primary' : 'bg-neutral-200'
+                  className={`w-9 h-9 rounded-full flex items-center justify-center text-sm font-semibold transition-colors ${
+                    isCompleted
+                      ? 'bg-primary text-white'
+                      : isCurrent
+                        ? 'bg-primary text-white ring-2 ring-primary/30 ring-offset-2'
+                        : 'bg-neutral-200 text-neutral-500'
                   }`}
-                />
+                  aria-hidden="true"
+                >
+                  {isCompleted ? '✓' : step.icon}
+                </div>
+                <span
+                  className={`text-xs mt-1.5 whitespace-nowrap ${
+                    isCurrent ? 'font-semibold text-primary' : 'text-neutral-500'
+                  }`}
+                >
+                  {isCompleted ? `${step.label} ✓` : step.label}
+                </span>
               </div>
-            )}
-          </div>
-        )
-      })}
-    </div>
+
+              {/* Connecting line */}
+              {stepNum < steps.length && (
+                <div className="flex-1 mx-2 mb-5" aria-hidden="true">
+                  <div
+                    className={`h-0.5 w-full transition-colors ${
+                      isCompleted ? 'bg-primary' : 'bg-neutral-200'
+                    }`}
+                  />
+                </div>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
   )
 }


### PR DESCRIPTION
## Summary
- **CustomerDetailsForm**: Per-field validation on blur with Greek error messages
- **CheckoutStepper**: Semantic HTML (nav/ol/li) with ARIA attributes

## Changes
### CustomerDetailsForm.tsx
- Added `validateField()` with per-field Greek validation (name, phone, email, address, city, postcode)
- `fieldErrors` + `touched` state tracking — errors show only after blur
- `aria-required`, `aria-invalid`, `aria-describedby` on all 6 inputs
- Inline error `<p>` elements with `role="alert"` for screen readers
- Red border styling (`border-red-400`) on invalid fields
- Phone: validates Greek format (10-14 digits, strips spaces/hyphens)
- Email: validates format with regex

### CheckoutStepper.tsx
- `<div>` → `<nav aria-label="Βήματα ολοκλήρωσης παραγγελίας">`
- Inner container → `<ol role="list">`
- Steps → `<li>` with `aria-current="step"` on current step
- Decorative icons + lines → `aria-hidden="true"`

## Test plan
- [ ] Checkout form: leave name empty, tab out → "Παρακαλώ εισάγετε το ονοματεπώνυμό σας" appears
- [ ] Enter invalid phone (e.g. "123"), tab out → phone error shown
- [ ] Enter invalid email, tab out → email error shown  
- [ ] Fill all fields correctly → no red borders, no error messages
- [ ] Screen reader: CheckoutStepper announces step progress correctly
- [ ] `npm run typecheck` — 0 errors