### PR TITLE
ui: Phase 5+6 — polish + storytelling final layer

### DIFF
--- a/frontend/src/components/AddToCartButton.tsx
+++ b/frontend/src/components/AddToCartButton.tsx
@@ -50,7 +50,7 @@ export default function AddToCartButton(props: {
   if (isOutOfStock) {
     return (
       <button
-        className="h-9 sm:h-11 px-3 sm:px-4 w-full sm:w-auto rounded text-sm bg-red-100 text-red-600 cursor-not-allowed"
+        className="h-9 sm:h-11 px-3 sm:px-4 w-full sm:w-auto rounded-full text-sm bg-red-100 text-red-600 cursor-not-allowed"
         disabled
         aria-label={`${props.title} - Εξαντλήθηκε`}
         aria-live="polite"
@@ -64,7 +64,7 @@ export default function AddToCartButton(props: {
 
   return (
     <button
-      className={`h-9 sm:h-11 px-3 sm:px-4 w-full sm:w-auto rounded text-sm transition-all duration-200 active:scale-95 ${
+      className={`h-9 sm:h-11 px-3 sm:px-4 w-full sm:w-auto rounded-full text-sm transition-all duration-200 active:scale-95 ${
         isAdded
           ? 'bg-accent-gold text-white'
           : 'bg-primary text-white hover:bg-primary-light'

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -136,12 +136,12 @@ export function ProductCardSkeleton() {
     <div data-testid="product-card-skeleton" className="flex flex-col h-full bg-white border border-neutral-200/80 rounded-xl overflow-hidden animate-pulse">
       <div className="aspect-square sm:aspect-[4/5] bg-accent-beige/60 w-full" />
       <div className="p-2.5 sm:p-4 flex-grow flex flex-col">
-        <div className="h-3 bg-neutral-200 w-1/3 mb-3 rounded" />
-        <div className="h-5 sm:h-6 bg-neutral-200 w-full mb-2 rounded" />
-        <div className="h-5 sm:h-6 bg-neutral-200 w-2/3 rounded" />
+        <div className="h-3 bg-accent-beige/60 w-1/3 mb-3 rounded" />
+        <div className="h-5 sm:h-6 bg-accent-beige/60 w-full mb-2 rounded" />
+        <div className="h-5 sm:h-6 bg-accent-beige/60 w-2/3 rounded" />
         <div className="mt-auto pt-3 sm:pt-4 flex flex-col sm:flex-row gap-2 sm:justify-between sm:items-center border-t border-neutral-100">
-          <div className="h-5 sm:h-6 bg-neutral-200 w-1/4 rounded" />
-          <div className="h-9 bg-neutral-200 w-full sm:w-24 rounded-lg" />
+          <div className="h-5 sm:h-6 bg-accent-beige/60 w-1/4 rounded" />
+          <div className="h-9 bg-accent-beige/60 w-full sm:w-24 rounded-lg" />
         </div>
       </div>
     </div>

--- a/frontend/src/components/marketing/CTA.tsx
+++ b/frontend/src/components/marketing/CTA.tsx
@@ -28,13 +28,13 @@ export default function CTA() {
         <div className="flex flex-col sm:flex-row gap-4 justify-center items-stretch sm:items-center">
           <Link
             href="/products"
-            className="inline-flex items-center justify-center min-h-[48px] px-8 py-3 bg-primary hover:bg-primary-light text-white font-semibold rounded-lg shadow-md hover:shadow-lg transition-all duration-200 active:scale-[0.98] touch-manipulation"
+            className="inline-flex items-center justify-center min-h-[48px] px-8 py-3 bg-primary hover:bg-primary-light text-white font-semibold rounded-full shadow-md hover:shadow-lg transition-all duration-200 active:scale-[0.98] touch-manipulation"
           >
             Δείτε τα Προϊόντα
           </Link>
           <Link
             href="/auth/register"
-            className="inline-flex items-center justify-center min-h-[48px] px-8 py-3 bg-white hover:bg-neutral-50 text-primary font-semibold rounded-lg border-2 border-primary transition-all duration-200 active:scale-[0.98] touch-manipulation"
+            className="inline-flex items-center justify-center min-h-[48px] px-8 py-3 bg-white hover:bg-neutral-50 text-primary font-semibold rounded-full border-2 border-primary transition-all duration-200 active:scale-[0.98] touch-manipulation"
           >
             Δημιουργία Λογαριασμού
           </Link>

--- a/frontend/src/components/marketing/Hero.tsx
+++ b/frontend/src/components/marketing/Hero.tsx
@@ -13,9 +13,10 @@ export default function Hero() {
   return (
     <section className="bg-gradient-to-b from-accent-cream via-primary-pale/30 to-white">
       {/* Mobile-first container with generous padding */}
-      <div className="max-w-6xl mx-auto px-4 py-12 sm:px-6 sm:py-16 lg:py-20">
+      <div className="max-w-6xl mx-auto px-4 py-16 sm:px-6 sm:py-20 lg:py-28">
         <div className="max-w-3xl mx-auto text-center">
           {/* Heading - optimized for mobile readability */}
+          <p className="text-sm font-medium text-accent-gold uppercase tracking-wider mb-3">Αγορά Παραγωγών</p>
           <h1 className="text-4xl font-bold text-neutral-900 leading-tight mb-6 sm:text-5xl lg:text-6xl">
             Αυθεντικά Ελληνικά Προϊόντα
             <span className="block text-accent-gold mt-2">
@@ -33,7 +34,7 @@ export default function Hero() {
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-stretch sm:items-center">
             <Link
               href="/products"
-              className="inline-flex items-center justify-center min-h-[48px] px-8 py-3 bg-primary hover:bg-primary-light text-white font-semibold rounded-lg shadow-md hover:shadow-lg transition-all duration-200 active:scale-[0.98] touch-manipulation"
+              className="inline-flex items-center justify-center min-h-[48px] px-8 py-3 bg-primary hover:bg-primary-light text-white font-semibold rounded-full shadow-md hover:shadow-lg transition-all duration-200 active:scale-[0.98] touch-manipulation"
             >
               Δείτε τα Προϊόντα
             </Link>
@@ -46,7 +47,7 @@ export default function Hero() {
           </div>
 
           {/* Trust indicator - subtle, mobile-optimized */}
-          <div className="mt-10 pt-8 border-t border-neutral-200">
+          <div className="mt-10 pt-8 border-t border-accent-gold/20">
             <div className="flex justify-center gap-6 flex-wrap">
               <div className="flex items-center gap-2">
                 <svg className="w-5 h-5 text-accent-gold" fill="currentColor" viewBox="0 0 20 20">

--- a/frontend/src/components/marketing/Trust.tsx
+++ b/frontend/src/components/marketing/Trust.tsx
@@ -16,7 +16,7 @@ export default function Trust() {
       ),
       title: 'Ποιότητα Εγγυημένη',
       description: 'Όλα τα προϊόντα μας είναι επιλεγμένα με αυστηρά κριτήρια ποιότητας, απευθείας από Έλληνες παραγωγούς.',
-      cardBg: 'bg-primary-pale',
+      cardBg: 'bg-white border border-accent-gold/10',
     },
     {
       icon: (
@@ -26,7 +26,7 @@ export default function Trust() {
       ),
       title: 'Τοπικοί Παραγωγοί',
       description: 'Γνωρίστε τους ανθρώπους πίσω από κάθε προϊόν. Υποστηρίζουμε μικρούς Έλληνες παραγωγούς.',
-      cardBg: 'bg-accent-beige',
+      cardBg: 'bg-white border border-accent-gold/10',
     },
     {
       icon: (
@@ -36,15 +36,16 @@ export default function Trust() {
       ),
       title: 'Γρήγορη Παράδοση',
       description: 'Παραλάβετε τα προϊόντα σας εντός 24-48 ωρών. Δωρεάν παράδοση για παραγγελίες άνω των 30€.',
-      cardBg: 'bg-blue-50',
+      cardBg: 'bg-white border border-accent-gold/10',
     },
   ];
 
   return (
-    <section className="bg-white py-12 sm:py-16 lg:py-20">
+    <section className="bg-accent-cream/30 py-12 sm:py-16 lg:py-20">
       <div className="max-w-6xl mx-auto px-4 sm:px-6">
         {/* Section header - mobile-optimized */}
         <div className="text-center mb-10 sm:mb-12">
+          <p className="text-sm font-medium text-accent-gold uppercase tracking-wider mb-2">Η Υπόσχεσή μας</p>
           <h2 className="text-3xl font-bold text-neutral-900 mb-4 sm:text-4xl">
             Γιατί να επιλέξετε το Dixis;
           </h2>


### PR DESCRIPTION
## Summary
- **Warm skeletons**: ProductCard loading skeleton colors from cold grey (`bg-neutral-200`) → warm beige (`bg-accent-beige/60`)
- **Pill buttons everywhere**: AddToCart, Hero CTAs, CTA section — all `rounded-full` matching header register button
- **Hero upgraded**: Taller padding (py-16→py-28 on desktop), gold "Αγορά Παραγωγών" label, gold trust border
- **Trust section**: Warm cream background, unified white cards with gold borders, "Η Υπόσχεσή μας" gold label
- **CTA buttons**: Pill-shaped for site-wide consistency

## Design Changes
| Element | Before | After |
|---------|--------|-------|
| Skeletons | `bg-neutral-200` (cold grey) | `bg-accent-beige/60` (warm) |
| AddToCart | `rounded` | `rounded-full` (pill) |
| Hero padding | `py-12 sm:py-16 lg:py-20` | `py-16 sm:py-20 lg:py-28` |
| Hero trust border | `border-neutral-200` | `border-accent-gold/20` |
| Trust bg | `bg-white` | `bg-accent-cream/30` |
| Trust cards | Mixed colors | White + gold border |
| All CTAs | `rounded-lg` | `rounded-full` |

## This completes all 6 phases of the UI redesign 🎉

## Test plan
- [ ] `npx tsc --noEmit` — zero errors ✅
- [ ] `npm run build` — clean ✅
- [ ] Visual: dixis.gr (hero, trust, CTA sections)
- [ ] Visual: dixis.gr/products (skeleton loading state)
- [ ] Mobile: 375px viewport — hero, trust cards, CTA buttons
- [ ] PR ≤ 300 LOC (34 LOC actual)