### PR TITLE
fix: sync product image_url with primary ProductImage

### DIFF
--- a/backend/database/migrations/2026_02_19_200000_sync_product_image_urls.php
+++ b/backend/database/migrations/2026_02_19_200000_sync_product_image_urls.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Sync products.image_url with the primary image from product_images.
+ *
+ * Fixes a bug where 7/17 products had a stale image_url (from before
+ * the Greek re-seeding) that didn't match their product_images[0].url.
+ * This caused different photos on product cards vs detail pages.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // For each product that has at least one ProductImage,
+        // set image_url to the primary image (is_primary DESC, sort_order ASC).
+        DB::statement("
+            UPDATE products
+            SET image_url = sub.url,
+                updated_at = NOW()
+            FROM (
+                SELECT DISTINCT ON (product_id) product_id, url
+                FROM product_images
+                ORDER BY product_id, is_primary DESC, sort_order ASC
+            ) AS sub
+            WHERE products.id = sub.product_id
+        ");
+    }
+
+    public function down(): void
+    {
+        // Not reversible — old stale image_url values are lost.
+    }
+};

--- a/backend/database/seeders/GreekProductSeeder.php
+++ b/backend/database/seeders/GreekProductSeeder.php
@@ -225,6 +225,7 @@ class GreekProductSeeder extends Seeder
         foreach ($products as $item) {
             $productData = array_merge($item['data'], [
                 'producer_id' => $item['producer']->id,
+                'image_url' => $item['image'],
             ]);
 
             $product = Product::firstOrCreate(


### PR DESCRIPTION
## Summary
- **Bug**: 7/17 products showed different photo on product card vs detail page
- **Cause**: `products.image_url` (used by cards) didn't match `product_images[0].url` (used by detail page) — stale data from before Greek re-seeding
- **Fix**: Migration syncs `image_url` from `product_images` primary image for all products
- **Prevention**: Seeder now includes `image_url` when creating products

## Test plan
- [ ] `php artisan migrate --force` on production — syncs all 7 mismatched products
- [ ] API check: `image_url` matches `images[0].url` for all 17 products
- [ ] Visual: click any product on dixis.gr/products → same image on card and detail page