### PR TITLE
style: compact 2-row filter card with unified pill row

### DIFF
--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -332,36 +332,39 @@ export default async function Page({ searchParams }: PageProps) {
           </Suspense>
         </div>
 
-        {/* Filter Card — search + sort + cultivation */}
-        <div className="bg-accent-cream/60 rounded-xl border border-accent-gold/15 shadow-card p-4 mb-5 space-y-3">
-          {/* Search + Sort */}
-          <div className="flex flex-col sm:flex-row gap-3">
+        {/* Filter area — compact 2-row layout */}
+        <div className="rounded-lg border border-accent-gold/10 bg-white/40 py-2 px-3 mb-4 space-y-2">
+          {/* Row 1: Search + Sort */}
+          <div className="flex flex-col sm:flex-row gap-2.5">
             <div className="flex-1">
               <Suspense fallback={<div className="h-10 w-full bg-accent-beige/50 rounded-lg animate-pulse" />}>
                 <ProductSearchInput />
               </Suspense>
             </div>
-            <div className="sm:w-52">
+            <div className="sm:w-48">
               <Suspense fallback={<div className="h-10 w-full bg-accent-beige/50 rounded-lg animate-pulse" />}>
                 <ProductSort />
               </Suspense>
             </div>
           </div>
 
-          {/* Cultivation (conditional) */}
-          {hasCultivationData && (
+          {/* Row 2: All pills in one unified row */}
+          <div className="flex flex-wrap items-center gap-2">
+            {hasCultivationData && (
+              <Suspense fallback={null}>
+                <CultivationFilter
+                  selectedCultivation={cultivationFilter}
+                  availableCounts={cultivationCounts}
+                />
+              </Suspense>
+            )}
+            {hasCultivationData && (
+              <div className="hidden lg:block w-px h-5 bg-neutral-300/50 mx-0.5" aria-hidden="true" />
+            )}
             <Suspense fallback={null}>
-              <CultivationFilter
-                selectedCultivation={cultivationFilter}
-                availableCounts={cultivationCounts}
-              />
+              <RatingFilter selectedRating={ratingFilter} />
             </Suspense>
-          )}
-
-          {/* Rating filter */}
-          <Suspense fallback={null}>
-            <RatingFilter selectedRating={ratingFilter} />
-          </Suspense>
+          </div>
         </div>
 
         {items.length > 0 ? (

--- a/frontend/src/components/CultivationFilter.tsx
+++ b/frontend/src/components/CultivationFilter.tsx
@@ -61,9 +61,8 @@ export function CultivationFilter({
   };
 
   return (
-    <div className="w-full">
-      <div className="flex flex-wrap gap-2.5">
-        {/* "All" option */}
+    <>
+      {/* "All" option */}
         <button
           onClick={() => handleClick(null)}
           aria-pressed={!current}
@@ -116,7 +115,6 @@ export function CultivationFilter({
             </button>
           );
         })}
-      </div>
-    </div>
+    </>
   );
 }

--- a/frontend/src/components/RatingFilter.tsx
+++ b/frontend/src/components/RatingFilter.tsx
@@ -33,7 +33,7 @@ export function RatingFilter({ selectedRating }: RatingFilterProps) {
   };
 
   return (
-    <div className="flex flex-wrap gap-2.5">
+    <>
       {RATING_OPTIONS.map((opt) => {
         const isSelected = current === opt.value;
         return (
@@ -57,6 +57,6 @@ export function RatingFilter({ selectedRating }: RatingFilterProps) {
           </button>
         );
       })}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Restructure filter area: 3 stacked rows → 2 compact rows (~200px → ~100px, -50%)
- Row 1: search + sort, Row 2: all cultivation + rating pills in one unified flex row
- CultivationFilter & RatingFilter return Fragments (pills become shared flex children)
- Subtle vertical divider between cultivation/rating groups on lg+ screens
- Lighter card styling: bg-white/40, no shadow, tighter padding

## Test plan
- [ ] Desktop: filter card is 2 rows, all pills visible in one line
- [ ] Mobile: pills wrap naturally across lines
- [ ] Click cultivation pill → filters products correctly
- [ ] Click rating pill → URL updates with min_rating, filters correctly
- [ ] Divider visible on lg+ only, hidden on mobile