### PR TITLE
fix(checkout): add payment API timeout + fix useEffect dependencies

### DIFF
--- a/frontend/src/app/(storefront)/checkout/useCheckout.ts
+++ b/frontend/src/app/(storefront)/checkout/useCheckout.ts
@@ -154,19 +154,23 @@ export function useCheckout() {
     }
   }, [cartItems, subtotal, t, paymentMethod])
 
+  // Keep a stable ref for use in effects to avoid stale closure issues
+  const fetchShippingRef = useRef(fetchCartShippingQuote)
+  useEffect(() => { fetchShippingRef.current = fetchCartShippingQuote }, [fetchCartShippingQuote])
+
   // Auto-fetch shipping when postal code is pre-filled from saved address
   useEffect(() => {
     if (postalCode && postalCode.length === 5 && !shippingQuote && !shippingLoading) {
-      fetchCartShippingQuote(postalCode)
+      fetchShippingRef.current(postalCode)
     }
-  }, [postalCode, savedAddress]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [postalCode, savedAddress, shippingQuote, shippingLoading])
 
   // Re-fetch when payment method changes (COD fee differs)
   useEffect(() => {
     if (postalCode && postalCode.length === 5) {
-      fetchCartShippingQuote(postalCode, paymentMethod)
+      fetchShippingRef.current(postalCode, paymentMethod)
     }
-  }, [paymentMethod]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [paymentMethod, postalCode])
 
   // --- Handlers ---
 

--- a/frontend/src/lib/api/payment.ts
+++ b/frontend/src/lib/api/payment.ts
@@ -63,6 +63,8 @@ export interface PaymentStatusResponse {
 import { API_BASE_URL } from '@/env';
 
 class PaymentApiClient {
+  private static readonly TIMEOUT_MS = 30_000; // 30s timeout for payment APIs
+
   private async request<T>(
     endpoint: string,
     options: RequestInit = {}
@@ -70,21 +72,34 @@ class PaymentApiClient {
     const token = localStorage.getItem('auth_token');
     const url = `${API_BASE_URL}${endpoint}`;
 
-    const response = await fetch(url, {
-      ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token && { 'Authorization': `Bearer ${token}` }),
-        ...options.headers,
-      },
-    });
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), PaymentApiClient.TIMEOUT_MS);
 
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({ message: 'Network error' }));
-      throw new Error(`HTTP ${response.status}: ${error.message || 'Unknown error'}`);
+    try {
+      const response = await fetch(url, {
+        ...options,
+        signal: controller.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token && { 'Authorization': `Bearer ${token}` }),
+          ...options.headers,
+        },
+      });
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ message: 'Network error' }));
+        throw new Error(`HTTP ${response.status}: ${error.message || 'Unknown error'}`);
+      }
+
+      return response.json();
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        throw new Error('Η σύνδεση έληξε. Ελέγξτε τη σύνδεσή σας και δοκιμάστε ξανά.');
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeout);
     }
-
-    return response.json();
   }
 
   async getPaymentMethods(): Promise<PaymentMethodsResponse> {


### PR DESCRIPTION
## Summary
- Add 30-second AbortController timeout to PaymentApiClient — prevents checkout from hanging indefinitely on slow/dead network connections
- Replace `eslint-disable-line react-hooks/exhaustive-deps` with proper `useRef` pattern for `fetchCartShippingQuote` in useCheckout.ts
- Greek error message on timeout: "Η σύνδεση έληξε. Ελέγξτε τη σύνδεσή σας και δοκιμάστε ξανά."

## Test plan
- [ ] Checkout with card payment on normal connection → works as before
- [ ] Simulate slow network (DevTools throttle) → timeout after 30s with Greek error message
- [ ] No eslint warnings about exhaustive-deps in useCheckout.ts
- [ ] Payment method change → shipping re-fetches correctly (no stale closures)