### PR TITLE
fix: min_rating filter SQL for PostgreSQL

### DIFF
--- a/backend/app/Http/Controllers/Public/ProductController.php
+++ b/backend/app/Http/Controllers/Public/ProductController.php
@@ -104,9 +104,12 @@ class ProductController extends Controller
             }
         }
 
-        // Minimum rating filter (uses HAVING because reviews_avg_rating is an aggregate)
+        // Minimum rating filter (subquery approach — PostgreSQL doesn't allow HAVING on aliases)
         if ($minRating = $request->get('min_rating')) {
-            $query->having('reviews_avg_rating', '>=', (float) $minRating);
+            $query->whereRaw(
+                '(select avg(r.rating) from reviews r where r.product_id = products.id and r.is_approved = true) >= ?',
+                [(float) $minRating]
+            );
         }
 
         // Sorting


### PR DESCRIPTION
## Summary
- Fix 500 error on `?min_rating=` filter — PostgreSQL doesn't allow `HAVING` on `withAvg` aliases
- Use correlated subquery in `WHERE` instead

## Test plan
- [ ] `curl /api/v1/public/products?min_rating=4` returns filtered results
- [ ] `curl /api/v1/public/products` still works (no regression)