### PR TITLE
feat(T11b): Mediterranean Pantry — 10→9 categories + premium 3×3 grid

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -309,9 +309,9 @@ export default async function Page({ searchParams }: PageProps) {
             fallback={
               <div>
                 <div className="h-10 w-24 bg-neutral-100 rounded-full animate-pulse mb-3" />
-                <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
-                  {Array.from({ length: 10 }).map((_, i) => (
-                    <div key={i} className="h-28 sm:h-32 bg-neutral-100 rounded-xl animate-pulse" />
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
+                  {Array.from({ length: 9 }).map((_, i) => (
+                    <div key={i} className="h-36 sm:h-44 bg-neutral-100 rounded-xl animate-pulse" />
                   ))}
                 </div>
               </div>

--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -17,8 +17,6 @@ const slugIconMap: Record<string, string> = {
   'herbs': 'herbs',
   'sweets': 'candy',
   'sauces': 'jar',
-  'wine': 'beverage',
-  'beverages': 'beverage',
   'cosmetics': 'cosmetics',
 };
 
@@ -35,8 +33,6 @@ const slugBgMap: Record<string, string> = {
   'herbs': 'bg-category-vegetables',
   'sweets': 'bg-category-fruits',
   'sauces': 'bg-category-meat',
-  'wine': 'bg-category-wine',
-  'beverages': 'bg-category-wine',
   'cosmetics': 'bg-category-dairy',
 };
 
@@ -131,8 +127,8 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
         <span>Όλα</span>
       </button>
 
-      {/* Category grid — 2 cols mobile, 5 cols tablet+ = perfect 10 */}
-      <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+      {/* Category grid — 2 cols mobile, 3 cols tablet+ = perfect 3×3 */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
         {items.map((item) => {
           const isSelected = currentCat === item.slug;
 
@@ -143,12 +139,12 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
               aria-pressed={isSelected}
               aria-label={`Κατηγορία: ${item.label}`}
               className={`
-                group flex flex-col items-center justify-center gap-2 p-3 sm:p-4
-                rounded-xl transition-all duration-300 cursor-pointer
+                group flex flex-col items-center justify-center gap-3 p-4 sm:p-6
+                rounded-xl border-2 transition-all duration-300 ease-out cursor-pointer
                 ${
                   isSelected
-                    ? 'bg-primary/5 ring-2 ring-primary shadow-md'
-                    : `${item.chipBg} hover:-translate-y-1 hover:shadow-card-hover`
+                    ? 'border-primary/40 shadow-glow bg-white'
+                    : `border-transparent ${item.chipBg} hover:shadow-card-hover hover:border-primary/20`
                 }
               `}
             >
@@ -157,13 +153,13 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
                 alt=""
                 width={80}
                 height={80}
-                className="w-14 h-14 sm:w-16 sm:h-16 flex-shrink-0 drop-shadow-sm
-                           group-hover:scale-110 transition-transform duration-300"
+                className="w-16 h-16 sm:w-20 sm:h-20 flex-shrink-0 drop-shadow-md
+                           group-hover:scale-105 transition-transform duration-300 ease-out"
               />
               <span
-                className={`text-sm sm:text-base font-medium text-center leading-tight
+                className={`text-sm font-semibold text-center leading-snug
                   line-clamp-2 min-h-[2.5rem] flex items-center
-                  ${isSelected ? 'text-primary' : 'text-neutral-700'}`}
+                  ${isSelected ? 'text-primary' : 'text-neutral-800'}`}
               >
                 {item.label}
               </span>

--- a/frontend/src/data/categories.ts
+++ b/frontend/src/data/categories.ts
@@ -1,6 +1,6 @@
 /**
- * Categories v2: 10 locker-compatible categories (was 13)
- * Removed: dairy, fruits-vegetables (need refrigeration)
+ * Categories v3: 9 locker-compatible categories (was 10)
+ * Removed: dairy, fruits-vegetables (need refrigeration), beverages (alcohol license)
  * Merged: grains-rice into legumes, flours-bakery into pasta
  * Added: cosmetics (natural cosmetics)
  * Icon PNGs stored in public/icons/categories/
@@ -28,7 +28,7 @@ export const CATEGORIES: Category[] = [
   {
     id: 2,
     slug: 'honey-bee',
-    labelEl: 'Μέλι & Κυψέλη',
+    labelEl: 'Μέλι & Προϊόντα Μελισσοκομίας',
     labelEn: 'Honey & Bee Products',
     emoji: 'honey',
     chipBg: 'bg-category-honey',
@@ -52,8 +52,8 @@ export const CATEGORIES: Category[] = [
   {
     id: 5,
     slug: 'nuts-dried',
-    labelEl: 'Ξηροί Καρποί',
-    labelEn: 'Nuts & Dried Fruits',
+    labelEl: 'Ξηροί Καρποί & Σνακ',
+    labelEn: 'Nuts & Snacks',
     emoji: 'nuts',
     chipBg: 'bg-category-fruits',
   },
@@ -76,21 +76,13 @@ export const CATEGORIES: Category[] = [
   {
     id: 8,
     slug: 'sauces-preserves',
-    labelEl: 'Σάλτσες & Κονσέρβες',
-    labelEn: 'Sauces & Preserves',
+    labelEl: 'Σάλτσες & Τουρσιά',
+    labelEn: 'Sauces & Pickles',
     emoji: 'jar',
     chipBg: 'bg-category-meat',
   },
   {
     id: 9,
-    slug: 'beverages',
-    labelEl: 'Ποτά & Αποστάγματα',
-    labelEn: 'Beverages & Spirits',
-    emoji: 'beverage',
-    chipBg: 'bg-category-wine',
-  },
-  {
-    id: 10,
     slug: 'cosmetics',
     labelEl: 'Φυσικά Καλλυντικά',
     labelEn: 'Natural Cosmetics',


### PR DESCRIPTION
## Summary
- **Remove "Ποτά & Αποστάγματα"** — alcohol license (ΑΑΔΕ) needed, skip for MVP → 10→9 categories
- **3 renames**: Μέλι & Κυψέλη → Μελισσοκομίας, Σάλτσες & Κονσέρβες → Τουρσιά, Ξηροί Καρποί → + Σνακ
- **3×3 grid** (was 5×2) — 67% wider cards, premium feel like curated artisan pantry
- **Larger icons**: 64→80px desktop with `drop-shadow-md` + refined `scale-105` hover
- **Premium selected state**: `shadow-glow` (green aura) + white bg instead of ring
- **Premium hover**: subtle green border fade-in instead of translate bounce
- **Generous padding**: `p-4 sm:p-6` (was `p-3 sm:p-4`)
- **Border system**: `border-2 border-transparent` prevents layout shift on select
- **Text**: `font-semibold text-neutral-800` (darker, bolder for pastel readability)
- **Cleanup**: Remove wine/beverages from dynamic slug maps

## Before → After
| | Before | After |
|---|---|---|
| Categories | 10 | 9 (no beverages) |
| Grid | 5+5 desktop, 2×5 mobile | **3×3 desktop**, 2-col mobile |
| Card width | ~230px | **~385px** (+67%) |
| Icons | 64px, drop-shadow-sm | **80px, drop-shadow-md** |
| Hover | translate-y bounce | shadow + green border |
| Selected | ring-2 + bg-primary/5 | **shadow-glow** + white |
| Padding | p-3/p-4 | **p-4/p-6** |

## Files changed (3)
- `categories.ts` — Remove beverages entry, rename 3 labels (-12, +8)
- `CategoryStrip.tsx` — Grid 5→3 col, premium card styling (-14, +11)
- `products/page.tsx` — Skeleton: 10→9 items, 5→3 col, taller (-3, +3)

## Test plan
- [ ] Desktop: "Όλα" pill + **3×3 grid** perfectly symmetric
- [ ] Mobile: 2-col grid, 5 rows (last row 1 item)
- [ ] Hover: green border + shadow (NO translate bounce)
- [ ] Selected: warm green glow + white bg + green border
- [ ] Icons: 80px crisp with drop-shadow-md
- [ ] Labels: "Μελισσοκομίας", "Σνακ", "Τουρσιά" correct
- [ ] No "Ποτά" category visible
- [ ] `?cat=slug` routing works correctly
- [ ] `npx tsc --noEmit` passes