### PR TITLE
ui: Phase 2 — full-bleed layout + warm header/footer

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -173,11 +173,9 @@ export default function RootLayout({
             <ToastProvider>
               <AuthProvider>
                 <Header />
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-                  <main id="main-content" data-testid="page-root">
-                    {children}
-                  </main>
-                </div>
+                <main id="main-content" data-testid="page-root">
+                  {children}
+                </main>
                 <Footer />
                 <ToastContainer />
               </AuthProvider>

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -12,7 +12,7 @@ export default function Footer() {
     setLocale(newLocale);
   };
   return (
-    <footer className="border-t border-neutral-200 bg-white mt-auto">
+    <footer className="border-t border-accent-gold/10 bg-accent-cream/50 mt-auto">
       {/* Mobile-first padding */}
       <div className="max-w-6xl mx-auto px-4 py-8 sm:py-10">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6 sm:gap-8">
@@ -26,7 +26,7 @@ export default function Footer() {
 
           {/* Quick Links - touch-friendly spacing */}
           <div>
-            <h4 className="font-semibold text-neutral-900 mb-3 sm:mb-4">Γρήγοροι Σύνδεσμοι</h4>
+            <h4 className="text-xs font-semibold text-accent-gold uppercase tracking-wider mb-3 sm:mb-4">Γρήγοροι Σύνδεσμοι</h4>
             <nav className="flex flex-col gap-1" data-testid="footer-quick-links">
               <Link href="/products" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
                 Προϊόντα
@@ -42,7 +42,7 @@ export default function Footer() {
 
           {/* For Producers - touch-friendly spacing */}
           <div>
-            <h4 className="font-semibold text-neutral-900 mb-3 sm:mb-4">Για Παραγωγούς</h4>
+            <h4 className="text-xs font-semibold text-accent-gold uppercase tracking-wider mb-3 sm:mb-4">Για Παραγωγούς</h4>
             <nav className="flex flex-col gap-1">
               <Link href="/producers" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
                 Γίνε Παραγωγός
@@ -55,7 +55,7 @@ export default function Footer() {
 
           {/* Legal & Support - touch-friendly spacing */}
           <div>
-            <h4 className="font-semibold text-neutral-900 mb-3 sm:mb-4">Υποστήριξη</h4>
+            <h4 className="text-xs font-semibold text-accent-gold uppercase tracking-wider mb-3 sm:mb-4">Υποστήριξη</h4>
             <nav className="flex flex-col gap-1">
               <Link href="/faq" className="py-2 text-sm text-neutral-600 hover:text-primary active:text-primary transition-colors touch-manipulation">
                 Συχνές Ερωτήσεις
@@ -74,7 +74,7 @@ export default function Footer() {
         </div>
 
         {/* Bottom Bar - mobile-first spacing */}
-        <div className="mt-8 sm:mt-10 pt-5 sm:pt-6 border-t border-neutral-200 flex flex-col sm:flex-row items-center justify-between gap-3 sm:gap-4">
+        <div className="mt-8 sm:mt-10 pt-5 sm:pt-6 border-t border-accent-gold/10 flex flex-col sm:flex-row items-center justify-between gap-3 sm:gap-4">
           <p className="text-sm text-neutral-500">
             © {new Date().getFullYear()} Dixis. Με αγάπη για τους τοπικούς παραγωγούς.
           </p>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -47,7 +47,7 @@ export default function Header() {
   // Cart visible for all roles (producers can also shop as customers)
 
   return (
-    <header className="border-b border-neutral-200 bg-white/95 backdrop-blur-sm supports-[backdrop-filter]:bg-white/80 sticky top-0 z-40">
+    <header className="border-b border-accent-gold/10 bg-accent-cream/95 backdrop-blur-sm supports-[backdrop-filter]:bg-accent-cream/80 sticky top-0 z-40">
       <div className="max-w-6xl mx-auto px-4 h-16 flex items-center justify-between">
         {/* Logo - Desktop: 48px, Mobile: 36px (per NAVIGATION-V1.md) */}
         <Link
@@ -71,7 +71,7 @@ export default function Header() {
             <Link
               key={link.href}
               href={link.href}
-              className="text-sm font-medium text-neutral-600 hover:text-primary transition-colors"
+              className="text-sm font-medium text-neutral-700 hover:text-accent-gold transition-colors"
             >
               {link.label}
             </Link>
@@ -193,7 +193,7 @@ export default function Header() {
               </Link>
               <Link
                 href="/auth/register"
-                className="text-sm font-medium bg-primary hover:bg-primary-light text-white px-4 py-2 rounded-md transition-colors"
+                className="text-sm font-medium bg-primary hover:bg-primary-light text-white px-5 py-2 rounded-full transition-colors"
                 data-testid="nav-register"
               >
                 {t('nav.signup')}
@@ -231,7 +231,7 @@ export default function Header() {
 
       {/* Mobile Menu */}
       {mobileMenuOpen && (
-        <nav className="md:hidden border-t border-neutral-200 bg-white shadow-lg" data-testid="mobile-menu">
+        <nav className="md:hidden border-t border-accent-gold/10 bg-accent-cream shadow-lg" data-testid="mobile-menu">
           <div className="max-w-6xl mx-auto px-4 py-2">
             {/* Mobile Search - Pass HEADER-SEARCH-01 */}
             <div className="py-2">

--- a/frontend/src/components/marketing/FeaturedProducts.tsx
+++ b/frontend/src/components/marketing/FeaturedProducts.tsx
@@ -81,11 +81,12 @@ export default async function FeaturedProducts() {
   const hasProducts = products.length > 0;
 
   return (
-    <section className="bg-neutral-50 py-12 sm:py-16 lg:py-20" data-testid="featured-products">
+    <section className="bg-gradient-to-b from-white to-accent-cream/30 py-16 sm:py-20 lg:py-24" data-testid="featured-products">
       <div className="max-w-6xl mx-auto px-4 sm:px-6">
         {/* Section header */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8 sm:mb-10 gap-4">
           <div>
+            <p className="text-sm font-medium text-accent-gold uppercase tracking-wider mb-2">Επιλεγμένα για Εσάς</p>
             <h2 className="text-3xl font-bold text-neutral-900 mb-2 sm:text-4xl">
               Προτεινόμενα Προϊόντα
             </h2>
@@ -106,7 +107,7 @@ export default async function FeaturedProducts() {
 
         {/* Products grid */}
         {hasProducts ? (
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-5 sm:gap-7">
             {products.map((product) => {
               const imageUrl = product.image_url || product.images?.[0]?.url || null;
               return (
@@ -127,7 +128,7 @@ export default async function FeaturedProducts() {
             })}
           </div>
         ) : (
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-5 sm:gap-7">
             {[...Array(8)].map((_, i) => (
               <ProductCardSkeleton key={i} />
             ))}


### PR DESCRIPTION
## Summary
- **Remove root layout `max-w-7xl` wrapper** — every page already has its own container (verified 17+ pages). This unlocks full-bleed backgrounds across the site
- **Header**: clinical white → warm cream (`bg-accent-cream/95`), gold border, gold nav hovers, pill-shaped register button
- **Footer**: white → cream (`bg-accent-cream/50`), gold section headers (uppercase tracking), gold borders
- **FeaturedProducts**: grey `bg-neutral-50` → warm gradient, gold "Επιλεγμένα για Εσάς" label, wider grid gaps

## Why
Phase 1 (product cards + products page) was deployed but user feedback was "δεν βλεπω καμια αλλαγη" — too subtle. This phase makes changes **visible on EVERY page** by warming up the frame (header+footer) and unlocking full-width backgrounds.

## Test plan
- [ ] `npx tsc --noEmit` — zero errors ✅
- [ ] `npm run build` — clean ✅
- [ ] Visual: homepage, /products, /products/[id], /cart, /auth/login
- [ ] Mobile: 375px viewport — header, footer, all pages
- [ ] No page has lost container/padding (all have their own wrappers)
- [ ] LOC: 33 (well within ≤300 limit)