### PR TITLE
fix: register category pastel colors in Tailwind v4 @theme + larger icons

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -24,6 +24,16 @@
   --color-primary-foreground: var(--brand-primary-foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+
+  /* Category pastel backgrounds (Wolt-style cards) */
+  --color-category-vegetables: #e8f5ed;
+  --color-category-fruits: #fef3c7;
+  --color-category-dairy: #e0f2fe;
+  --color-category-meat: #fee2e2;
+  --color-category-bakery: #f5f0e6;
+  --color-category-honey: #fef9c3;
+  --color-category-wine: #fce7f3;
+  --color-category-olive: #ecfccb;
 }
 
 /* =============================================================================

--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -175,7 +175,7 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
               bg-accent-cream
             `}
           >
-            <LayoutGrid className="w-7 h-7 sm:w-9 sm:h-9 text-neutral-500" />
+            <LayoutGrid className="w-9 h-9 sm:w-11 sm:h-11 text-neutral-500" />
           </div>
           <span
             className={`text-xs font-medium text-center leading-tight
@@ -213,7 +213,7 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
                   ${item.bg}
                 `}
               >
-                <Icon className="w-7 h-7 sm:w-9 sm:h-9 text-neutral-700" />
+                <Icon className="w-9 h-9 sm:w-11 sm:h-11 text-neutral-700" />
               </div>
               <span
                 className={`text-xs font-medium text-center leading-tight max-w-[76px] sm:max-w-[88px] line-clamp-2


### PR DESCRIPTION
## Summary
- **Fix pastel backgrounds**: Tailwind v4 ignores `tailwind.config.ts` — `bg-category-*` classes weren't generated. Added all 8 colors to `@theme inline` block in globals.css
- **Bigger icons**: Category card icons bumped from 28/36px to 36/44px (mobile/desktop) per user request

## Test plan
- [ ] Visual: dixis.gr/products — category cards now have colored backgrounds
- [ ] Icons visibly larger inside cards
- [ ] Build: clean