### PR TITLE
cat: unify 14 categories into 10 definitive slugs

### DIFF
--- a/backend/database/migrations/2026_02_19_100000_unify_categories_to_10.php
+++ b/backend/database/migrations/2026_02_19_100000_unify_categories_to_10.php
@@ -1,0 +1,157 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Unify 14 legacy categories into 10 definitive categories.
+ *
+ * Phase 10: Merges, renames and deletes categories so that the storefront
+ * and backend share the same 10 locker-compatible slugs.
+ *
+ * Slug mapping (old → new):
+ *   olive-oil-olives   → olive-oil-olives (unchanged)
+ *   honey-preserves    → honey-bee
+ *   nuts-dried-fruits   → nuts-dried
+ *   cosmetics          → cosmetics (created if missing)
+ *   wine-beverages     → beverages
+ *   sweets-preserves   → sweets-jams
+ *   pasta-trahanas     → pasta
+ *   herbs-spices       → herbs-spices-tea
+ *   sauces-pickles     → sauces-spreads
+ *   legumes + grains-cereals + flours-bakery → legumes-grains
+ *   dairy-products     → nuts-dried (reassign products)
+ *   fruits             → DELETE (not shelf-stable)
+ *   vegetables         → DELETE (not shelf-stable)
+ */
+return new class extends Migration
+{
+    /**
+     * The 10 definitive categories to create/ensure.
+     */
+    private const TARGET_CATEGORIES = [
+        'olive-oil-olives'  => 'Ελαιόλαδο & Ελιές',
+        'honey-bee'         => 'Μέλι & Προϊόντα Μέλισσας',
+        'nuts-dried'        => 'Ξηροί Καρποί',
+        'cosmetics'         => 'Φυσικά Καλλυντικά',
+        'beverages'         => 'Ποτά',
+        'sweets-jams'       => 'Γλυκά & Μαρμελάδες',
+        'pasta'             => 'Ζυμαρικά',
+        'herbs-spices-tea'  => 'Βότανα, Μπαχαρικά & Τσάι',
+        'sauces-spreads'    => 'Σάλτσες & Αλείμματα',
+        'legumes-grains'    => 'Όσπρια & Δημητριακά',
+    ];
+
+    /**
+     * Old slug → new slug mapping for product reassignment.
+     * Slugs not listed here are either unchanged or deleted.
+     */
+    private const SLUG_MAP = [
+        'honey-preserves'  => 'honey-bee',
+        'nuts-dried-fruits' => 'nuts-dried',
+        'wine-beverages'   => 'beverages',
+        'sweets-preserves' => 'sweets-jams',
+        'pasta-trahanas'   => 'pasta',
+        'herbs-spices'     => 'herbs-spices-tea',
+        'sauces-pickles'   => 'sauces-spreads',
+        'legumes'          => 'legumes-grains',
+        'grains-cereals'   => 'legumes-grains',
+        'flours-bakery'    => 'legumes-grains',
+        'dairy-products'   => 'nuts-dried',
+    ];
+
+    /**
+     * Old slugs whose products are deleted (not shelf-stable).
+     */
+    private const DELETE_SLUGS = [
+        'fruits',
+        'vegetables',
+    ];
+
+    public function up(): void
+    {
+        // Step 1: Create all 10 target categories (if they don't exist)
+        $now = now();
+        foreach (self::TARGET_CATEGORIES as $slug => $name) {
+            $exists = DB::table('categories')->where('slug', $slug)->exists();
+            if (! $exists) {
+                DB::table('categories')->insert([
+                    'name' => $name,
+                    'slug' => $slug,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            } else {
+                // Update the name to the definitive Greek name
+                DB::table('categories')
+                    ->where('slug', $slug)
+                    ->update(['name' => $name, 'updated_at' => $now]);
+            }
+        }
+
+        // Step 2: Reassign products from old categories to new ones
+        foreach (self::SLUG_MAP as $oldSlug => $newSlug) {
+            $oldCat = DB::table('categories')->where('slug', $oldSlug)->first();
+            $newCat = DB::table('categories')->where('slug', $newSlug)->first();
+
+            if (! $oldCat || ! $newCat) {
+                continue; // Skip if source or target doesn't exist
+            }
+
+            // Get product IDs that are currently assigned to old category
+            $productIds = DB::table('category_product')
+                ->where('category_id', $oldCat->id)
+                ->pluck('product_id')
+                ->toArray();
+
+            foreach ($productIds as $productId) {
+                // Check if product already has the new category
+                $alreadyHas = DB::table('category_product')
+                    ->where('product_id', $productId)
+                    ->where('category_id', $newCat->id)
+                    ->exists();
+
+                if (! $alreadyHas) {
+                    DB::table('category_product')->insert([
+                        'product_id' => $productId,
+                        'category_id' => $newCat->id,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ]);
+                }
+            }
+
+            // Remove old category assignments
+            DB::table('category_product')
+                ->where('category_id', $oldCat->id)
+                ->delete();
+        }
+
+        // Step 3: Remove products from deleted categories
+        foreach (self::DELETE_SLUGS as $slug) {
+            $cat = DB::table('categories')->where('slug', $slug)->first();
+            if ($cat) {
+                DB::table('category_product')
+                    ->where('category_id', $cat->id)
+                    ->delete();
+            }
+        }
+
+        // Step 4: Delete old categories that are no longer needed
+        $targetSlugs = array_keys(self::TARGET_CATEGORIES);
+        $oldSlugs = array_merge(array_keys(self::SLUG_MAP), self::DELETE_SLUGS);
+        $toDelete = array_diff($oldSlugs, $targetSlugs);
+
+        if (! empty($toDelete)) {
+            DB::table('categories')
+                ->whereIn('slug', $toDelete)
+                ->delete();
+        }
+    }
+
+    public function down(): void
+    {
+        // This migration is not safely reversible since product reassignments
+        // lose the original category info. To restore, re-run seeders.
+    }
+};

--- a/backend/database/seeders/CategorySeeder.php
+++ b/backend/database/seeders/CategorySeeder.php
@@ -4,32 +4,29 @@ namespace Database\Seeders;
 
 use App\Models\Category;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Str;
 
 class CategorySeeder extends Seeder
 {
     /**
      * Run the database seeds.
+     *
+     * Phase 10: Definitive 10 locker-compatible categories for Greek
+     * artisan products. Covers all non-refrigerated, shelf-stable goods
+     * suitable for parcel delivery (Skroutz Point, ACS, ΕΛΤΑ, etc.).
      */
     public function run(): void
     {
-        // Greek-first category names (slug stays English for URLs)
         $categories = [
-            'fruits' => 'Φρούτα',
-            'vegetables' => 'Λαχανικά',
-            'herbs-spices' => 'Βότανα & Μπαχαρικά',
-            'grains-cereals' => 'Δημητριακά & Όσπρια',
-            'dairy-products' => 'Γαλακτοκομικά',
-            'olive-oil-olives' => 'Ελαιόλαδο & Ελιές',
-            'wine-beverages' => 'Κρασιά & Ποτά',
-            'honey-preserves' => 'Μέλι & Κονσέρβες',
-            // Phase 3: Categories needed by Greek storefront products
-            'legumes' => 'Όσπρια',
-            'pasta-trahanas' => 'Ζυμαρικά & Τραχανάς',
-            'flours-bakery' => 'Αλεύρια & Αρτοποιία',
-            'nuts-dried-fruits' => 'Ξηροί Καρποί',
-            'sweets-preserves' => 'Γλυκά & Μαρμελάδες',
-            'sauces-pickles' => 'Σάλτσες & Τουρσιά',
+            'olive-oil-olives'  => 'Ελαιόλαδο & Ελιές',
+            'honey-bee'         => 'Μέλι & Προϊόντα Μέλισσας',
+            'nuts-dried'        => 'Ξηροί Καρποί',
+            'cosmetics'         => 'Φυσικά Καλλυντικά',
+            'beverages'         => 'Ποτά',
+            'sweets-jams'       => 'Γλυκά & Μαρμελάδες',
+            'pasta'             => 'Ζυμαρικά',
+            'herbs-spices-tea'  => 'Βότανα, Μπαχαρικά & Τσάι',
+            'sauces-spreads'    => 'Σάλτσες & Αλείμματα',
+            'legumes-grains'    => 'Όσπρια & Δημητριακά',
         ];
 
         foreach ($categories as $slug => $greekName) {

--- a/backend/database/seeders/GreekProductSeeder.php
+++ b/backend/database/seeders/GreekProductSeeder.php
@@ -95,7 +95,7 @@ class GreekProductSeeder extends Seeder
                     'is_organic' => false,
                     'is_active' => true,
                 ],
-                'category' => 'sweets-preserves',
+                'category' => 'sweets-jams',
                 'image' => 'https://images.unsplash.com/photo-1597714026720-8f74c62310ba',
             ],
             [
@@ -110,7 +110,7 @@ class GreekProductSeeder extends Seeder
                     'is_organic' => false,
                     'is_active' => true,
                 ],
-                'category' => 'dairy-products',
+                'category' => 'nuts-dried',
                 'image' => 'https://images.unsplash.com/photo-1559561853-08451507cbe7',
             ],
             [
@@ -125,7 +125,7 @@ class GreekProductSeeder extends Seeder
                     'is_organic' => true,
                     'is_active' => true,
                 ],
-                'category' => 'fruits',
+                'category' => 'legumes-grains',
                 'image' => 'https://images.unsplash.com/photo-1547036967-23d11aacaee0',
             ],
             [
@@ -140,7 +140,7 @@ class GreekProductSeeder extends Seeder
                     'is_organic' => false,
                     'is_active' => true,
                 ],
-                'category' => 'vegetables',
+                'category' => 'legumes-grains',
                 'image' => 'https://images.unsplash.com/photo-1518977676601-b53f82ber39a',
             ],
             [
@@ -155,7 +155,7 @@ class GreekProductSeeder extends Seeder
                     'is_organic' => false,
                     'is_active' => true,
                 ],
-                'category' => 'pasta-trahanas',
+                'category' => 'pasta',
                 'image' => 'https://images.unsplash.com/photo-1621996346565-e3dbc646d9a9',
             ],
 
@@ -172,7 +172,7 @@ class GreekProductSeeder extends Seeder
                     'is_organic' => true,
                     'is_active' => true,
                 ],
-                'category' => 'honey-preserves',
+                'category' => 'honey-bee',
                 'image' => 'https://images.unsplash.com/photo-1558642452-9d2a7deb7f62',
             ],
             [
@@ -187,7 +187,7 @@ class GreekProductSeeder extends Seeder
                     'is_organic' => false,
                     'is_active' => true,
                 ],
-                'category' => 'wine-beverages',
+                'category' => 'beverages',
                 'image' => 'https://images.unsplash.com/photo-1569529465841-dfecdab7503b',
             ],
             [
@@ -202,7 +202,7 @@ class GreekProductSeeder extends Seeder
                     'is_organic' => true,
                     'is_active' => true,
                 ],
-                'category' => 'herbs-spices',
+                'category' => 'herbs-spices-tea',
                 'image' => 'https://images.unsplash.com/photo-1515586000433-45406d8e6662',
             ],
             [
@@ -217,7 +217,7 @@ class GreekProductSeeder extends Seeder
                     'is_organic' => false,
                     'is_active' => true,
                 ],
-                'category' => 'wine-beverages',
+                'category' => 'beverages',
                 'image' => 'https://images.unsplash.com/photo-1553361371-9b22f78e8b1d',
             ],
         ];

--- a/backend/database/seeders/ProductSeeder.php
+++ b/backend/database/seeders/ProductSeeder.php
@@ -26,13 +26,12 @@ class ProductSeeder extends Seeder
             return;
         }
 
-        // Get categories for assignment
-        $vegetables = Category::where('slug', 'vegetables')->first();
-        $fruits = Category::where('slug', 'fruits')->first();
+        // Get categories for assignment (Phase 10: unified slugs)
+        $legumeGrains = Category::where('slug', 'legumes-grains')->first();
         $oliveOil = Category::where('slug', 'olive-oil-olives')->first();
-        $herbs = Category::where('slug', 'herbs-spices')->first();
-        $dairy = Category::where('slug', 'dairy-products')->first();
-        $honey = Category::where('slug', 'honey-preserves')->first();
+        $herbsTea = Category::where('slug', 'herbs-spices-tea')->first();
+        $nutsDried = Category::where('slug', 'nuts-dried')->first();
+        $honey = Category::where('slug', 'honey-bee')->first();
 
         // Get producers by slug for explicit assignment, with fallbacks
         $ktima = $producers->firstWhere('slug', 'ktima-papadopoulou') ?? $producers->firstWhere('slug', 'green-farm-co') ?? $producers->first();
@@ -58,7 +57,7 @@ class ProductSeeder extends Seeder
                     'status' => 'available',
                     'is_active' => true,
                 ],
-                'categories' => [$vegetables],
+                'categories' => [$legumeGrains],
                 'images' => [
                     ['url' => 'https://images.unsplash.com/photo-1592841200221-a6898f307baa', 'is_primary' => true, 'sort_order' => 0],
                     ['url' => 'https://images.unsplash.com/photo-1546470427-a465b4e8c3c8', 'is_primary' => false, 'sort_order' => 1],
@@ -80,7 +79,7 @@ class ProductSeeder extends Seeder
                     'status' => 'available',
                     'is_active' => true,
                 ],
-                'categories' => [$vegetables],
+                'categories' => [$legumeGrains],
                 'images' => [
                     ['url' => 'https://images.unsplash.com/photo-1622206151226-18ca2c9ab4a1', 'is_primary' => true, 'sort_order' => 0],
                 ],
@@ -101,7 +100,7 @@ class ProductSeeder extends Seeder
                     'status' => 'available',
                     'is_active' => true,
                 ],
-                'categories' => [$herbs],
+                'categories' => [$herbsTea],
                 'images' => [
                     ['url' => 'https://images.unsplash.com/photo-1629978452215-6ab392d7abb9', 'is_primary' => true, 'sort_order' => 0],
                 ],
@@ -145,7 +144,7 @@ class ProductSeeder extends Seeder
                     'status' => 'available',
                     'is_active' => true,
                 ],
-                'categories' => [$honey ?? $oliveOil],
+                'categories' => [$honey],
                 'images' => [
                     ['url' => 'https://images.unsplash.com/photo-1587049352846-4a222e784d38', 'is_primary' => true, 'sort_order' => 0],
                 ],
@@ -167,7 +166,7 @@ class ProductSeeder extends Seeder
                     'status' => 'available',
                     'is_active' => true,
                 ],
-                'categories' => [$fruits],
+                'categories' => [$legumeGrains],
                 'images' => [
                     ['url' => 'https://images.unsplash.com/photo-1560806887-1e4cd0b6cbd6', 'is_primary' => true, 'sort_order' => 0],
                 ],
@@ -188,7 +187,7 @@ class ProductSeeder extends Seeder
                     'status' => 'available',
                     'is_active' => true,
                 ],
-                'categories' => [$dairy ?? $vegetables],
+                'categories' => [$nutsDried],
                 'images' => [
                     ['url' => 'https://images.unsplash.com/photo-1626957341926-98752fc2ba90', 'is_primary' => true, 'sort_order' => 0],
                 ],

--- a/backend/tests/Feature/TaxonomyGuardrailTest.php
+++ b/backend/tests/Feature/TaxonomyGuardrailTest.php
@@ -7,14 +7,15 @@ use App\Models\Product;
 use App\Models\Producer;
 use Database\Seeders\CategorySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Str;
 use Tests\TestCase;
 
 /**
  * Guardrail tests for category/product taxonomy consistency.
  *
+ * Phase 10: Definitive 10 locker-compatible categories.
+ *
  * Ensures:
- * - All expected categories exist with correct slugs
+ * - All 10 expected categories exist with correct slugs
  * - Products reference valid categories
  * - No orphaned category references
  *
@@ -25,66 +26,40 @@ class TaxonomyGuardrailTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * The canonical category slugs created by CategorySeeder.
+     * The canonical 10 category slugs created by CategorySeeder.
      * Any code referencing categories should use these exact slugs.
      */
     private const CANONICAL_CATEGORY_SLUGS = [
-        'fruits',
-        'vegetables',
-        'herbs-spices',
-        'grains-cereals',
-        'dairy-products',
         'olive-oil-olives',
-        'wine-beverages',
-        'honey-preserves',
+        'honey-bee',
+        'nuts-dried',
+        'cosmetics',
+        'beverages',
+        'sweets-jams',
+        'pasta',
+        'herbs-spices-tea',
+        'sauces-spreads',
+        'legumes-grains',
     ];
 
     /**
-     * Test that CategorySeeder creates all expected categories.
+     * Test that CategorySeeder creates all 10 expected categories.
      */
     public function test_category_seeder_creates_all_expected_categories(): void
     {
-        // Run the seeder
         $this->seed(CategorySeeder::class);
 
-        // Verify all canonical categories exist
         foreach (self::CANONICAL_CATEGORY_SLUGS as $slug) {
             $this->assertDatabaseHas('categories', [
                 'slug' => $slug,
-            ], "Category with slug '{$slug}' should exist");
+            ]);
         }
 
-        // Verify count matches
         $this->assertEquals(
             count(self::CANONICAL_CATEGORY_SLUGS),
             Category::count(),
             'CategorySeeder should create exactly '.count(self::CANONICAL_CATEGORY_SLUGS).' categories'
         );
-    }
-
-    /**
-     * Test that category slugs are generated correctly from names.
-     */
-    public function test_category_slug_generation_is_consistent(): void
-    {
-        $expectedMappings = [
-            'Fruits' => 'fruits',
-            'Vegetables' => 'vegetables',
-            'Herbs & Spices' => 'herbs-spices',
-            'Grains & Cereals' => 'grains-cereals',
-            'Dairy Products' => 'dairy-products',
-            'Olive Oil & Olives' => 'olive-oil-olives',
-            'Wine & Beverages' => 'wine-beverages',
-            'Honey & Preserves' => 'honey-preserves',
-        ];
-
-        foreach ($expectedMappings as $name => $expectedSlug) {
-            $this->assertEquals(
-                $expectedSlug,
-                Str::slug($name),
-                "Str::slug('{$name}') should produce '{$expectedSlug}'"
-            );
-        }
     }
 
     /**
@@ -97,17 +72,15 @@ class TaxonomyGuardrailTest extends TestCase
         $producer = Producer::factory()->create();
         $product = Product::factory()->create(['producer_id' => $producer->id]);
 
-        $vegetables = Category::where('slug', 'vegetables')->first();
-        $fruits = Category::where('slug', 'fruits')->first();
+        $oliveOil = Category::where('slug', 'olive-oil-olives')->first();
+        $honey = Category::where('slug', 'honey-bee')->first();
 
-        // Attach categories
-        $product->categories()->attach([$vegetables->id, $fruits->id]);
+        $product->categories()->attach([$oliveOil->id, $honey->id]);
 
-        // Reload and verify
         $product->refresh();
         $this->assertCount(2, $product->categories);
-        $this->assertTrue($product->categories->contains('slug', 'vegetables'));
-        $this->assertTrue($product->categories->contains('slug', 'fruits'));
+        $this->assertTrue($product->categories->contains('slug', 'olive-oil-olives'));
+        $this->assertTrue($product->categories->contains('slug', 'honey-bee'));
     }
 
     /**
@@ -121,14 +94,12 @@ class TaxonomyGuardrailTest extends TestCase
         $product1 = Product::factory()->create(['producer_id' => $producer->id]);
         $product2 = Product::factory()->create(['producer_id' => $producer->id]);
 
-        $vegetables = Category::where('slug', 'vegetables')->first();
+        $pasta = Category::where('slug', 'pasta')->first();
 
-        // Attach products to category
-        $vegetables->products()->attach([$product1->id, $product2->id]);
+        $pasta->products()->attach([$product1->id, $product2->id]);
 
-        // Reload and verify
-        $vegetables->refresh();
-        $this->assertCount(2, $vegetables->products);
+        $pasta->refresh();
+        $this->assertCount(2, $pasta->products);
     }
 
     /**
@@ -153,7 +124,6 @@ class TaxonomyGuardrailTest extends TestCase
      */
     public function test_category_seeder_is_idempotent(): void
     {
-        // Run seeder twice
         $this->seed(CategorySeeder::class);
         $countAfterFirst = Category::count();
 
@@ -170,56 +140,42 @@ class TaxonomyGuardrailTest extends TestCase
     /**
      * Test lookup by known slugs works (guard against typos in code).
      *
-     * This test documents the exact slugs that ProductSeeder and other
+     * Documents the exact slugs that GreekProductSeeder and other
      * code should use when looking up categories.
      */
     public function test_known_category_slug_lookups(): void
     {
         $this->seed(CategorySeeder::class);
 
-        // All canonical slugs used in ProductSeeder - verify they exist
-        $this->assertNotNull(
-            Category::where('slug', 'vegetables')->first(),
-            "Category 'vegetables' should exist"
-        );
-        $this->assertNotNull(
-            Category::where('slug', 'fruits')->first(),
-            "Category 'fruits' should exist"
-        );
-        $this->assertNotNull(
-            Category::where('slug', 'olive-oil-olives')->first(),
-            "Category 'olive-oil-olives' should exist"
-        );
-        $this->assertNotNull(
-            Category::where('slug', 'herbs-spices')->first(),
-            "Category 'herbs-spices' should exist"
-        );
-        $this->assertNotNull(
-            Category::where('slug', 'dairy-products')->first(),
-            "Category 'dairy-products' should exist"
-        );
-        $this->assertNotNull(
-            Category::where('slug', 'honey-preserves')->first(),
-            "Category 'honey-preserves' should exist"
-        );
+        // All 10 canonical slugs must exist
+        foreach (self::CANONICAL_CATEGORY_SLUGS as $slug) {
+            $this->assertNotNull(
+                Category::where('slug', $slug)->first(),
+                "Category '{$slug}' should exist"
+            );
+        }
 
-        // Guard against common typo slugs that would silently fail
-        // (these would return NULL and cause products to have no category)
-        $this->assertNull(
-            Category::where('slug', 'dairy')->first(),
-            "Category 'dairy' should NOT exist (use 'dairy-products' instead)"
-        );
-        $this->assertNull(
-            Category::where('slug', 'honey')->first(),
-            "Category 'honey' should NOT exist (use 'honey-preserves' instead)"
-        );
-        $this->assertNull(
-            Category::where('slug', 'herbs')->first(),
-            "Category 'herbs' should NOT exist (use 'herbs-spices' instead)"
-        );
-        $this->assertNull(
-            Category::where('slug', 'oil')->first(),
-            "Category 'oil' should NOT exist (use 'olive-oil-olives' instead)"
-        );
+        // Guard against legacy slugs that would silently fail
+        $legacySlugs = [
+            'fruits',
+            'vegetables',
+            'dairy-products',
+            'wine-beverages',
+            'honey-preserves',
+            'herbs-spices',
+            'grains-cereals',
+            'pasta-trahanas',
+            'flours-bakery',
+            'nuts-dried-fruits',
+            'sweets-preserves',
+            'sauces-pickles',
+        ];
+
+        foreach ($legacySlugs as $legacy) {
+            $this->assertNull(
+                Category::where('slug', $legacy)->first(),
+                "Legacy category '{$legacy}' should NOT exist"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- New migration reassigns all products from 14 legacy categories to 10 unified, locker-compatible slugs
- Updates CategorySeeder, GreekProductSeeder, ProductSeeder with new slugs
- Rewrites TaxonomyGuardrailTest to validate exactly 10 canonical categories

## 10 Definitive Categories
| Slug | Name |
|------|------|
| `olive-oil-olives` | Ελαιόλαδο & Ελιές |
| `honey-bee` | Μέλι & Προϊόντα Μέλισσας |
| `nuts-dried` | Ξηροί Καρποί |
| `cosmetics` | Φυσικά Καλλυντικά |
| `beverages` | Ποτά |
| `sweets-jams` | Γλυκά & Μαρμελάδες |
| `pasta` | Ζυμαρικά |
| `herbs-spices-tea` | Βότανα, Μπαχαρικά & Τσάι |
| `sauces-spreads` | Σάλτσες & Αλείμματα |
| `legumes-grains` | Όσπρια & Δημητριακά |

## Slug transitions
- `honey-preserves` → `honey-bee`
- `wine-beverages` → `beverages`
- `nuts-dried-fruits` → `nuts-dried`
- `dairy-products` → `nuts-dried` (reassign)
- `sweets-preserves` → `sweets-jams`
- `pasta-trahanas` → `pasta`
- `herbs-spices` → `herbs-spices-tea`
- `sauces-pickles` → `sauces-spreads`
- `legumes` + `grains-cereals` + `flours-bakery` → `legumes-grains`
- `fruits`, `vegetables` → removed (not shelf-stable)

## Test plan
- [x] `php artisan test --filter=Taxonomy` — 6/6 pass
- [ ] Run migration on staging: `php artisan migrate`
- [ ] Verify products retain categories via API
- [ ] Frontend PR follows (cat/frontend-unify-10)