### PR TITLE
ui: Phase 7 — warm filter area

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -311,16 +311,16 @@ export default async function Page({ searchParams }: PageProps) {
         </div>
 
         {/* Filter Card — search + sort + categories + cultivation */}
-        <div className="bg-white/80 backdrop-blur-sm rounded-xl border border-neutral-200/60 shadow-sm p-5 mb-8 space-y-4">
+        <div className="bg-accent-cream/60 rounded-xl border border-accent-gold/15 shadow-card p-6 mb-8 space-y-5">
           {/* Search + Sort */}
           <div className="flex flex-col sm:flex-row gap-3">
             <div className="flex-1">
-              <Suspense fallback={<div className="h-10 w-full bg-neutral-100 rounded-lg animate-pulse" />}>
+              <Suspense fallback={<div className="h-10 w-full bg-accent-beige/50 rounded-lg animate-pulse" />}>
                 <ProductSearchInput />
               </Suspense>
             </div>
             <div className="sm:w-52">
-              <Suspense fallback={<div className="h-10 w-full bg-neutral-100 rounded-lg animate-pulse" />}>
+              <Suspense fallback={<div className="h-10 w-full bg-accent-beige/50 rounded-lg animate-pulse" />}>
                 <ProductSort />
               </Suspense>
             </div>
@@ -331,7 +331,7 @@ export default async function Page({ searchParams }: PageProps) {
             fallback={
               <div className="flex flex-wrap gap-2">
                 {Array.from({ length: 5 }).map((_, i) => (
-                  <div key={i} className="h-9 w-24 bg-neutral-100 rounded-full animate-pulse" />
+                  <div key={i} className="h-9 w-24 bg-accent-beige/50 rounded-full animate-pulse" />
                 ))}
               </div>
             }

--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -87,8 +87,8 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
             transition-all duration-200
             ${
               !currentCat
-                ? 'bg-primary text-white shadow-md'
-                : 'bg-white text-neutral-600 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale'
+                ? 'bg-primary text-white shadow-card'
+                : 'bg-white text-neutral-700 border border-accent-gold/20 hover:border-accent-gold/50 hover:bg-accent-cream'
             }
           `}
         >

--- a/frontend/src/components/CultivationFilter.tsx
+++ b/frontend/src/components/CultivationFilter.tsx
@@ -70,8 +70,8 @@ export function CultivationFilter({
             transition-all duration-200
             ${
               !current
-                ? 'bg-primary text-white shadow-md'
-                : 'bg-white text-neutral-600 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale'
+                ? 'bg-primary text-white shadow-card'
+                : 'bg-white text-neutral-700 border border-accent-gold/20 hover:border-accent-gold/50 hover:bg-accent-cream'
             }
           `}
         >
@@ -105,7 +105,7 @@ export function CultivationFilter({
               {count > 0 && (
                 <span
                   className={`ml-0.5 text-xs ${
-                    isSelected ? 'opacity-80' : 'text-neutral-400'
+                    isSelected ? 'opacity-80' : 'text-accent-gold/60'
                   }`}
                 >
                   ({count})

--- a/frontend/src/components/ProductSearchInput.tsx
+++ b/frontend/src/components/ProductSearchInput.tsx
@@ -66,7 +66,7 @@ export function ProductSearchInput() {
   return (
     <div className="relative w-full">
       <svg
-        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-neutral-500"
+        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-neutral-400"
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"
@@ -79,7 +79,7 @@ export function ProductSearchInput() {
         placeholder={t('products.searchPlaceholder')}
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
-        className="w-full pl-11 pr-10 py-2.5 border border-neutral-300 rounded-xl focus:ring-2 focus:ring-primary/50 focus:border-transparent outline-none transition-all"
+        className="w-full pl-11 pr-10 py-2.5 border border-neutral-200 rounded-xl bg-white focus:border-accent-gold focus:ring-1 focus:ring-accent-gold/30 outline-none transition-all"
         aria-label={t('products.searchPlaceholder')}
       />
       {inputValue && (

--- a/frontend/src/components/ProductSort.tsx
+++ b/frontend/src/components/ProductSort.tsx
@@ -49,7 +49,7 @@ export function ProductSort() {
         value={currentValue}
         onChange={handleChange}
         aria-label="Ταξινόμηση προϊόντων"
-        className="w-full appearance-none pl-3.5 pr-8 py-2.5 border border-neutral-300 rounded-xl bg-white text-sm font-medium text-neutral-700 focus:ring-2 focus:ring-primary/50 focus:border-transparent outline-none transition-all cursor-pointer"
+        className="w-full appearance-none pl-3.5 pr-8 py-2.5 border border-neutral-200 rounded-xl bg-white text-sm font-medium text-neutral-800 focus:border-accent-gold focus:ring-1 focus:ring-accent-gold/30 outline-none transition-all cursor-pointer"
       >
         {SORT_OPTIONS.map((opt) => (
           <option key={opt.value} value={opt.value}>
@@ -58,7 +58,7 @@ export function ProductSort() {
         ))}
       </select>
       <svg
-        className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400"
+        className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-500"
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"


### PR DESCRIPTION
## Summary
The filter area on /products was a cold, clinical "foreign body" on an otherwise warm, premium page. This PR integrates it into the warm design system.

- **Filter card**: Cream bg + gold border + proper shadow (was: translucent white, grey border, tiny shadow)
- **Search input**: Gold focus ring (was: green ring jarring on cream background)
- **Sort dropdown**: Gold focus ring + darker text for readability
- **Category pills**: Gold borders + cream hover (was: grey borders, green hover)
- **Cultivation pills**: Same warm treatment + gold-tinted count badges
- **Skeleton fallbacks**: Warm beige loading states

## Design Changes
| Element | Before (cold) | After (warm) |
|---------|--------------|-------------|
| Filter card bg | `bg-white/80` | `bg-accent-cream/60` |
| Card border | `border-neutral-200/60` | `border-accent-gold/15` |
| Card shadow | `shadow-sm` | `shadow-card` |
| Input focus | `focus:ring-primary/50` | `focus:ring-accent-gold/30` |
| Pill border | `border-neutral-200` | `border-accent-gold/20` |
| Pill hover | `hover:bg-primary-pale` | `hover:bg-accent-cream` |
| Count badge | `text-neutral-400` | `text-accent-gold/60` |

## Test plan
- [ ] `npx tsc --noEmit` — zero errors ✅
- [ ] `npm run build` — clean ✅
- [ ] Visual: dixis.gr/products — filter card feels integrated
- [ ] Interaction: search focus, sort focus — gold ring
- [ ] Interaction: category pill click — warm styling
- [ ] Mobile 375px — pills wrap, card responsive
- [ ] PR ≤ 300 LOC (26 LOC actual)