### PR TITLE
feat: FeaturedProducts & HomeClient grid color differentiation

### DIFF
--- a/frontend/src/app/HomeClient.tsx
+++ b/frontend/src/app/HomeClient.tsx
@@ -316,8 +316,8 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
               <p className="text-sm text-neutral-600">Βρείτε τοπικά προϊόντα από πιστοποιημένους Έλληνες παραγωγούς</p>
             </div>
             <div className="text-center">
-              <div className="w-14 h-14 mx-auto mb-4 bg-primary-pale rounded-full flex items-center justify-center">
-                <svg className="w-7 h-7 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <div className="w-14 h-14 mx-auto mb-4 bg-accent-cream rounded-full flex items-center justify-center">
+                <svg className="w-7 h-7 text-accent-gold" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z" />
                 </svg>
               </div>
@@ -325,8 +325,8 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
               <p className="text-sm text-neutral-600">Προσθέστε στο καλάθι και πληρώστε με κάρτα ή αντικαταβολή</p>
             </div>
             <div className="text-center">
-              <div className="w-14 h-14 mx-auto mb-4 bg-primary-pale rounded-full flex items-center justify-center">
-                <svg className="w-7 h-7 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <div className="w-14 h-14 mx-auto mb-4 bg-blue-50 rounded-full flex items-center justify-center">
+                <svg className="w-7 h-7 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
                 </svg>
               </div>
@@ -345,14 +345,14 @@ export default function HomeClient({ initialProducts }: HomeClientProps) {
             <span>Ασφαλείς Πληρωμές</span>
           </div>
           <div className="flex items-center gap-2 text-sm text-neutral-600">
-            <svg className="w-5 h-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-5 h-5 text-accent-gold" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
             </svg>
             <span>Απευθείας από Παραγωγούς</span>
           </div>
           <div className="flex items-center gap-2 text-sm text-neutral-600">
-            <svg className="w-5 h-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-5 h-5 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" />
             </svg>
             <span>100% Ελληνικά Προϊόντα</span>

--- a/frontend/src/components/marketing/FeaturedProducts.tsx
+++ b/frontend/src/components/marketing/FeaturedProducts.tsx
@@ -138,7 +138,7 @@ export default async function FeaturedProducts() {
         <div className="text-center mt-10 sm:mt-12">
           <Link
             href="/products"
-            className="inline-flex items-center justify-center min-h-[48px] px-8 py-3 bg-white hover:bg-neutral-50 text-primary font-semibold rounded-lg border-2 border-primary transition-all duration-200 active:scale-[0.98] touch-manipulation"
+            className="inline-flex items-center justify-center min-h-[48px] px-8 py-3 bg-white hover:bg-accent-cream text-accent-gold font-semibold rounded-lg border-2 border-accent-gold transition-all duration-200 active:scale-[0.98] touch-manipulation"
           >
             Εξερευνήστε Περισσότερα Προϊόντα
           </Link>


### PR DESCRIPTION
## Summary
- FeaturedProducts CTA button: green border → gold accent (`border-accent-gold`, `text-accent-gold`, `hover:bg-accent-cream`)
- HomeClient "How It Works" circles: semantic colors (green=Browse, gold=Cart, blue=Delivery)
- HomeClient Trust badge icons: differentiated (green=Security, gold=Producers, blue=Greek Products)

## Why
Breaks green monotony — consistent with the semantic color system introduced in PR3 (Trust.tsx). Same pattern: green=nature/brand, gold=premium/trust, blue=logistics/reliability.

## T7 PR4 of 6 — UI Beauty Sprint

## Test plan
- [ ] `npm run typecheck` — 0 errors ✅
- [ ] Homepage "How It Works" shows 3 different colored circles
- [ ] Trust badges show 3 different icon colors
- [ ] FeaturedProducts CTA button uses gold accent
- [ ] No visual regressions on mobile