### PR TITLE
cat: unify frontend categories to 10 definitive slugs

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -25,15 +25,17 @@
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 
-  /* Category pastel backgrounds (Wolt-style cards) */
-  --color-category-vegetables: #e8f5ed;
-  --color-category-fruits: #fef3c7;
-  --color-category-dairy: #e0f2fe;
-  --color-category-meat: #fee2e2;
-  --color-category-bakery: #f5f0e6;
-  --color-category-honey: #fef9c3;
-  --color-category-wine: #fce7f3;
+  /* Category pastel backgrounds — 10 unified categories */
   --color-category-olive: #ecfccb;
+  --color-category-honey: #fef9c3;
+  --color-category-nuts: #fef3c7;
+  --color-category-cosmetics: #e0f2fe;
+  --color-category-beverages: #fce7f3;
+  --color-category-sweets: #fde2e4;
+  --color-category-pasta: #f5f0e6;
+  --color-category-herbs: #e8f5ed;
+  --color-category-sauces: #fee2e2;
+  --color-category-legumes: #efebe9;
 }
 
 /* =============================================================================
@@ -306,15 +308,17 @@ textarea::placeholder {
   color: var(--neutral-800);
 }
 
-/* Category background colors */
-.category-vegetables { background: var(--category-vegetables); }
-.category-fruits { background: var(--category-fruits); }
-.category-dairy { background: var(--category-dairy); }
-.category-meat { background: var(--category-meat); }
-.category-bakery { background: var(--category-bakery); }
-.category-honey { background: var(--category-honey); }
-.category-wine { background: var(--category-wine); }
+/* Category background colors — 10 unified categories */
 .category-olive { background: var(--category-olive); }
+.category-honey { background: var(--category-honey); }
+.category-nuts { background: var(--category-nuts); }
+.category-cosmetics { background: var(--category-cosmetics); }
+.category-beverages { background: var(--category-beverages); }
+.category-sweets { background: var(--category-sweets); }
+.category-pasta { background: var(--category-pasta); }
+.category-herbs { background: var(--category-herbs); }
+.category-sauces { background: var(--category-sauces); }
+.category-legumes { background: var(--category-legumes); }
 
 /* =============================================================================
    PRODUCT CARDS

--- a/frontend/src/components/CategoryStrip.tsx
+++ b/frontend/src/components/CategoryStrip.tsx
@@ -13,103 +13,53 @@ import {
   CookingPot,
   Sparkles,
   LayoutGrid,
-  Apple,
-  Carrot,
   Grape,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { CATEGORIES } from '@/data/categories';
 
-/* ── Frontend label overrides (rename backend categories) ── */
-const SLUG_LABEL_OVERRIDE: Record<string, string> = {
-  'dairy-products': 'Ξηροί Καρποί',
-};
-
 /* ── Custom image icons (used instead of Lucide for specific categories) ── */
 const SLUG_IMAGE_MAP: Record<string, string> = {
-  'dairy-products': '/icons/categories/nuts-bowl.png',
-  'honey': '/icons/categories/honey-3d.png',
-  'olive-oil': '/icons/categories/olive-oil-3d.png',
+  'nuts-dried': '/icons/categories/nuts-bowl.png',
+  'honey-bee': '/icons/categories/honey-3d.png',
+  'olive-oil-olives': '/icons/categories/olive-oil-3d.png',
   'cosmetics': '/icons/categories/cosmetics-3d.png',
 };
 
-/* ── Icon mapping (partial slug match) ── */
+/* ── Icon mapping (exact slug → Lucide component) ── */
 const SLUG_ICON_MAP: Record<string, LucideIcon> = {
-  'olive-oil': Droplets,
-  'honey': Flower2,
-  'legumes': Bean,
-  'grains': Bean,
-  'rice': Bean,
-  'pasta': Wheat,
-  'flours': Wheat,
-  'nuts': Nut,
-  'herbs': Leaf,
-  'sweets': Candy,
-  'sauces': CookingPot,
-  'cosmetics': Sparkles,
-  'fruits': Apple,
-  'vegetables': Carrot,
-  'wine': Grape,
-};
-
-const STATIC_ICON_MAP: Record<string, LucideIcon> = {
   'olive-oil-olives': Droplets,
   'honey-bee': Flower2,
-  'legumes-grains': Bean,
-  'pasta-flours': Wheat,
   'nuts-dried': Nut,
-  'herbs-spices': Leaf,
-  'sweets-spreads': Candy,
-  'sauces-preserves': CookingPot,
   'cosmetics': Sparkles,
+  'beverages': Grape,
+  'sweets-jams': Candy,
+  'pasta': Wheat,
+  'herbs-spices-tea': Leaf,
+  'sauces-spreads': CookingPot,
+  'legumes-grains': Bean,
 };
 
-/* ── Background color mapping (Wolt-style pastel cards) ── */
+/* ── Background color mapping (pastel cards) ── */
 const SLUG_BG_MAP: Record<string, string> = {
-  'olive-oil': 'bg-category-olive',
-  'honey': 'bg-category-honey',
-  'legumes': 'bg-category-vegetables',
-  'grains': 'bg-category-vegetables',
-  'rice': 'bg-category-vegetables',
-  'pasta': 'bg-category-bakery',
-  'flours': 'bg-category-bakery',
-  'nuts': 'bg-category-fruits',
-  'herbs': 'bg-category-vegetables',
-  'sweets': 'bg-category-fruits',
-  'sauces': 'bg-category-meat',
-  'cosmetics': 'bg-category-dairy',
-  'fruits': 'bg-category-fruits',
-  'vegetables': 'bg-category-vegetables',
-  'dairy': 'bg-category-fruits',
-  'wine': 'bg-category-wine',
-};
-
-const STATIC_BG_MAP: Record<string, string> = {
   'olive-oil-olives': 'bg-category-olive',
   'honey-bee': 'bg-category-honey',
-  'legumes-grains': 'bg-category-vegetables',
-  'pasta-flours': 'bg-category-bakery',
-  'nuts-dried': 'bg-category-fruits',
-  'herbs-spices': 'bg-category-vegetables',
-  'sweets-spreads': 'bg-category-fruits',
-  'sauces-preserves': 'bg-category-meat',
-  'cosmetics': 'bg-category-dairy',
+  'nuts-dried': 'bg-category-nuts',
+  'cosmetics': 'bg-category-cosmetics',
+  'beverages': 'bg-category-beverages',
+  'sweets-jams': 'bg-category-sweets',
+  'pasta': 'bg-category-pasta',
+  'herbs-spices-tea': 'bg-category-herbs',
+  'sauces-spreads': 'bg-category-sauces',
+  'legumes-grains': 'bg-category-legumes',
 };
 
 function getIconForSlug(slug: string): LucideIcon {
-  if (STATIC_ICON_MAP[slug]) return STATIC_ICON_MAP[slug];
-  for (const [key, icon] of Object.entries(SLUG_ICON_MAP)) {
-    if (slug.includes(key)) return icon;
-  }
-  return LayoutGrid;
+  return SLUG_ICON_MAP[slug] ?? LayoutGrid;
 }
 
 function getBgForSlug(slug: string): string {
-  if (STATIC_BG_MAP[slug]) return STATIC_BG_MAP[slug];
-  for (const [key, bg] of Object.entries(SLUG_BG_MAP)) {
-    if (slug.includes(key)) return bg;
-  }
-  return 'bg-accent-cream';
+  return SLUG_BG_MAP[slug] ?? 'bg-accent-cream';
 }
 
 /* ── Types ── */
@@ -150,29 +100,20 @@ export function CategoryStrip({ selectedCategory, dynamicCategories }: CategoryS
 
   const useDynamic = dynamicCategories && dynamicCategories.length > 0;
 
-  /* Helper: resolve custom image for a slug */
-  function getImageForSlug(slug: string): string | undefined {
-    if (SLUG_IMAGE_MAP[slug]) return SLUG_IMAGE_MAP[slug];
-    for (const [key, img] of Object.entries(SLUG_IMAGE_MAP)) {
-      if (slug.includes(key)) return img;
-    }
-    return undefined;
-  }
-
   const items: CategoryItem[] = useDynamic
     ? dynamicCategories.map((cat) => ({
         slug: cat.slug,
-        label: SLUG_LABEL_OVERRIDE[cat.slug] || cat.name,
+        label: cat.name,
         icon: getIconForSlug(cat.slug),
         bg: getBgForSlug(cat.slug),
-        customImage: getImageForSlug(cat.slug),
+        customImage: SLUG_IMAGE_MAP[cat.slug],
       }))
     : CATEGORIES.map((cat) => ({
         slug: cat.slug,
         label: cat.labelEl,
         icon: getIconForSlug(cat.slug),
         bg: getBgForSlug(cat.slug),
-        customImage: getImageForSlug(cat.slug),
+        customImage: SLUG_IMAGE_MAP[cat.slug],
       }));
 
   return (

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -123,25 +123,27 @@ export function ProductCard({
 export interface CategoryCardProps extends React.HTMLAttributes<HTMLDivElement> {
   icon: React.ReactNode;
   label: string;
-  category?: 'vegetables' | 'fruits' | 'dairy' | 'meat' | 'bakery' | 'honey' | 'wine' | 'olive';
+  category?: 'olive' | 'honey' | 'nuts' | 'cosmetics' | 'beverages' | 'sweets' | 'pasta' | 'herbs' | 'sauces' | 'legumes';
 }
 
 export function CategoryCard({
   className,
   icon,
   label,
-  category = 'vegetables',
+  category = 'olive',
   ...props
 }: CategoryCardProps) {
   const categoryColors = {
-    vegetables: 'bg-category-vegetables',
-    fruits: 'bg-category-fruits',
-    dairy: 'bg-category-dairy',
-    meat: 'bg-category-meat',
-    bakery: 'bg-category-bakery',
-    honey: 'bg-category-honey',
-    wine: 'bg-category-wine',
     olive: 'bg-category-olive',
+    honey: 'bg-category-honey',
+    nuts: 'bg-category-nuts',
+    cosmetics: 'bg-category-cosmetics',
+    beverages: 'bg-category-beverages',
+    sweets: 'bg-category-sweets',
+    pasta: 'bg-category-pasta',
+    herbs: 'bg-category-herbs',
+    sauces: 'bg-category-sauces',
+    legumes: 'bg-category-legumes',
   };
 
   return (

--- a/frontend/src/data/categories.ts
+++ b/frontend/src/data/categories.ts
@@ -1,8 +1,8 @@
 /**
- * Categories v4: 9 locker-compatible categories
- * Removed: dairy, fruits-vegetables (need refrigeration), beverages (alcohol license)
- * Merged: grains-rice into legumes, flours-bakery into pasta
- * Added: cosmetics (natural cosmetics)
+ * Categories v5: 10 definitive locker-compatible categories
+ *
+ * Phase 10: Unified backend + frontend taxonomy.
+ * All shelf-stable, parcel-deliverable Greek artisan products.
  * Icons: Lucide React SVGs (see CategoryStrip.tsx for rendering)
  */
 
@@ -12,7 +12,7 @@ export interface Category {
   labelEl: string;
   labelEn: string;
   iconName: string; // Lucide icon name (rendered by CategoryStrip)
-  /** Tailwind bg color class for unselected chip */
+  /** Tailwind bg color class for card */
   chipBg: string;
 }
 
@@ -28,66 +28,74 @@ export const CATEGORIES: Category[] = [
   {
     id: 2,
     slug: 'honey-bee',
-    labelEl: 'Μέλι & Προϊόντα Μελισσοκομίας',
+    labelEl: 'Μέλι & Προϊόντα Μέλισσας',
     labelEn: 'Honey & Bee Products',
     iconName: 'Flower2',
     chipBg: 'bg-category-honey',
   },
   {
     id: 3,
-    slug: 'legumes-grains',
-    labelEl: 'Όσπρια & Δημητριακά',
-    labelEn: 'Legumes & Grains',
-    iconName: 'Bean',
-    chipBg: 'bg-category-vegetables',
+    slug: 'nuts-dried',
+    labelEl: 'Ξηροί Καρποί',
+    labelEn: 'Nuts & Dried Fruits',
+    iconName: 'Nut',
+    chipBg: 'bg-category-nuts',
   },
   {
     id: 4,
-    slug: 'pasta-flours',
-    labelEl: 'Ζυμαρικά & Αλεύρια',
-    labelEn: 'Pasta & Flours',
-    iconName: 'Wheat',
-    chipBg: 'bg-category-bakery',
-  },
-  {
-    id: 5,
-    slug: 'nuts-dried',
-    labelEl: 'Ξηροί Καρποί & Σνακ',
-    labelEn: 'Nuts & Snacks',
-    iconName: 'Nut',
-    chipBg: 'bg-category-fruits',
-  },
-  {
-    id: 6,
-    slug: 'herbs-spices',
-    labelEl: 'Βότανα & Μπαχαρικά',
-    labelEn: 'Herbs & Spices',
-    iconName: 'Leaf',
-    chipBg: 'bg-category-vegetables',
-  },
-  {
-    id: 7,
-    slug: 'sweets-spreads',
-    labelEl: 'Γλυκά & Αλείμματα',
-    labelEn: 'Sweets & Spreads',
-    iconName: 'Candy',
-    chipBg: 'bg-category-fruits',
-  },
-  {
-    id: 8,
-    slug: 'sauces-preserves',
-    labelEl: 'Σάλτσες & Τουρσιά',
-    labelEn: 'Sauces & Pickles',
-    iconName: 'CookingPot',
-    chipBg: 'bg-category-meat',
-  },
-  {
-    id: 9,
     slug: 'cosmetics',
     labelEl: 'Φυσικά Καλλυντικά',
     labelEn: 'Natural Cosmetics',
     iconName: 'Sparkles',
-    chipBg: 'bg-category-dairy',
+    chipBg: 'bg-category-cosmetics',
+  },
+  {
+    id: 5,
+    slug: 'beverages',
+    labelEl: 'Ποτά',
+    labelEn: 'Beverages',
+    iconName: 'Grape',
+    chipBg: 'bg-category-beverages',
+  },
+  {
+    id: 6,
+    slug: 'sweets-jams',
+    labelEl: 'Γλυκά & Μαρμελάδες',
+    labelEn: 'Sweets & Jams',
+    iconName: 'Candy',
+    chipBg: 'bg-category-sweets',
+  },
+  {
+    id: 7,
+    slug: 'pasta',
+    labelEl: 'Ζυμαρικά',
+    labelEn: 'Pasta',
+    iconName: 'Wheat',
+    chipBg: 'bg-category-pasta',
+  },
+  {
+    id: 8,
+    slug: 'herbs-spices-tea',
+    labelEl: 'Βότανα, Μπαχαρικά & Τσάι',
+    labelEn: 'Herbs, Spices & Tea',
+    iconName: 'Leaf',
+    chipBg: 'bg-category-herbs',
+  },
+  {
+    id: 9,
+    slug: 'sauces-spreads',
+    labelEl: 'Σάλτσες & Αλείμματα',
+    labelEn: 'Sauces & Spreads',
+    iconName: 'CookingPot',
+    chipBg: 'bg-category-sauces',
+  },
+  {
+    id: 10,
+    slug: 'legumes-grains',
+    labelEl: 'Όσπρια & Δημητριακά',
+    labelEn: 'Legumes & Grains',
+    iconName: 'Bean',
+    chipBg: 'bg-category-legumes',
   },
 ];
 

--- a/frontend/src/data/demoProducts.ts
+++ b/frontend/src/data/demoProducts.ts
@@ -54,7 +54,7 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     producerName: 'Μέλι Βορείου Ελλάδος',
     categorySlug: 'honey-bee',
   },
-  // Legumes - Producer: Αγροτικός Συν/μός Πρεσπών (demo-producer-4)
+  // Legumes & Grains - Producer: Αγροτικός Συν/μός Πρεσπών (demo-producer-4)
   {
     id: 'demo-5',
     name: 'Φασόλια Γίγαντες Πρεσπών ΠΟΠ',
@@ -62,9 +62,9 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     unit: '500g',
     producerId: 'demo-producer-4',
     producerName: 'Αγροτικός Συν/μός Πρεσπών',
-    categorySlug: 'legumes',
+    categorySlug: 'legumes-grains',
   },
-  // Legumes - Producer: Green Farm Co. (demo-producer-5)
+  // Legumes & Grains - Producer: Green Farm Co. (demo-producer-5)
   {
     id: 'demo-6',
     name: 'Φακές Εγκλουβής Λευκάδας',
@@ -72,9 +72,9 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     unit: '500g',
     producerId: 'demo-producer-5',
     producerName: 'Green Farm Co.',
-    categorySlug: 'legumes',
+    categorySlug: 'legumes-grains',
   },
-  // Grains & Rice - Producer: Αγρόκτημα Σερρών (demo-producer-6)
+  // Legumes & Grains - Producer: Αγρόκτημα Σερρών (demo-producer-6)
   {
     id: 'demo-7',
     name: 'Ρύζι Καρολίνα Σερρών',
@@ -82,9 +82,9 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     unit: '1kg',
     producerId: 'demo-producer-6',
     producerName: 'Αγρόκτημα Σερρών',
-    categorySlug: 'grains-rice',
+    categorySlug: 'legumes-grains',
   },
-  // Grains & Rice - Producer: Ελληνικά Δημητριακά (demo-producer-7)
+  // Legumes & Grains - Producer: Ελληνικά Δημητριακά (demo-producer-7)
   {
     id: 'demo-8',
     name: 'Κριθαράκι Ολικής Άλεσης',
@@ -92,7 +92,7 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     unit: '500g',
     producerId: 'demo-producer-7',
     producerName: 'Ελληνικά Δημητριακά',
-    categorySlug: 'grains-rice',
+    categorySlug: 'legumes-grains',
   },
   // Pasta - Producer: Γιαγιάς Ζυμαρικά (demo-producer-8)
   {
@@ -113,7 +113,7 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     producerName: 'Γιαγιάς Ζυμαρικά',
     categorySlug: 'pasta',
   },
-  // Flours & Bakery - Producer: Βιο-Αλεύρια Θεσσαλίας (demo-producer-9)
+  // Legumes & Grains - Producer: Βιο-Αλεύρια Θεσσαλίας (demo-producer-9)
   {
     id: 'demo-11',
     name: 'Αλεύρι Ζέας Βιολογικό',
@@ -121,7 +121,7 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     unit: '1kg',
     producerId: 'demo-producer-9',
     producerName: 'Βιο-Αλεύρια Θεσσαλίας',
-    categorySlug: 'flours-bakery',
+    categorySlug: 'legumes-grains',
   },
   // Nuts & Dried - Producer: Φιστικοπαραγωγοί Αιγίνης (demo-producer-10)
   {
@@ -143,7 +143,7 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     producerName: 'Αγρόκτημα Κύμης',
     categorySlug: 'nuts-dried',
   },
-  // Herbs & Spices - Producer: Βότανα Μάνης (demo-producer-12)
+  // Herbs, Spices & Tea - Producer: Βότανα Μάνης (demo-producer-12)
   {
     id: 'demo-14',
     name: 'Ρίγανη Βουνού Ταϋγέτου',
@@ -151,9 +151,9 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     unit: '100g',
     producerId: 'demo-producer-12',
     producerName: 'Βότανα Μάνης',
-    categorySlug: 'herbs-spices',
+    categorySlug: 'herbs-spices-tea',
   },
-  // Herbs & Spices - Producer: Κροκοπαραγωγοί Κοζάνης (demo-producer-13)
+  // Herbs, Spices & Tea - Producer: Κροκοπαραγωγοί Κοζάνης (demo-producer-13)
   {
     id: 'demo-15',
     name: 'Κρόκος Κοζάνης ΠΟΠ',
@@ -161,9 +161,9 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     unit: '1g',
     producerId: 'demo-producer-13',
     producerName: 'Κροκοπαραγωγοί Κοζάνης',
-    categorySlug: 'herbs-spices',
+    categorySlug: 'herbs-spices-tea',
   },
-  // Sweets & Spreads - Producer: Χιώτικα Γλυκά (demo-producer-14)
+  // Sweets & Jams - Producer: Χιώτικα Γλυκά (demo-producer-14)
   {
     id: 'demo-16',
     name: 'Μαρμελάδα Πορτοκάλι Χίου',
@@ -171,9 +171,9 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     unit: '380g',
     producerId: 'demo-producer-14',
     producerName: 'Χιώτικα Γλυκά',
-    categorySlug: 'sweets-spreads',
+    categorySlug: 'sweets-jams',
   },
-  // Sweets & Spreads - Producer: Αμπελώνες Νεμέας (demo-producer-15)
+  // Sweets & Jams - Producer: Αμπελώνες Νεμέας (demo-producer-15)
   {
     id: 'demo-17',
     name: 'Πετιμέζι Παραδοσιακό',
@@ -181,9 +181,9 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     unit: '500ml',
     producerId: 'demo-producer-15',
     producerName: 'Αμπελώνες Νεμέας',
-    categorySlug: 'sweets-spreads',
+    categorySlug: 'sweets-jams',
   },
-  // Sauces & Preserves - Producer: Σαντορινιά Γεύση (demo-producer-16)
+  // Sauces & Spreads - Producer: Σαντορινιά Γεύση (demo-producer-16)
   {
     id: 'demo-18',
     name: 'Σάλτσα Ντομάτας Σαντορίνης',
@@ -191,7 +191,7 @@ export const DEMO_PRODUCTS: DemoProduct[] = [
     unit: '500g',
     producerId: 'demo-producer-16',
     producerName: 'Σαντορινιά Γεύση',
-    categorySlug: 'sauces-preserves',
+    categorySlug: 'sauces-spreads',
   },
 ];
 

--- a/frontend/src/lib/category-map.ts
+++ b/frontend/src/lib/category-map.ts
@@ -1,30 +1,38 @@
 /**
- * Category slug mapping between Laravel and Prisma/storefront.
+ * Category slug mapping between Laravel and storefront.
  *
- * STOREFRONT-LARAVEL-01 Phase 2-3: The storefront CategoryStrip uses Prisma
- * slugs (e.g. "fruits-vegetables"), but Laravel products carry Laravel
- * slugs (e.g. "fruits"). This mapping bridges the two until categories
- * are fully unified in Laravel.
+ * Phase 10: Backend and frontend now share the same 10 unified slugs.
+ * This map handles any lingering legacy slugs during the transition period.
+ * Once all products are migrated, this can be simplified to a passthrough.
  */
 
-/** Map a Laravel category slug to the corresponding Prisma/storefront slug. */
-const LARAVEL_TO_STOREFRONT: Record<string, string> = {
-  // Original 8 categories
-  'fruits': 'fruits-vegetables',
-  'vegetables': 'fruits-vegetables',
-  'herbs-spices': 'herbs-spices',
-  'grains-cereals': 'grains-rice',
-  'dairy-products': 'dairy',
-  'olive-oil-olives': 'olive-oil-olives',
+/** Map a Laravel category slug to the corresponding storefront slug. */
+const LEGACY_TO_UNIFIED: Record<string, string> = {
+  // Legacy slugs → unified slugs (transition period)
+  'fruits': 'legumes-grains',
+  'vegetables': 'legumes-grains',
+  'herbs-spices': 'herbs-spices-tea',
+  'grains-cereals': 'legumes-grains',
+  'dairy-products': 'nuts-dried',
   'wine-beverages': 'beverages',
   'honey-preserves': 'honey-bee',
-  // Phase 3: New categories added for Greek products
-  'legumes': 'legumes',
+  'legumes': 'legumes-grains',
   'pasta-trahanas': 'pasta',
-  'flours-bakery': 'flours-bakery',
+  'flours-bakery': 'legumes-grains',
   'nuts-dried-fruits': 'nuts-dried',
-  'sweets-preserves': 'sweets-spreads',
-  'sauces-pickles': 'sauces-preserves',
+  'sweets-preserves': 'sweets-jams',
+  'sauces-pickles': 'sauces-spreads',
+  // Unified slugs map to themselves (identity)
+  'olive-oil-olives': 'olive-oil-olives',
+  'honey-bee': 'honey-bee',
+  'nuts-dried': 'nuts-dried',
+  'cosmetics': 'cosmetics',
+  'beverages': 'beverages',
+  'sweets-jams': 'sweets-jams',
+  'pasta': 'pasta',
+  'herbs-spices-tea': 'herbs-spices-tea',
+  'sauces-spreads': 'sauces-spreads',
+  'legumes-grains': 'legumes-grains',
 };
 
 /**
@@ -33,5 +41,5 @@ const LARAVEL_TO_STOREFRONT: Record<string, string> = {
  */
 export function toStorefrontSlug(laravelSlug: string | null | undefined): string | null {
   if (!laravelSlug) return null;
-  return LARAVEL_TO_STOREFRONT[laravelSlug] ?? laravelSlug;
+  return LEGACY_TO_UNIFIED[laravelSlug] ?? laravelSlug;
 }

--- a/frontend/src/styles/brand.css
+++ b/frontend/src/styles/brand.css
@@ -47,16 +47,18 @@
   --danger-light: #fee2e2;
 
   /* -------------------------------------------------------------------------
-     CATEGORY COLORS - Wolt-style pastel backgrounds
+     CATEGORY COLORS - 10 unified categories (pastel backgrounds)
      ------------------------------------------------------------------------- */
-  --category-vegetables: #e8f5ed;
-  --category-fruits: #fef3c7;
-  --category-dairy: #e0f2fe;
-  --category-meat: #fee2e2;
-  --category-bakery: #f5f0e6;
-  --category-honey: #fef9c3;
-  --category-wine: #fce7f3;
   --category-olive: #ecfccb;
+  --category-honey: #fef9c3;
+  --category-nuts: #fef3c7;
+  --category-cosmetics: #e0f2fe;
+  --category-beverages: #fce7f3;
+  --category-sweets: #fde2e4;
+  --category-pasta: #f5f0e6;
+  --category-herbs: #e8f5ed;
+  --category-sauces: #fee2e2;
+  --category-legumes: #efebe9;
 
   /* -------------------------------------------------------------------------
      TYPOGRAPHY


### PR DESCRIPTION
## Summary
- Rewrites `categories.ts` with 10 definitive category entries
- Cleans up `CategoryStrip.tsx`: removes label override hacks, partial slug matching → exact lookups
- Updates `category-map.ts` with legacy-to-unified bridge for transition period
- Updates `demoProducts.ts` with all new slugs
- Updates CSS color tokens: 10 semantic names (`category-nuts`, `category-beverages`, etc.)
- Updates `card.tsx` CategoryCard type with new color options

## 10 Unified Category Slugs
`olive-oil-olives`, `honey-bee`, `nuts-dried`, `cosmetics`, `beverages`, `sweets-jams`, `pasta`, `herbs-spices-tea`, `sauces-spreads`, `legumes-grains`

## Files changed (7)
- `frontend/src/data/categories.ts` — 10 entries (was 9)
- `frontend/src/components/CategoryStrip.tsx` — simplified maps, exact lookups
- `frontend/src/lib/category-map.ts` — legacy bridge
- `frontend/src/data/demoProducts.ts` — updated slugs
- `frontend/src/app/globals.css` — 10 @theme color tokens
- `frontend/src/styles/brand.css` — 10 CSS variables
- `frontend/src/components/ui/card.tsx` — updated CategoryCard types

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — clean build
- [ ] Visual: dixis.gr/products — 10 category cards + "Όλα"
- [ ] Click each category → filter works
- [ ] Mobile 375px — horizontal scroll
- [ ] Depends on PR #3052 (backend migration) being deployed first