### PR TITLE
fix: T8b — filter UI visual polish

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -304,7 +304,7 @@ export default async function Page({ searchParams }: PageProps) {
         </div>
 
         {/* Filter Card */}
-        <div className="bg-white rounded-xl border border-neutral-100 shadow-card p-4 mb-6 space-y-3">
+        <div className="bg-white rounded-xl border border-neutral-200 shadow-card p-5 mb-6 space-y-4">
           {/* Row 1: Search + Sort */}
           <div className="flex flex-col sm:flex-row gap-3">
             <div className="flex-1">
@@ -312,12 +312,14 @@ export default async function Page({ searchParams }: PageProps) {
                 <ProductSearchInput />
               </Suspense>
             </div>
-            <div className="sm:w-48">
+            <div className="sm:w-52">
               <Suspense fallback={<div className="h-10 w-full bg-neutral-100 rounded-lg animate-pulse" />}>
                 <ProductSort />
               </Suspense>
             </div>
           </div>
+
+          <div className="border-t border-neutral-100" />
 
           {/* Row 2: Category Strip */}
           <Suspense fallback={<div className="h-10 bg-neutral-100 rounded animate-pulse" />}>

--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -101,7 +101,7 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
             ${
               !currentCat
                 ? 'bg-primary text-white shadow-md'
-                : 'bg-neutral-50 text-neutral-700 border border-neutral-200 hover:border-primary/40 hover:shadow-sm'
+                : 'bg-neutral-50 text-neutral-700 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale/60 hover:shadow-sm'
             }
           `}
         >
@@ -134,7 +134,7 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
                     ${
                       isSelected
                         ? 'bg-primary text-white shadow-md'
-                        : `${chipBg} text-neutral-700 border border-neutral-200/60 hover:border-primary/40 hover:shadow-sm`
+                        : `${chipBg} text-neutral-700 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale/60 hover:shadow-sm`
                     }
                   `}
                 >
@@ -165,7 +165,7 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
                     ${
                       isSelected
                         ? 'bg-primary text-white shadow-md'
-                        : `${category.chipBg} text-neutral-700 border border-neutral-200/60 hover:border-primary/40 hover:shadow-sm`
+                        : `${category.chipBg} text-neutral-700 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale/60 hover:shadow-sm`
                     }
                   `}
                 >

--- a/frontend/src/components/CultivationFilter.tsx
+++ b/frontend/src/components/CultivationFilter.tsx
@@ -59,23 +59,23 @@ export function CultivationFilter({
 
   return (
     <div className="w-full">
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap gap-2.5">
         {/* "All" option */}
         <button
           onClick={() => handleClick(null)}
           aria-pressed={!current}
           aria-label="Όλοι οι τρόποι καλλιέργειας"
           className={`
-            flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
+            flex items-center gap-2 px-3.5 py-2 rounded-full text-sm font-medium
             transition-all duration-200
             ${
               !current
-                ? 'bg-primary text-white shadow-sm'
+                ? 'bg-primary text-white shadow-md'
                 : 'bg-white text-neutral-600 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale'
             }
           `}
         >
-          <LayoutGrid className="w-3.5 h-3.5" />
+          <LayoutGrid className="w-4 h-4" />
           <span>Όλοι</span>
         </button>
 
@@ -91,20 +91,20 @@ export function CultivationFilter({
               aria-pressed={isSelected}
               aria-label={`Καλλιέργεια: ${opt.label}`}
               className={`
-                flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
+                flex items-center gap-2 px-3.5 py-2 rounded-full text-sm font-medium
                 transition-all duration-200
                 ${
                   isSelected
-                    ? 'bg-primary text-white shadow-sm'
+                    ? 'bg-primary text-white shadow-md'
                     : 'bg-white text-neutral-600 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale'
                 }
               `}
             >
-              <Icon className="w-3.5 h-3.5" />
+              <Icon className="w-4 h-4" />
               <span>{opt.label}</span>
               {count > 0 && (
                 <span
-                  className={`ml-0.5 text-[10px] ${
+                  className={`ml-0.5 text-xs ${
                     isSelected ? 'opacity-80' : 'text-neutral-400'
                   }`}
                 >

--- a/frontend/src/components/ProductSearchInput.tsx
+++ b/frontend/src/components/ProductSearchInput.tsx
@@ -66,7 +66,7 @@ export function ProductSearchInput() {
   return (
     <div className="relative w-full">
       <svg
-        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-neutral-400"
+        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-neutral-500"
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"
@@ -79,7 +79,7 @@ export function ProductSearchInput() {
         placeholder={t('products.searchPlaceholder')}
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
-        className="w-full pl-10 pr-10 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary/50 focus:border-transparent outline-none transition-all"
+        className="w-full pl-10 pr-10 py-2.5 border border-neutral-300 rounded-xl focus:ring-2 focus:ring-primary/50 focus:border-transparent outline-none transition-all"
         aria-label={t('products.searchPlaceholder')}
       />
       {inputValue && (

--- a/frontend/src/components/ProductSort.tsx
+++ b/frontend/src/components/ProductSort.tsx
@@ -45,19 +45,11 @@ export function ProductSort() {
 
   return (
     <div className="relative">
-      <svg
-        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-      >
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12" />
-      </svg>
       <select
         value={currentValue}
         onChange={handleChange}
         aria-label="Ταξινόμηση προϊόντων"
-        className="w-full appearance-none pl-9 pr-8 py-2 border border-neutral-300 rounded-lg bg-white text-sm text-neutral-700 focus:ring-2 focus:ring-primary/50 focus:border-transparent outline-none transition-all cursor-pointer"
+        className="w-full appearance-none pl-3.5 pr-8 py-2.5 border border-neutral-300 rounded-xl bg-white text-sm font-medium text-neutral-700 focus:ring-2 focus:ring-primary/50 focus:border-transparent outline-none transition-all cursor-pointer"
       >
         {SORT_OPTIONS.map((opt) => (
           <option key={opt.value} value={opt.value}>


### PR DESCRIPTION
## Summary
- **ProductSort**: Removed redundant left sort icon, wider padding (`py-2.5`), `rounded-xl` + `font-medium`
- **CultivationFilter**: Larger pills (`text-sm`, `px-3.5 py-2`), bigger icons (`w-4 h-4`), `shadow-md` selected state, `text-xs` count badge
- **ProductSearchInput**: Darker search icon (`text-neutral-500`), taller input (`py-2.5`), `rounded-xl` matching card container
- **CategoryStrip**: Full opacity borders (`border-neutral-200`), added `hover:bg-primary-pale/60` on 3 code paths
- **Filter card container**: More padding (`p-5`), wider spacing (`space-y-4`), visible border (`border-neutral-200`), sort width `sm:w-52`, visual divider between search row and categories

## Details
Pure CSS class changes — zero JS/logic modifications. ~42 LOC changed across 5 files.

## Test plan
- [ ] `npm run typecheck` — 0 errors ✅
- [ ] `/products` — filter card has clear border, breathing room between rows
- [ ] Search + sort inputs same height, rounded-xl corners
- [ ] Cultivation pills readable (14px), icons visible (16px)
- [ ] Category pills: visible borders, subtle green hover
- [ ] Mobile: pills wrap correctly, search/sort stack vertically
- [ ] Sort dropdown label not clipped (wider container)