### PR TITLE
feat(T9): Category grid layout with large 3D icon support

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -303,9 +303,27 @@ export default async function Page({ searchParams }: PageProps) {
           </p>
         </div>
 
-        {/* Filter Card */}
+        {/* Category Grid — standalone section above filters */}
+        <section className="mb-6" aria-label="Κατηγορίες">
+          <Suspense
+            fallback={
+              <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+                {Array.from({ length: 9 }).map((_, i) => (
+                  <div key={i} className="h-24 sm:h-28 bg-neutral-100 rounded-xl animate-pulse" />
+                ))}
+              </div>
+            }
+          >
+            <CategoryStrip
+              selectedCategory={categoryFilter}
+              dynamicCategories={activeCategories}
+            />
+          </Suspense>
+        </section>
+
+        {/* Filter Card — search + sort + cultivation */}
         <div className="bg-white rounded-xl border border-neutral-200 shadow-card p-5 mb-6 space-y-4">
-          {/* Row 1: Search + Sort */}
+          {/* Search + Sort */}
           <div className="flex flex-col sm:flex-row gap-3">
             <div className="flex-1">
               <Suspense fallback={<div className="h-10 w-full bg-neutral-100 rounded-lg animate-pulse" />}>
@@ -319,17 +337,7 @@ export default async function Page({ searchParams }: PageProps) {
             </div>
           </div>
 
-          <div className="border-t border-neutral-100" />
-
-          {/* Row 2: Category Strip */}
-          <Suspense fallback={<div className="h-10 bg-neutral-100 rounded animate-pulse" />}>
-            <CategoryStrip
-              selectedCategory={categoryFilter}
-              dynamicCategories={activeCategories}
-            />
-          </Suspense>
-
-          {/* Row 3: Cultivation (conditional) */}
+          {/* Cultivation (conditional) */}
           {hasCultivationData && (
             <Suspense fallback={null}>
               <CultivationFilter

--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -88,99 +88,116 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
   const useDynamic = dynamicCategories && dynamicCategories.length > 0;
 
   return (
-    <div className="w-full overflow-x-auto scrollbar-hide">
-      <div className="flex gap-2 pb-2 min-w-max px-1">
-        {/* "All" option */}
-        <button
-          onClick={() => handleCategoryClick(null)}
-          aria-pressed={!currentCat}
-          aria-label="Όλες οι κατηγορίες"
-          className={`
-            flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-medium
-            whitespace-nowrap transition-all duration-200
-            ${
-              !currentCat
-                ? 'bg-primary text-white shadow-md'
-                : 'bg-neutral-50 text-neutral-700 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale/60 hover:shadow-sm'
-            }
-          `}
+    <div
+      className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3"
+      role="group"
+      aria-label="Κατηγορίες προϊόντων"
+    >
+      {/* "All" card */}
+      <button
+        onClick={() => handleCategoryClick(null)}
+        aria-pressed={!currentCat}
+        aria-label="Όλες οι κατηγορίες"
+        className={`
+          flex flex-col items-center justify-center gap-2 p-3 sm:p-4
+          rounded-xl transition-all duration-200 cursor-pointer
+          ${
+            !currentCat
+              ? 'bg-white ring-2 ring-primary shadow-md'
+              : 'bg-accent-cream hover:shadow-card-hover hover:scale-[1.03]'
+          }
+        `}
+      >
+        <Image
+          src="/icons/categories/basket.png"
+          alt=""
+          width={56}
+          height={56}
+          className="w-12 h-12 sm:w-14 sm:h-14 flex-shrink-0 drop-shadow-sm"
+        />
+        <span
+          className={`text-xs sm:text-sm font-medium text-center leading-tight line-clamp-2
+            ${!currentCat ? 'text-primary' : 'text-neutral-700'}`}
         >
-          <Image
-            src="/icons/categories/basket.png"
-            alt=""
-            width={24}
-            height={24}
-            className="w-6 h-6 flex-shrink-0"
-          />
-          <span>Όλα</span>
-        </button>
+          Όλα
+        </span>
+      </button>
 
-        {useDynamic
-          ? /* Dynamic categories from API data */
-            dynamicCategories.map((cat) => {
-              const emoji = getEmojiForSlug(cat.slug);
-              const chipBg = getChipBgForSlug(cat.slug);
-              const isSelected = currentCat === cat.slug;
+      {useDynamic
+        ? /* Dynamic categories from API data */
+          dynamicCategories.map((cat) => {
+            const emoji = getEmojiForSlug(cat.slug);
+            const chipBg = getChipBgForSlug(cat.slug);
+            const isSelected = currentCat === cat.slug;
 
-              return (
-                <button
-                  key={cat.slug}
-                  onClick={() => handleCategoryClick(cat.slug)}
-                  aria-pressed={isSelected}
-                  aria-label={`Κατηγορία: ${cat.name}`}
-                  className={`
-                    flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-medium
-                    whitespace-nowrap transition-all duration-200
-                    ${
-                      isSelected
-                        ? 'bg-primary text-white shadow-md'
-                        : `${chipBg} text-neutral-700 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale/60 hover:shadow-sm`
-                    }
-                  `}
+            return (
+              <button
+                key={cat.slug}
+                onClick={() => handleCategoryClick(cat.slug)}
+                aria-pressed={isSelected}
+                aria-label={`Κατηγορία: ${cat.name}`}
+                className={`
+                  flex flex-col items-center justify-center gap-2 p-3 sm:p-4
+                  rounded-xl transition-all duration-200 cursor-pointer
+                  ${
+                    isSelected
+                      ? 'bg-white ring-2 ring-primary shadow-md'
+                      : `${chipBg} hover:shadow-card-hover hover:scale-[1.03]`
+                  }
+                `}
+              >
+                <Image
+                  src={`/icons/categories/${emoji}.png`}
+                  alt=""
+                  width={56}
+                  height={56}
+                  className="w-12 h-12 sm:w-14 sm:h-14 flex-shrink-0 drop-shadow-sm"
+                />
+                <span
+                  className={`text-xs sm:text-sm font-medium text-center leading-tight line-clamp-2
+                    ${isSelected ? 'text-primary' : 'text-neutral-700'}`}
                 >
-                  <Image
-                    src={`/icons/categories/${emoji}.png`}
-                    alt=""
-                    width={24}
-                    height={24}
-                    className="w-6 h-6 flex-shrink-0"
-                  />
-                  <span>{cat.name}</span>
-                </button>
-              );
-            })
-          : /* Static fallback categories */
-            CATEGORIES.map((category) => {
-              const isSelected = currentCat === category.slug;
+                  {cat.name}
+                </span>
+              </button>
+            );
+          })
+        : /* Static fallback categories */
+          CATEGORIES.map((category) => {
+            const isSelected = currentCat === category.slug;
 
-              return (
-                <button
-                  key={category.id}
-                  onClick={() => handleCategoryClick(category.slug)}
-                  aria-pressed={isSelected}
-                  aria-label={`Κατηγορία: ${category.labelEl}`}
-                  className={`
-                    flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-medium
-                    whitespace-nowrap transition-all duration-200
-                    ${
-                      isSelected
-                        ? 'bg-primary text-white shadow-md'
-                        : `${category.chipBg} text-neutral-700 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale/60 hover:shadow-sm`
-                    }
-                  `}
+            return (
+              <button
+                key={category.id}
+                onClick={() => handleCategoryClick(category.slug)}
+                aria-pressed={isSelected}
+                aria-label={`Κατηγορία: ${category.labelEl}`}
+                className={`
+                  flex flex-col items-center justify-center gap-2 p-3 sm:p-4
+                  rounded-xl transition-all duration-200 cursor-pointer
+                  ${
+                    isSelected
+                      ? 'bg-white ring-2 ring-primary shadow-md'
+                      : `${category.chipBg} hover:shadow-card-hover hover:scale-[1.03]`
+                  }
+                `}
+              >
+                <Image
+                  src={`/icons/categories/${category.emoji}.png`}
+                  alt=""
+                  width={56}
+                  height={56}
+                  className="w-12 h-12 sm:w-14 sm:h-14 flex-shrink-0 drop-shadow-sm"
+                />
+                <span
+                  className={`text-xs sm:text-sm font-medium text-center leading-tight line-clamp-2
+                    ${isSelected ? 'text-primary' : 'text-neutral-700'}`}
                 >
-                  <Image
-                    src={`/icons/categories/${category.emoji}.png`}
-                    alt=""
-                    width={24}
-                    height={24}
-                    className="w-6 h-6 flex-shrink-0"
-                  />
-                  <span>{category.labelEl}</span>
-                </button>
-              );
-            })}
-      </div>
+                  {category.labelEl}
+                </span>
+              </button>
+            );
+          })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **CategoryStrip.tsx**: Replaced horizontal scroll pill strip with responsive grid cards (3-col mobile, 4-col tablet, 6-col desktop). All categories now visible without scrolling.
- **products/page.tsx**: Moved category grid above the filter card as a standalone `<section>`. Filter card now contains only search + sort + cultivation. Grid skeleton loading state replaces old pill skeleton.
- Icons enlarged from 24px to 48-56px with `drop-shadow-sm` — ready for upcoming 3D clay-style PNGs (user creating via GPT/DALL-E, same filenames).

## Visual changes
- **Selected card**: White bg + green ring + shadow (was: green bg + white text pill)
- **Unselected card**: Pastel bg + `hover:scale-[1.03]` subtle lift (was: neutral pill + border)
- **"All" card**: `bg-accent-cream` to differentiate from category pastels
- **Labels**: Centered, `line-clamp-2` for long names

## Test plan
- [ ] `/products` desktop: 2 rows of category cards, all visible, no horizontal scrolling
- [ ] `/products` mobile (375px): 3-col grid, 3-4 rows, all visible without scroll
- [ ] Category click updates `?cat=slug`, products filter correctly
- [ ] Selected card shows white bg + green ring + shadow
- [ ] Hover on unselected: subtle scale-up + shadow
- [ ] Skeleton loading: 9 grey rectangles in matching grid
- [ ] Filter card below: only search + sort + cultivation (categories removed)
- [ ] `npm run typecheck` — 0 errors