### PR TITLE
T6 PR3: Polish state components — EmptyState, ErrorState, ProductImage

### DIFF
--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,24 +1,32 @@
 'use client';
 import React from 'react';
 
-export default function EmptyState() {
+interface EmptyStateProps {
+  icon?: React.ReactNode;
+  title?: string;
+  message?: string;
+}
+
+export default function EmptyState({
+  icon,
+  title = 'Δεν βρέθηκαν αποτελέσματα',
+  message = 'Δοκίμασε να αλλάξεις ή να καθαρίσεις τα φίλτρα',
+}: EmptyStateProps) {
   return (
     <div
       data-testid="empty-state"
       aria-live="polite"
-      style={{
-        padding: 32,
-        display: 'grid',
-        gap: 8,
-        alignItems: 'center',
-        justifyItems: 'center',
-        textAlign: 'center',
-        border: '1px dashed #DDD',
-        borderRadius: 8,
-      }}
+      className="grid gap-2 place-items-center text-center p-8 border border-dashed border-neutral-300 rounded-xl"
     >
-      <div style={{fontSize: 16, fontWeight: 600}}>Δεν βρέθηκαν αποτελέσματα</div>
-      <div style={{fontSize: 12, color: '#666'}}>Δοκίμασε να αλλάξεις ή να καθαρίσεις τα φίλτρα</div>
+      <div className="text-neutral-400 mb-1">
+        {icon ?? (
+          <svg className="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+          </svg>
+        )}
+      </div>
+      <div className="text-base font-semibold text-neutral-700">{title}</div>
+      <div className="text-xs text-neutral-500">{message}</div>
     </div>
   );
 }

--- a/frontend/src/components/ErrorState.tsx
+++ b/frontend/src/components/ErrorState.tsx
@@ -5,11 +5,11 @@ interface ErrorStateProps {
   showRetry?: boolean;
 }
 
-export default function ErrorState({ 
-  title = 'Something went wrong', 
-  message, 
-  onRetry, 
-  showRetry = true 
+export default function ErrorState({
+  title = 'Κάτι πήγε στραβά',
+  message,
+  onRetry,
+  showRetry = true
 }: ErrorStateProps) {
   return (
     <div className="text-center py-12">
@@ -18,14 +18,14 @@ export default function ErrorState({
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.5 0L4.268 16.5c-.77.833.192 2.5 1.732 2.5z" />
         </svg>
       </div>
-      <h3 className="text-lg font-medium text-gray-900 mb-2">{title}</h3>
-      <p className="text-gray-600 mb-6 max-w-md mx-auto">{message}</p>
+      <h3 className="text-lg font-medium text-neutral-900 mb-2">{title}</h3>
+      <p className="text-neutral-600 mb-6 max-w-md mx-auto">{message}</p>
       {showRetry && onRetry && (
         <button
           onClick={onRetry}
-          className="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded-lg font-medium transition-colors"
+          className="bg-primary hover:bg-primary-light text-white px-6 py-2 rounded-lg font-medium transition-colors"
         >
-          Try Again
+          Δοκίμασε ξανά
         </button>
       )}
     </div>

--- a/frontend/src/components/product/ProductImage.tsx
+++ b/frontend/src/components/product/ProductImage.tsx
@@ -11,33 +11,35 @@ interface ProductImageProps {
 }
 
 const Skeleton: FC<{ className?: string }> = ({ className }) => (
-  <div className={`bg-gray-200 animate-pulse flex items-center justify-center ${className}`} data-testid="product-image-skeleton">
-    <div className="w-8 h-8 bg-gray-300 rounded animate-spin" />
+  <div className={`bg-neutral-200 animate-pulse flex items-center justify-center ${className}`} data-testid="product-image-skeleton">
+    <div className="w-8 h-8 bg-neutral-300 rounded animate-spin" />
   </div>
 );
 
-const ErrorState: FC<{ onRetry: () => void; retryCount: number; className?: string; testId?: string }> = ({ 
-  onRetry, retryCount, className, testId 
+const ErrorState: FC<{ onRetry: () => void; retryCount: number; className?: string; testId?: string }> = ({
+  onRetry, retryCount, className, testId
 }) => (
-  <div className={`bg-gray-100 flex flex-col items-center justify-center ${className}`} data-testid={testId}>
-    <div className="w-12 h-12 text-gray-400 mb-2">⚠️</div>
-    <p className="text-xs text-gray-500 mb-2">Failed to load</p>
+  <div className={`bg-neutral-100 flex flex-col items-center justify-center ${className}`} data-testid={testId}>
+    <svg className="w-10 h-10 text-neutral-400 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.41a2.25 2.25 0 013.182 0l2.909 2.91m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
+    </svg>
+    <p className="text-xs text-neutral-500 mb-2">Σφάλμα φόρτωσης</p>
     {retryCount < 2 && (
-      <button onClick={onRetry} className="px-2 py-1 text-xs bg-gray-200 rounded" data-testid="product-image-retry-btn">
-        Retry ({2 - retryCount} left)
+      <button onClick={onRetry} className="px-2 py-1 text-xs bg-neutral-200 hover:bg-neutral-300 rounded transition-colors" data-testid="product-image-retry-btn">
+        Ξαναδοκίμασε ({2 - retryCount})
       </button>
     )}
   </div>
 );
 
-const ProductImage: FC<ProductImageProps> = ({ 
-  src, alt, className = "h-48", priority = false, 'data-testid': testId 
+const ProductImage: FC<ProductImageProps> = ({
+  src, alt, className = "h-48", priority = false, 'data-testid': testId
 }) => {
   const { state, retry, retryCount } = useImageTimeout(src || '/placeholder.jpg');
   const getTestId = (suffix: string) => testId ? `${testId}-${suffix}` : `product-image-${suffix}`;
 
   if (state === 'loading') return <Skeleton className={className} />;
-  
+
   if (state === 'error' || state === 'timeout') {
     return <ErrorState onRetry={retry} retryCount={retryCount} className={className} testId={getTestId(state)} />;
   }


### PR DESCRIPTION
## Summary
- **EmptyState**: Full rewrite — inline styles → Tailwind, added magnifying glass SVG icon, optional `icon`/`title`/`message` props
- **ErrorState**: Greek text defaults, `bg-green-600` → `bg-primary`, gray → neutral palette
- **ProductImage**: ⚠️ emoji → image placeholder SVG, Greek error text, gray → neutral tokens

## Test plan
- [ ] /products with empty filter → EmptyState shows search icon + Greek text
- [ ] Simulate API error → ErrorState in Greek, brand green "Δοκίμασε ξανά" button
- [ ] Break product image URL → SVG placeholder + "Σφάλμα φόρτωσης" text
- [ ] `npm run typecheck` — 0 errors