### PR TITLE
fix: avoid unique name collision in category migration

### DIFF
--- a/backend/database/migrations/2026_02_19_100000_unify_categories_to_10.php
+++ b/backend/database/migrations/2026_02_19_100000_unify_categories_to_10.php
@@ -70,8 +70,19 @@ return new class extends Migration
 
     public function up(): void
     {
-        // Step 1: Create all 10 target categories (if they don't exist)
         $now = now();
+
+        // Step 0: Temporarily rename old categories that will be merged/deleted
+        // to avoid unique name collisions (e.g. nuts-dried-fruits already has
+        // name "Ξηροί Καρποί" which collides with new nuts-dried target).
+        $allOldSlugs = array_merge(array_keys(self::SLUG_MAP), self::DELETE_SLUGS);
+        foreach ($allOldSlugs as $oldSlug) {
+            DB::table('categories')
+                ->where('slug', $oldSlug)
+                ->update(['name' => DB::raw("name || ' [migrating]'"), 'updated_at' => $now]);
+        }
+
+        // Step 1: Create all 10 target categories (if they don't exist)
         foreach (self::TARGET_CATEGORIES as $slug => $name) {
             $exists = DB::table('categories')->where('slug', $slug)->exists();
             if (! $exists) {


### PR DESCRIPTION
## Summary
- Adds Step 0 to the category unification migration that temporarily renames old categories by appending ` [migrating]` to their names
- Prevents `duplicate key value violates unique constraint "categories_name_unique"` error when creating new target categories (e.g. `nuts-dried-fruits` has name "Ξηροί Καρποί" which collides with new `nuts-dried` category)

## Test plan
- [ ] `php artisan migrate --force` runs without error on production
- [ ] 10 definitive categories exist after migration
- [ ] No orphaned `[migrating]` names remain (old categories get deleted in Step 4)