### PR TITLE
feat: seed reviews + rating filter

### DIFF
--- a/backend/app/Http/Controllers/Public/ProductController.php
+++ b/backend/app/Http/Controllers/Public/ProductController.php
@@ -104,6 +104,11 @@ class ProductController extends Controller
             }
         }
 
+        // Minimum rating filter (uses HAVING because reviews_avg_rating is an aggregate)
+        if ($minRating = $request->get('min_rating')) {
+            $query->having('reviews_avg_rating', '>=', (float) $minRating);
+        }
+
         // Sorting
         // When FTS is active and no explicit sort requested, order by search_rank DESC
         $sortField = $request->get('sort', $usesFts ? 'relevance' : 'created_at');

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -71,6 +71,7 @@ class DatabaseSeeder extends Seeder
             OrderSeeder::class, // New structured order seeder
             FeeDefaultsSeeder::class, // FINANCE-02: Global fee defaults
             FeeRulesSeeder::class, // FINANCE-04: DB-driven fee rules
+            ReviewSeeder::class, // Seed realistic Greek reviews
         ]);
 
         // E2E deterministic data for testing and local environments

--- a/backend/database/seeders/ReviewSeeder.php
+++ b/backend/database/seeders/ReviewSeeder.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Product;
+use App\Models\Review;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class ReviewSeeder extends Seeder
+{
+    /**
+     * Seed realistic Greek reviews for all products.
+     *
+     * - 2-4 reviews per product, ratings 3-5 (artisan quality!)
+     * - Greek titles & comments
+     * - is_approved=true for public display
+     * - firstOrCreate on [user_id, product_id] for idempotency
+     */
+    public function run(): void
+    {
+        // Collect reviewer users (consumer + demo customers)
+        $reviewerEmails = [
+            'consumer@example.com',
+            'customer1@demo.com',
+            'customer2@demo.com',
+            'customer3@demo.com',
+            'customer4@demo.com',
+            'customer5@demo.com',
+        ];
+
+        $reviewers = User::whereIn('email', $reviewerEmails)->get();
+
+        if ($reviewers->isEmpty()) {
+            $this->command->warn('No reviewer users found — skipping ReviewSeeder.');
+            return;
+        }
+
+        $products = Product::all();
+
+        if ($products->isEmpty()) {
+            $this->command->warn('No products found — skipping ReviewSeeder.');
+            return;
+        }
+
+        $greekReviews = $this->getGreekReviews();
+        $seeded = 0;
+
+        foreach ($products as $product) {
+            // 2-4 reviews per product
+            $numReviews = rand(2, 4);
+            $shuffledReviewers = $reviewers->shuffle();
+
+            for ($i = 0; $i < $numReviews && $i < $shuffledReviewers->count(); $i++) {
+                $user = $shuffledReviewers[$i];
+                $review = $greekReviews[array_rand($greekReviews)];
+
+                Review::firstOrCreate(
+                    [
+                        'user_id' => $user->id,
+                        'product_id' => $product->id,
+                    ],
+                    [
+                        'rating' => $review['rating'],
+                        'title' => $review['title'],
+                        'comment' => $review['comment'],
+                        'is_verified_purchase' => (bool) rand(0, 1),
+                        'is_approved' => true,
+                        'created_at' => now()->subDays(rand(1, 90)),
+                    ]
+                );
+                $seeded++;
+            }
+        }
+
+        $this->command->info("ReviewSeeder: {$seeded} reviews seeded across {$products->count()} products.");
+    }
+
+    /**
+     * Pool of realistic Greek reviews with ratings 3-5.
+     */
+    private function getGreekReviews(): array
+    {
+        return [
+            ['rating' => 5, 'title' => 'Εξαιρετικό!', 'comment' => 'Απίστευτη ποιότητα, θα παραγγείλω ξανά σίγουρα!'],
+            ['rating' => 5, 'title' => 'Το καλύτερο που δοκίμασα', 'comment' => 'Φρέσκο, αρωματικό, ακριβώς όπως το περίμενα.'],
+            ['rating' => 5, 'title' => 'Φανταστικό', 'comment' => 'Η γεύση είναι μοναδική. Προτείνω ανεπιφύλακτα.'],
+            ['rating' => 5, 'title' => 'Αυθεντικό ελληνικό', 'comment' => 'Σαν να το αγόρασα από χωριό! Τέλεια ποιότητα.'],
+            ['rating' => 4, 'title' => 'Πολύ καλό', 'comment' => 'Πολύ καλή ποιότητα, γρήγορη αποστολή.'],
+            ['rating' => 4, 'title' => 'Ευχαριστημένος/η', 'comment' => 'Ωραία γεύση, καλή τιμή. Θα ξαναπαραγγείλω.'],
+            ['rating' => 4, 'title' => 'Καλή επιλογή', 'comment' => 'Σωστή σχέση ποιότητας-τιμής. Συνιστώ!'],
+            ['rating' => 4, 'title' => 'Νόστιμο!', 'comment' => 'Πολύ νόστιμο προϊόν, η συσκευασία ήταν άψογη.'],
+            ['rating' => 4, 'title' => 'Ικανοποιητικό', 'comment' => 'Καλό προϊόν, ίσως λίγο ακριβό αλλά αξίζει.'],
+            ['rating' => 3, 'title' => 'Αρκετά καλό', 'comment' => 'Καλή ποιότητα αλλά αναμένω λίγο πιο έντονη γεύση.'],
+            ['rating' => 3, 'title' => 'Μέτριο', 'comment' => 'Εντάξει για την τιμή του, τίποτα το ιδιαίτερο.'],
+            ['rating' => 5, 'title' => 'Δεν αλλάζω!', 'comment' => 'Τρίτη παραγγελία μου. Δεν αλλάζω παραγωγό!'],
+            ['rating' => 5, 'title' => 'Συγκλονιστικό άρωμα', 'comment' => 'Μόλις το άνοιξα κατάλαβα την ποιότητα. Μπράβο!'],
+            ['rating' => 4, 'title' => 'Γρήγορη παράδοση', 'comment' => 'Ήρθε σε 2 μέρες, φρέσκο και καλά συσκευασμένο.'],
+            ['rating' => 5, 'title' => 'Δώρο που εντυπωσίασε', 'comment' => 'Το πήρα για δώρο και ενθουσιάστηκαν! Υπέροχο.'],
+        ];
+    }
+}

--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import { ProductCard } from '@/components/ProductCard';
 import { CategoryStrip } from '@/components/CategoryStrip';
 import { CultivationFilter } from '@/components/CultivationFilter';
+import { RatingFilter } from '@/components/RatingFilter';
 import { ProductSearchInput } from '@/components/ProductSearchInput';
 import { ProductSort } from '@/components/ProductSort';
 import { DEMO_PRODUCTS } from '@/data/demoProducts';
@@ -45,7 +46,8 @@ async function getData(
   category?: string,
   cultivationType?: string,
   sort?: string,
-  dir?: string
+  dir?: string,
+  minRating?: string
 ): Promise<{ items: ApiItem[]; total: number; isDemo: boolean; apiTotal: number }> {
   // Pass CI-SMOKE-STABILIZE-002: In CI mode, use internal Next.js API
   // which reads from Prisma DB (seeded with ci:seed) — same pattern as products/[id]/page.tsx
@@ -78,6 +80,9 @@ async function getData(
     }
     if (dir) {
       params.set('dir', dir);
+    }
+    if (minRating) {
+      params.set('min_rating', minRating);
     }
 
     const res = await fetch(`${base}/public/products?${params.toString()}`, {
@@ -218,7 +223,7 @@ const cultivationLabels: Record<string, string> = {
 export async function generateMetadata({
   searchParams,
 }: {
-  searchParams: Promise<{ cat?: string; search?: string; cult?: string; sort?: string; dir?: string }>;
+  searchParams: Promise<{ cat?: string; search?: string; cult?: string; sort?: string; dir?: string; min_rating?: string }>;
 }): Promise<Metadata> {
   const params = await searchParams;
   const parts: string[] = [];
@@ -231,7 +236,7 @@ export async function generateMetadata({
 }
 
 interface PageProps {
-  searchParams: Promise<{ cat?: string; search?: string; cult?: string; sort?: string; dir?: string }>;
+  searchParams: Promise<{ cat?: string; search?: string; cult?: string; sort?: string; dir?: string; min_rating?: string }>;
 }
 
 export default async function Page({ searchParams }: PageProps) {
@@ -239,16 +244,18 @@ export default async function Page({ searchParams }: PageProps) {
   const categoryFilter = params.cat || null;
   const searchQuery = params.search || null;
   const cultivationFilter = params.cult || null;
+  const ratingFilter = params.min_rating || null;
   const sortField = params.sort || undefined;
   const sortDir = params.dir || undefined;
 
-  // Fetch products (server-side filtering for category + search + cultivation + sort)
+  // Fetch products (server-side filtering for category + search + cultivation + rating + sort)
   const { items, isDemo, apiTotal } = await getData(
     searchQuery || undefined,
     categoryFilter || undefined,
     cultivationFilter || undefined,
     sortField,
-    sortDir
+    sortDir,
+    ratingFilter || undefined
   );
   const total = items.length;
 
@@ -356,6 +363,11 @@ export default async function Page({ searchParams }: PageProps) {
               />
             </Suspense>
           )}
+
+          {/* Rating filter */}
+          <Suspense fallback={null}>
+            <RatingFilter selectedRating={ratingFilter} />
+          </Suspense>
         </div>
 
         {items.length > 0 ? (

--- a/frontend/src/components/RatingFilter.tsx
+++ b/frontend/src/components/RatingFilter.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+interface RatingOption {
+  value: string;
+  label: string;
+}
+
+const RATING_OPTIONS: RatingOption[] = [
+  { value: '4.5', label: '4.5+' },
+  { value: '4', label: '4+' },
+  { value: '3', label: '3+' },
+];
+
+interface RatingFilterProps {
+  selectedRating?: string | null;
+}
+
+export function RatingFilter({ selectedRating }: RatingFilterProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const current = selectedRating ?? searchParams.get('min_rating');
+
+  const handleClick = (value: string | null) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set('min_rating', value);
+    } else {
+      params.delete('min_rating');
+    }
+    router.push(`/products?${params.toString()}`);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-sm font-medium text-neutral-600 mr-1">Βαθμολογία:</span>
+      {RATING_OPTIONS.map((opt) => {
+        const isSelected = current === opt.value;
+        return (
+          <button
+            key={opt.value}
+            onClick={() => handleClick(isSelected ? null : opt.value)}
+            aria-pressed={isSelected}
+            aria-label={`Ελάχιστη βαθμολογία ${opt.label}`}
+            className={`
+              flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium
+              transition-all duration-200 border
+              ${
+                isSelected
+                  ? 'bg-amber-500 text-white shadow-md border-amber-500'
+                  : 'bg-amber-50 text-amber-800 border-amber-200 hover:border-amber-400 hover:shadow-sm'
+              }
+            `}
+          >
+            <svg className={`w-3.5 h-3.5 ${isSelected ? 'text-white' : 'text-amber-400'}`} fill="currentColor" viewBox="0 0 20 20">
+              <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+            </svg>
+            <span>{opt.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **ReviewSeeder**: Seeds 2-4 realistic Greek reviews per product (ratings 3-5, is_approved=true, idempotent via firstOrCreate)
- **Backend min_rating filter**: `having('reviews_avg_rating', '>=', ...)` in ProductController
- **RatingFilter component**: Amber star pills (3+, 4+, 4.5+) matching design system
- **Products page wiring**: URL param `?min_rating=` sent server-side to backend

## Test plan
- [ ] Run `php artisan db:seed --class=ReviewSeeder` on production
- [ ] Verify stars appear on product cards at /products
- [ ] Test `/products?min_rating=4` filters correctly
- [ ] Verify rating filter pills work on mobile (wrap correctly)
- [ ] `npm run build` passes clean