### PR TITLE
T7 PR3: Homepage visual warmth — break green monotony

### DIFF
--- a/frontend/src/components/marketing/CTA.tsx
+++ b/frontend/src/components/marketing/CTA.tsx
@@ -11,7 +11,7 @@ import Link from 'next/link';
  */
 export default function CTA() {
   return (
-    <section className="bg-primary-pale py-12 sm:py-16 lg:py-20">
+    <section className="bg-gradient-to-br from-accent-cream to-accent-beige py-12 sm:py-16 lg:py-20">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 text-center">
         {/* Heading - mobile-optimized */}
         <h2 className="text-3xl font-bold text-neutral-900 mb-4 sm:text-4xl lg:text-5xl">
@@ -41,7 +41,7 @@ export default function CTA() {
         </div>
 
         {/* Trust indicator - subtle */}
-        <div className="mt-10 pt-8 border-t border-primary/20">
+        <div className="mt-10 pt-8 border-t border-accent-gold/20">
           <div className="flex flex-wrap justify-center gap-6 text-sm text-neutral-600">
             <div className="flex items-center gap-2">
               <svg className="w-5 h-5 text-accent-gold" fill="currentColor" viewBox="0 0 20 20">

--- a/frontend/src/components/marketing/Hero.tsx
+++ b/frontend/src/components/marketing/Hero.tsx
@@ -11,14 +11,14 @@ import Link from 'next/link';
  */
 export default function Hero() {
   return (
-    <section className="bg-gradient-to-b from-primary-pale to-white">
+    <section className="bg-gradient-to-b from-accent-cream via-primary-pale/30 to-white">
       {/* Mobile-first container with generous padding */}
       <div className="max-w-6xl mx-auto px-4 py-12 sm:px-6 sm:py-16 lg:py-20">
         <div className="max-w-3xl mx-auto text-center">
           {/* Heading - optimized for mobile readability */}
           <h1 className="text-4xl font-bold text-neutral-900 leading-tight mb-6 sm:text-5xl lg:text-6xl">
             Φρέσκα τοπικά προϊόντα
-            <span className="block text-primary mt-2">
+            <span className="block text-accent-gold mt-2">
               από Έλληνες παραγωγούς
             </span>
           </h1>

--- a/frontend/src/components/marketing/Trust.tsx
+++ b/frontend/src/components/marketing/Trust.tsx
@@ -1,11 +1,10 @@
 /**
  * Trust Section - Build confidence with key value propositions
  *
- * Features:
- * - 3 trust indicators (freshness, local producers, fast delivery)
- * - Mobile-first 1-column, scales to 3-column on desktop
- * - Generous whitespace and readable icons
- * - Brand color accents
+ * T7: Differentiated card backgrounds to break green monotony
+ * - Card 1 (Freshness): green = nature
+ * - Card 2 (Producers): beige/gold = premium, trust
+ * - Card 3 (Delivery): blue = logistics, reliability
  */
 export default function Trust() {
   const trustPoints = [
@@ -17,24 +16,27 @@ export default function Trust() {
       ),
       title: 'Φρεσκάδα Εγγυημένη',
       description: 'Όλα τα προϊόντα μας είναι φρέσκα και συλλέγονται την ίδια μέρα ή την προηγούμενη της παράδοσης.',
+      cardBg: 'bg-primary-pale',
     },
     {
       icon: (
-        <svg className="w-12 h-12 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className="w-12 h-12 text-accent-gold" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
         </svg>
       ),
       title: 'Τοπικοί Παραγωγοί',
       description: 'Γνωρίστε τους ανθρώπους πίσω από κάθε προϊόν. Υποστηρίζουμε μικρούς Έλληνες παραγωγούς.',
+      cardBg: 'bg-accent-beige',
     },
     {
       icon: (
-        <svg className="w-12 h-12 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className="w-12 h-12 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
         </svg>
       ),
       title: 'Γρήγορη Παράδοση',
       description: 'Παραλάβετε τα προϊόντα σας εντός 24-48 ωρών. Δωρεάν παράδοση για παραγγελίες άνω των 30€.',
+      cardBg: 'bg-blue-50',
     },
   ];
 
@@ -56,7 +58,7 @@ export default function Trust() {
           {trustPoints.map((point, index) => (
             <div
               key={index}
-              className="bg-primary-pale rounded-xl p-6 sm:p-8 text-center hover:shadow-card transition-shadow duration-200"
+              className={`${point.cardBg} rounded-xl p-6 sm:p-8 text-center hover:shadow-card transition-shadow duration-200`}
             >
               {/* Icon - centered, generous spacing */}
               <div className="flex justify-center mb-5">


### PR DESCRIPTION
## Summary
- Break the **green monotony** across Hero, Trust, and CTA sections
- Hero: warm **cream gradient** instead of pure green
- Trust cards: **3 distinct colors** (green=nature, gold=premium, blue=logistics)
- CTA: warm **cream-to-beige gradient** instead of bg-primary-pale

## Changes
- `Hero.tsx` — gradient: `from-accent-cream via-primary-pale/30 to-white`, subtitle gold
- `Trust.tsx` — Card 1: green, Card 2: beige/gold, Card 3: blue
- `CTA.tsx` — `bg-gradient-to-br from-accent-cream to-accent-beige`

## Test plan
- [ ] / (marketing homepage) → Hero has warm cream-green gradient
- [ ] Trust section → 3 cards with 3 different background colors
- [ ] CTA section → warm cream/beige background instead of green
- [ ] `npm run typecheck` — 0 errors