### PR TITLE
T6 PR1: Layout width + brand token consistency

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -173,7 +173,7 @@ export default function RootLayout({
             <ToastProvider>
               <AuthProvider>
                 <Header />
-                <div className="max-w-6xl mx-auto px-4 py-8">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
                   <main id="main-content" data-testid="page-root">
                     {children}
                   </main>

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -6,7 +6,7 @@ interface LoadingSpinnerProps {
 
 export default function LoadingSpinner({ 
   size = 'md', 
-  text = 'Loading...', 
+  text = 'Φόρτωση...',
   fullScreen = false 
 }: LoadingSpinnerProps) {
   const spinnerSizes = {
@@ -22,10 +22,10 @@ export default function LoadingSpinner({
   return (
     <div className={containerClass} data-testid="loading-spinner">
       <div 
-        className={`animate-spin rounded-full ${spinnerSizes[size]} border-b-2 border-green-600 mb-4`}
+        className={`animate-spin rounded-full ${spinnerSizes[size]} border-b-2 border-primary mb-4`}
         data-testid="loading-spinner-icon"
       ></div>
-      <p className="text-gray-600 text-sm font-medium" data-testid="loading-spinner-text">{text}</p>
+      <p className="text-neutral-600 text-sm font-medium" data-testid="loading-spinner-text">{text}</p>
     </div>
   );
 }

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -5,7 +5,7 @@ export default function Skeleton({ className = '', style }: Props) {
   return (
     <div
       aria-hidden="true"
-      className={`animate-pulse bg-gray-200 rounded-md ${className}`}
+      className={`animate-pulse bg-neutral-200 rounded-md ${className}`}
       style={{ height: 12, ...style }}
       data-testid="skeleton"
     />

--- a/frontend/src/components/SkipLink.tsx
+++ b/frontend/src/components/SkipLink.tsx
@@ -13,7 +13,7 @@ export default function SkipLink() {
   return (
     <a
       href="#main-content"
-      className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-green-600 text-white px-4 py-2 rounded-md z-50 focus:outline-none focus:ring-2 focus:ring-green-500"
+      className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-primary text-white px-4 py-2 rounded-md z-50 focus:outline-none focus:ring-2 focus:ring-primary/50"
       onClick={handleClick}
     >
       Μετάβαση στο περιεχόμενο


### PR DESCRIPTION
## Summary
- Widen root layout from `max-w-6xl` (1152px) to `max-w-7xl` (1280px) with responsive padding — all pages breathe more on desktop
- Replace raw `bg-green-600`, `text-gray-*` with brand tokens (`bg-primary`, `text-neutral-*`) in LoadingSpinner, SkipLink, Skeleton
- Greek default text for LoadingSpinner (`Φόρτωση...` instead of `Loading...`)

## Test plan
- [ ] /products on 1440px viewport — grid uses wider container
- [ ] Loading states show brand green spinner (not raw green-600)
- [ ] Tab key → skip link shows brand green background
- [ ] `npm run typecheck` — 0 errors