### PR TITLE
ui: Phase 8 — Lucide SVG category icons

### DIFF
--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -1,30 +1,58 @@
 'use client';
 
-import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  Droplets,
+  Flower2,
+  Bean,
+  Wheat,
+  Nut,
+  Leaf,
+  Candy,
+  CookingPot,
+  Sparkles,
+  LayoutGrid,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { CATEGORIES } from '@/data/categories';
 
-/** Icon filename mapping for dynamic (API-sourced) categories */
-const slugIconMap: Record<string, string> = {
-  'olive-oil': 'olive',
-  'honey': 'honey',
-  'legumes': 'beans',
-  'grains': 'beans',
-  'rice': 'beans',
-  'pasta': 'pasta',
-  'flours': 'pasta',
-  'nuts': 'nuts',
-  'herbs': 'herbs',
-  'sweets': 'candy',
-  'sauces': 'jar',
-  'cosmetics': 'cosmetics',
+/** Lucide icon mapping for dynamic (API-sourced) categories */
+const SLUG_ICON_MAP: Record<string, LucideIcon> = {
+  'olive-oil': Droplets,
+  'honey': Flower2,
+  'legumes': Bean,
+  'grains': Bean,
+  'rice': Bean,
+  'pasta': Wheat,
+  'flours': Wheat,
+  'nuts': Nut,
+  'herbs': Leaf,
+  'sweets': Candy,
+  'sauces': CookingPot,
+  'cosmetics': Sparkles,
 };
 
-function getIconForSlug(slug: string): string {
-  for (const [key, icon] of Object.entries(slugIconMap)) {
+/** Static icon mapping keyed by category slug from categories.ts */
+const STATIC_ICON_MAP: Record<string, LucideIcon> = {
+  'olive-oil-olives': Droplets,
+  'honey-bee': Flower2,
+  'legumes-grains': Bean,
+  'pasta-flours': Wheat,
+  'nuts-dried': Nut,
+  'herbs-spices': Leaf,
+  'sweets-spreads': Candy,
+  'sauces-preserves': CookingPot,
+  'cosmetics': Sparkles,
+};
+
+function getIconForSlug(slug: string): LucideIcon {
+  // Exact match first (static categories)
+  if (STATIC_ICON_MAP[slug]) return STATIC_ICON_MAP[slug];
+  // Partial match (dynamic API categories)
+  for (const [key, icon] of Object.entries(SLUG_ICON_MAP)) {
     if (slug.includes(key)) return icon;
   }
-  return 'basket';
+  return LayoutGrid;
 }
 
 interface DynamicCategory {
@@ -42,7 +70,7 @@ interface CategoryStripProps {
 interface CategoryItem {
   slug: string;
   label: string;
-  icon: string;
+  icon: LucideIcon;
 }
 
 export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryStripProps) {
@@ -71,7 +99,7 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
     : CATEGORIES.map((cat) => ({
         slug: cat.slug,
         label: cat.labelEl,
-        icon: cat.emoji,
+        icon: getIconForSlug(cat.slug),
       }));
 
   return (
@@ -92,18 +120,13 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
             }
           `}
         >
-          <Image
-            src="/icons/categories/basket.png"
-            alt=""
-            width={20}
-            height={20}
-            className="w-5 h-5 flex-shrink-0"
-          />
+          <LayoutGrid className="w-5 h-5 sm:w-6 sm:h-6 flex-shrink-0" />
           <span>Όλα</span>
         </button>
 
         {/* Category pills */}
         {items.map((item) => {
+          const Icon = item.icon;
           const isSelected = currentCat === item.slug;
 
           return (
@@ -117,18 +140,12 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
                 transition-all duration-200
                 ${
                   isSelected
-                    ? 'bg-primary text-white shadow-md'
-                    : 'bg-white text-neutral-600 border border-neutral-200 hover:border-primary/40 hover:bg-primary-pale'
+                    ? 'bg-primary text-white shadow-card'
+                    : 'bg-white text-neutral-700 border border-accent-gold/20 hover:border-accent-gold/50 hover:bg-accent-cream'
                 }
               `}
             >
-              <Image
-                src={`/icons/categories/${item.icon}.png`}
-                alt=""
-                width={20}
-                height={20}
-                className="w-5 h-5 flex-shrink-0"
-              />
+              <Icon className="w-5 h-5 sm:w-6 sm:h-6 flex-shrink-0" />
               <span>{item.label}</span>
             </button>
           );

--- a/frontend/src/data/categories.ts
+++ b/frontend/src/data/categories.ts
@@ -1,9 +1,9 @@
 /**
- * Categories v3: 9 locker-compatible categories (was 10)
+ * Categories v4: 9 locker-compatible categories
  * Removed: dairy, fruits-vegetables (need refrigeration), beverages (alcohol license)
  * Merged: grains-rice into legumes, flours-bakery into pasta
  * Added: cosmetics (natural cosmetics)
- * Icon PNGs stored in public/icons/categories/
+ * Icons: Lucide React SVGs (see CategoryStrip.tsx for rendering)
  */
 
 export interface Category {
@@ -11,7 +11,7 @@ export interface Category {
   slug: string;
   labelEl: string;
   labelEn: string;
-  emoji: string; // PNG filename (without extension) in public/icons/categories/
+  iconName: string; // Lucide icon name (rendered by CategoryStrip)
   /** Tailwind bg color class for unselected chip */
   chipBg: string;
 }
@@ -22,7 +22,7 @@ export const CATEGORIES: Category[] = [
     slug: 'olive-oil-olives',
     labelEl: 'Ελαιόλαδο & Ελιές',
     labelEn: 'Olive Oil & Olives',
-    emoji: 'olive',
+    iconName: 'Droplets',
     chipBg: 'bg-category-olive',
   },
   {
@@ -30,7 +30,7 @@ export const CATEGORIES: Category[] = [
     slug: 'honey-bee',
     labelEl: 'Μέλι & Προϊόντα Μελισσοκομίας',
     labelEn: 'Honey & Bee Products',
-    emoji: 'honey',
+    iconName: 'Flower2',
     chipBg: 'bg-category-honey',
   },
   {
@@ -38,7 +38,7 @@ export const CATEGORIES: Category[] = [
     slug: 'legumes-grains',
     labelEl: 'Όσπρια & Δημητριακά',
     labelEn: 'Legumes & Grains',
-    emoji: 'beans',
+    iconName: 'Bean',
     chipBg: 'bg-category-vegetables',
   },
   {
@@ -46,7 +46,7 @@ export const CATEGORIES: Category[] = [
     slug: 'pasta-flours',
     labelEl: 'Ζυμαρικά & Αλεύρια',
     labelEn: 'Pasta & Flours',
-    emoji: 'pasta',
+    iconName: 'Wheat',
     chipBg: 'bg-category-bakery',
   },
   {
@@ -54,7 +54,7 @@ export const CATEGORIES: Category[] = [
     slug: 'nuts-dried',
     labelEl: 'Ξηροί Καρποί & Σνακ',
     labelEn: 'Nuts & Snacks',
-    emoji: 'nuts',
+    iconName: 'Nut',
     chipBg: 'bg-category-fruits',
   },
   {
@@ -62,7 +62,7 @@ export const CATEGORIES: Category[] = [
     slug: 'herbs-spices',
     labelEl: 'Βότανα & Μπαχαρικά',
     labelEn: 'Herbs & Spices',
-    emoji: 'herbs',
+    iconName: 'Leaf',
     chipBg: 'bg-category-vegetables',
   },
   {
@@ -70,7 +70,7 @@ export const CATEGORIES: Category[] = [
     slug: 'sweets-spreads',
     labelEl: 'Γλυκά & Αλείμματα',
     labelEn: 'Sweets & Spreads',
-    emoji: 'candy',
+    iconName: 'Candy',
     chipBg: 'bg-category-fruits',
   },
   {
@@ -78,7 +78,7 @@ export const CATEGORIES: Category[] = [
     slug: 'sauces-preserves',
     labelEl: 'Σάλτσες & Τουρσιά',
     labelEn: 'Sauces & Pickles',
-    emoji: 'jar',
+    iconName: 'CookingPot',
     chipBg: 'bg-category-meat',
   },
   {
@@ -86,7 +86,7 @@ export const CATEGORIES: Category[] = [
     slug: 'cosmetics',
     labelEl: 'Φυσικά Καλλυντικά',
     labelEn: 'Natural Cosmetics',
-    emoji: 'cosmetics',
+    iconName: 'Sparkles',
     chipBg: 'bg-category-dairy',
   },
 ];


### PR DESCRIPTION
## Summary
- Replace ugly PNG category icons (149KB-1.1MB each) with Lucide React SVGs (0KB overhead — already bundled)
- Icons now 20px mobile → 24px desktop (bigger, clearer)
- Each category visually distinctive: Droplets (olive oil), Flower2 (honey), Bean (legumes), Wheat (pasta), Nut (nuts), Leaf (herbs), Candy (sweets), CookingPot (sauces), Sparkles (cosmetics)
- Consistent icon library with CultivationFilter (both use Lucide)

## Files changed (2)
- `frontend/src/components/CategoryStrip.tsx` — PNG Image → Lucide Icon components
- `frontend/src/data/categories.ts` — emoji field → iconName field (v3→v4)

## Test plan
- [ ] `npx tsc --noEmit` — zero errors ✅
- [ ] `npm run build` — clean ✅
- [ ] Visual: /products — SVG icons in category pills
- [ ] Mobile 375px — icons w-5 h-5
- [ ] Desktop — icons sm:w-6 sm:h-6 (24px)
- [ ] Click category — icon renders in selected (white) state
- [ ] CultivationFilter unaffected