### PR TITLE
fix(checkout): show shipping error instead of silently disabling submit

### DIFF
--- a/frontend/src/app/(storefront)/checkout/page.tsx
+++ b/frontend/src/app/(storefront)/checkout/page.tsx
@@ -159,6 +159,20 @@ function CheckoutContent() {
             </div>
           )}
 
+          {/* Shipping error with retry — prevents silent disabled button */}
+          {cartShippingError && !shippingLoading && (
+            <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700 flex items-center justify-between gap-2" data-testid="shipping-error">
+              <span>{cartShippingError}</span>
+              <button
+                type="button"
+                onClick={() => fetchCartShippingQuote(postalCode)}
+                className="text-red-600 hover:text-red-800 underline text-xs whitespace-nowrap flex-shrink-0"
+              >
+                Δοκιμάστε ξανά
+              </button>
+            </div>
+          )}
+
           <button
             type="submit"
             disabled={loading || cardProcessing || !!cartShippingError || shippingLoading || (!shippingQuote && !cartShippingQuote)}

--- a/frontend/src/app/(storefront)/checkout/useCheckout.ts
+++ b/frontend/src/app/(storefront)/checkout/useCheckout.ts
@@ -130,7 +130,6 @@ export function useCheckout() {
         setShippingQuote(null)
       } else {
         setCartShippingQuote(null)
-        setCartShippingError(null)
         try {
           const legacyQuote = await apiClient.getZoneShippingQuote({
             postal_code: postal,
@@ -138,6 +137,7 @@ export function useCheckout() {
             subtotal: subtotal,
           })
           trackShippingQuoteFailed({ postalCode: postal, errorCode: err?.code, fallbackUsed: true })
+          setCartShippingError(null)
           setShippingQuote({
             price_eur: legacyQuote.price_eur,
             zone_name: legacyQuote.zone_name,
@@ -147,6 +147,7 @@ export function useCheckout() {
         } catch {
           trackShippingQuoteFailed({ postalCode: postal, errorCode: err?.code, fallbackUsed: false })
           setShippingQuote(null)
+          setCartShippingError('Δεν ήταν δυνατός ο υπολογισμός μεταφορικών. Δοκιμάστε ξανά.')
         }
       }
     } finally {


### PR DESCRIPTION
## Summary
- Fix silent checkout failure when shipping API fails — submit button was disabled with no error message
- Move `setCartShippingError(null)` to success path only (was being cleared before fallback attempt)
- Set actionable Greek error message when both cart and legacy shipping APIs fail
- Add visible error banner with retry button near the submit button

## Root Cause
`useCheckout.ts` line 133: `setCartShippingError(null)` was called **before** the legacy fallback attempt. If both APIs failed:
- `cartShippingQuote = null`
- `shippingQuote = null`
- `cartShippingError = null` (cleared prematurely)
- Result: button disabled by `(!shippingQuote && !cartShippingQuote)` but no error shown

## Test plan
- [ ] Go to checkout with items in cart
- [ ] Enter valid postal code → shipping loads normally
- [ ] Simulate API failure (e.g., disconnect network) → error banner shows with retry button
- [ ] Click retry → shipping attempts to load again
- [ ] Submit button is never stuck in disabled state without explanation