### PR TITLE
T5: Frontend polish — LCP priority, console cleanup, ARIA, manifest fix

### DIFF
--- a/frontend/src/app/(storefront)/checkout/page.tsx
+++ b/frontend/src/app/(storefront)/checkout/page.tsx
@@ -162,7 +162,7 @@ function CheckoutContent() {
           <button
             type="submit"
             disabled={loading || cardProcessing || !!cartShippingError || shippingLoading || (!shippingQuote && !cartShippingQuote)}
-            className="w-full h-12 mt-4 bg-primary hover:bg-primary-light disabled:bg-neutral-400 text-white font-medium rounded-lg text-base touch-manipulation active:opacity-90"
+            className="w-full h-12 mt-4 bg-primary hover:bg-primary-light disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg text-base touch-manipulation active:opacity-90"
             data-testid="checkout-submit"
           >
             {cardProcessing

--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -322,7 +322,7 @@ export default async function Page({ searchParams }: PageProps) {
         {items.length > 0 ? (
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
             {/* Pass FIX-STOCK-GUARD-01: Include stock for OOS check */}
-            {items.map((p: ApiItem) => (
+            {items.map((p: ApiItem, index: number) => (
               <ProductCard
                 key={p.id}
                 id={p.id}
@@ -337,6 +337,7 @@ export default async function Page({ searchParams }: PageProps) {
                 reviewsAvgRating={p.reviewsAvgRating}
                 discountPriceCents={p.discountPriceCents}
                 isSeasonal={p.isSeasonal}
+                priority={index < 4}
               />
             ))}
           </div>

--- a/frontend/src/app/manifest.ts
+++ b/frontend/src/app/manifest.ts
@@ -69,7 +69,7 @@ export default function manifest(): MetadataRoute.Manifest {
         name: 'Προϊόντα',
         short_name: 'Προϊόντα',
         description: 'Περιηγηθείτε σε φρέσκα προϊόντα από τοπικούς παραγωγούς',
-        url: '/',
+        url: '/products',
         icons: [
           {
             src: '/icons/products-96x96.png',

--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -105,6 +105,8 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
         {/* "All" option */}
         <button
           onClick={() => handleCategoryClick(null)}
+          aria-pressed={!currentCat}
+          aria-label="Όλες οι κατηγορίες"
           className={`
             flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium
             whitespace-nowrap transition-all duration-200
@@ -129,6 +131,8 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
                 <button
                   key={cat.slug}
                   onClick={() => handleCategoryClick(cat.slug)}
+                  aria-pressed={isSelected}
+                  aria-label={`Κατηγορία: ${cat.name}`}
                   className={`
                     flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium
                     whitespace-nowrap transition-all duration-200
@@ -153,6 +157,8 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
                 <button
                   key={category.id}
                   onClick={() => handleCategoryClick(category.slug)}
+                  aria-pressed={isSelected}
+                  aria-label={`Κατηγορία: ${category.labelEl}`}
                   className={`
                     flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium
                     whitespace-nowrap transition-all duration-200

--- a/frontend/src/components/CultivationFilter.tsx
+++ b/frontend/src/components/CultivationFilter.tsx
@@ -95,6 +95,8 @@ export function CultivationFilter({
         {/* "All" option */}
         <button
           onClick={() => handleClick(null)}
+          aria-pressed={!current}
+          aria-label="Όλοι οι τρόποι καλλιέργειας"
           className={`
             flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
             transition-all duration-200
@@ -118,6 +120,8 @@ export function CultivationFilter({
             <button
               key={opt.value}
               onClick={() => handleClick(opt.value)}
+              aria-pressed={isSelected}
+              aria-label={`Καλλιέργεια: ${opt.label}`}
               className={`
                 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
                 transition-all duration-200

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -8,6 +8,7 @@ import StarRating from '@/components/StarRating'
 /**
  * Pass FIX-STOCK-GUARD-01: Added stock prop for OOS awareness
  * Pass PRODUCT-CARD-RATINGS-01: Added reviewsCount + reviewsAvgRating
+ * T5: Added priority prop for LCP image optimization
  */
 type Props = {
   id: string | number
@@ -23,11 +24,13 @@ type Props = {
   hideProducerLink?: boolean
   reviewsCount?: number
   reviewsAvgRating?: number | null
+  /** T5: Set true for above-the-fold cards to preload LCP image */
+  priority?: boolean
 }
 
 const fmtEUR = new Intl.NumberFormat('el-GR', { style: 'currency', currency: 'EUR' })
 
-export function ProductCard({ id, title, producer, producerId, producerSlug, priceCents, discountPriceCents, image, stock, isSeasonal, hideProducerLink, reviewsCount, reviewsAvgRating }: Props) {
+export function ProductCard({ id, title, producer, producerId, producerSlug, priceCents, discountPriceCents, image, stock, isSeasonal, hideProducerLink, reviewsCount, reviewsAvgRating, priority }: Props) {
   const hasDiscount = discountPriceCents != null && discountPriceCents < priceCents
   const isOOS = typeof stock === 'number' && stock <= 0
   const displayPrice = hasDiscount ? fmtEUR.format(discountPriceCents / 100) : (typeof priceCents === 'number' ? fmtEUR.format(priceCents / 100) : '—')
@@ -50,6 +53,7 @@ export function ProductCard({ id, title, producer, producerId, producerSlug, pri
               fill
               sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
               className="object-cover group-hover:scale-105 transition-transform duration-500"
+              priority={priority}
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center text-neutral-400">

--- a/frontend/src/lib/auth/otp-store.ts
+++ b/frontend/src/lib/auth/otp-store.ts
@@ -53,8 +53,6 @@ export function storeOtp(phone: string): string {
 
   otpStore.set(normalizePhone(phone), entry);
 
-  console.log(`[OTP] Stored for ${maskPhone(phone)}, expires in 5 min`);
-
   return code;
 }
 
@@ -68,14 +66,12 @@ export function verifyOtp(phone: string, code: string): { valid: boolean; error?
   const entry = otpStore.get(normalizedPhone);
 
   if (!entry) {
-    console.log(`[OTP] No entry found for ${maskPhone(phone)}`);
     return { valid: false, error: 'Δεν βρέθηκε κωδικός OTP. Παρακαλώ ζητήστε νέο κωδικό.' };
   }
 
   // Check expiry
   if (Date.now() > entry.expiresAt) {
     otpStore.delete(normalizedPhone);
-    console.log(`[OTP] Expired for ${maskPhone(phone)}`);
     return { valid: false, error: 'Ο κωδικός OTP έληξε. Παρακαλώ ζητήστε νέο κωδικό.' };
   }
 
@@ -83,19 +79,16 @@ export function verifyOtp(phone: string, code: string): { valid: boolean; error?
   entry.attempts++;
   if (entry.attempts > MAX_ATTEMPTS) {
     otpStore.delete(normalizedPhone);
-    console.log(`[OTP] Max attempts exceeded for ${maskPhone(phone)}`);
     return { valid: false, error: 'Πολλές αποτυχημένες προσπάθειες. Παρακαλώ ζητήστε νέο κωδικό.' };
   }
 
   // Verify code
   if (entry.code !== code) {
-    console.log(`[OTP] Invalid code for ${maskPhone(phone)} (attempt ${entry.attempts}/${MAX_ATTEMPTS})`);
     return { valid: false, error: `Λανθασμένος κωδικός. Απομένουν ${MAX_ATTEMPTS - entry.attempts} προσπάθειες.` };
   }
 
   // Success - delete the entry (single use)
   otpStore.delete(normalizedPhone);
-  console.log(`[OTP] Verified successfully for ${maskPhone(phone)}`);
 
   return { valid: true };
 }
@@ -143,7 +136,5 @@ function cleanupExpired(): void {
     }
   }
 
-  if (cleaned > 0) {
-    console.log(`[OTP] Cleaned up ${cleaned} expired entries`);
-  }
+  // Cleanup is silent — no logging needed in production
 }


### PR DESCRIPTION
## Summary
- **LCP Image Priority**: Added `priority` prop to `ProductCard`; first 4 products on catalog page load eagerly for faster LCP
- **Console.log Cleanup**: Removed 7 `console.log` calls from `otp-store.ts` that leaked masked phone numbers to PM2 production logs
- **PWA Manifest Fix**: "Προϊόντα" shortcut now correctly points to `/products` instead of `/`
- **ARIA Accessibility**: Added `aria-pressed` + `aria-label` to all category and cultivation filter buttons for screen readers
- **Disabled Button Consistency**: Checkout submit button now uses `disabled:opacity-50 disabled:cursor-not-allowed` instead of `disabled:bg-neutral-400`

## Files Changed (7 files, ~20 LOC)
- `frontend/src/components/ProductCard.tsx` — priority prop
- `frontend/src/app/(storefront)/products/page.tsx` — pass priority to first 4 cards
- `frontend/src/lib/auth/otp-store.ts` — remove 7 console.log
- `frontend/src/app/manifest.ts` — fix shortcut URL
- `frontend/src/components/CategoryStrip.tsx` — aria-pressed on 3 button groups
- `frontend/src/components/CultivationFilter.tsx` — aria-pressed on 2 button groups
- `frontend/src/app/(storefront)/checkout/page.tsx` — disabled button style

## Test Plan
- [ ] `npx tsc --noEmit` — 0 errors ✅
- [ ] CI pipeline GREEN
- [ ] LCP: Lighthouse on /products → first 4 images preloaded
- [ ] PWA: Long-press icon → "Προϊόντα" → lands on /products
- [ ] Screen reader: filter buttons announce "pressed" state
- [ ] Checkout: disabled submit shows consistent opacity style
- [ ] PM2 logs: no more `[OTP]` log lines