### PR TITLE
feat: micro-interactions — fade-in, cart bounce, scroll affordance

### DIFF
--- a/frontend/src/components/AddToCartButton.tsx
+++ b/frontend/src/components/AddToCartButton.tsx
@@ -64,10 +64,10 @@ export default function AddToCartButton(props: {
 
   return (
     <button
-      className={`h-9 sm:h-11 px-3 sm:px-4 w-full sm:w-auto rounded text-sm transition-colors ${
+      className={`h-9 sm:h-11 px-3 sm:px-4 w-full sm:w-auto rounded text-sm transition-all duration-200 ${
         isAdded
-          ? 'bg-primary text-white'
-          : 'bg-primary text-white hover:bg-primary-light'
+          ? 'bg-primary text-white animate-cart-bounce'
+          : 'bg-primary text-white hover:bg-primary-light active:scale-95'
       }`}
       onClick={handleClick}
       disabled={isAdded}

--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -100,7 +100,8 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
   const useDynamic = dynamicCategories && dynamicCategories.length > 0;
 
   return (
-    <div className="w-full overflow-x-auto scrollbar-hide">
+    <div className="w-full relative">
+      <div className="overflow-x-auto scrollbar-hide scroll-smooth">
       <div className="flex gap-2 pb-2 min-w-max px-1">
         {/* "All" option */}
         <button
@@ -175,6 +176,10 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
               );
             })}
       </div>
+      </div>
+      {/* Fade edges to indicate horizontal scroll */}
+      <div className="pointer-events-none absolute inset-y-0 left-0 w-4 bg-gradient-to-r from-white to-transparent" />
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-4 bg-gradient-to-l from-white to-transparent" />
     </div>
   );
 }

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -30,7 +30,7 @@ type Props = {
 
 const fmtEUR = new Intl.NumberFormat('el-GR', { style: 'currency', currency: 'EUR' })
 
-export function ProductCard({ id, title, producer, producerId, producerSlug, priceCents, discountPriceCents, image, stock, isSeasonal, hideProducerLink, reviewsCount, reviewsAvgRating, priority }: Props) {
+export function ProductCard({ id, title, producer, producerId, producerSlug, priceCents, discountPriceCents, image, stock, isSeasonal, hideProducerLink, reviewsCount, reviewsAvgRating, priority, index }: Props & { index?: number }) {
   const hasDiscount = discountPriceCents != null && discountPriceCents < priceCents
   const isOOS = typeof stock === 'number' && stock <= 0
   const displayPrice = hasDiscount ? fmtEUR.format(discountPriceCents / 100) : (typeof priceCents === 'number' ? fmtEUR.format(priceCents / 100) : '—')
@@ -42,7 +42,7 @@ export function ProductCard({ id, title, producer, producerId, producerSlug, pri
   const producerUrl = (producerSlug || producerId) ? `/producers/${producerSlug || producerId}` : null
 
   return (
-    <div data-testid="product-card" className="group flex flex-col h-full bg-white border border-neutral-200 rounded-xl overflow-hidden hover:shadow-card-hover hover:border-primary/20 transition-all duration-300">
+    <div data-testid="product-card" className="group flex flex-col h-full bg-white border border-neutral-200 rounded-xl overflow-hidden hover:shadow-card-hover hover:border-primary/20 transition-all duration-300 opacity-0 animate-fade-in-up" style={typeof index === 'number' ? { animationDelay: `${index * 60}ms` } : undefined}>
       {/* Image — navigates to product page */}
       <Link href={productUrl} className="flex flex-col touch-manipulation active:scale-[0.99]">
         <div data-testid="product-card-image" className={`relative aspect-square sm:h-48 sm:aspect-auto w-full bg-neutral-100 overflow-hidden${isOOS ? ' opacity-50 grayscale' : ''}`}>

--- a/frontend/src/components/marketing/Trust.tsx
+++ b/frontend/src/components/marketing/Trust.tsx
@@ -56,7 +56,8 @@ export default function Trust() {
           {trustPoints.map((point, index) => (
             <div
               key={index}
-              className="bg-primary-pale rounded-xl p-6 sm:p-8 text-center hover:shadow-card transition-shadow duration-200"
+              className="bg-primary-pale rounded-xl p-6 sm:p-8 text-center hover:shadow-card transition-shadow duration-200 opacity-0 animate-fade-in-up"
+              style={{ animationDelay: `${index * 100}ms` }}
             >
               {/* Icon - centered, generous spacing */}
               <div className="flex justify-center mb-5">

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -84,7 +84,21 @@ const config: Config = {
       },
       transitionTimingFunction: {
         'bounce-in': 'cubic-bezier(0.68, -0.55, 0.265, 1.55)'
-      }
+      },
+      keyframes: {
+        fadeInUp: {
+          '0%': { opacity: '0', transform: 'translateY(12px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        cartBounce: {
+          '0%, 100%': { transform: 'scale(1)' },
+          '50%': { transform: 'scale(1.15)' },
+        },
+      },
+      animation: {
+        'fade-in-up': 'fadeInUp 0.5s ease-out forwards',
+        'cart-bounce': 'cartBounce 0.3s ease-in-out',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- **fadeInUp animation**: Product cards and Trust cards fade in with staggered delays for visual rhythm
- **cartBounce animation**: AddToCartButton bounces on confirmed "✓ Προστέθηκε" state
- **active:scale-95**: Button press feedback for tactile feel
- **Scroll affordance**: CategoryStrip gets smooth scrolling + gradient fade edges to hint at horizontal overflow

## Technical
- New Tailwind keyframes: `fadeInUp` (0.5s ease-out), `cartBounce` (0.3s ease-in-out)
- New animation utilities: `animate-fade-in-up`, `animate-cart-bounce`
- ProductCard accepts optional `index` prop for stagger delay (60ms per card)
- Trust cards use 100ms stagger delay
- CSS-only — no JS logic changes

## T7 PR5 of 6 — UI Beauty Sprint

## Test plan
- [ ] `npm run typecheck` — 0 errors ✅
- [ ] /products page: cards fade in with stagger effect
- [ ] Click "Προσθήκη" → button bounces when confirmed
- [ ] Category strip shows gradient edges on mobile
- [ ] Trust cards on homepage fade in with stagger