### PR TITLE
refactor: remove rating pills, add sort-by-rating, compact header

### DIFF
--- a/backend/app/Http/Controllers/Public/ProductController.php
+++ b/backend/app/Http/Controllers/Public/ProductController.php
@@ -121,6 +121,13 @@ class ProductController extends Controller
         if ($usesFts && $sortField === 'relevance') {
             // FTS ranking: best matches first
             $query->orderByRaw('search_rank DESC');
+        } elseif ($sortField === 'rating') {
+            // Sort by average review rating (NULLs last)
+            $dir = $sortDir === 'asc' ? 'ASC' : 'DESC';
+            $nullsPos = $sortDir === 'asc' ? 'FIRST' : 'LAST';
+            $query->orderByRaw(
+                "(SELECT AVG(r.rating) FROM reviews r WHERE r.product_id = products.id AND r.is_approved = true) {$dir} NULLS {$nullsPos}"
+            );
         } elseif (in_array($sortField, $allowedSorts)) {
             $query->orderBy($sortField, $sortDir === 'asc' ? 'asc' : 'desc');
         } else {

--- a/frontend/src/app/(storefront)/products/page.tsx
+++ b/frontend/src/app/(storefront)/products/page.tsx
@@ -3,7 +3,6 @@ import type { Metadata } from 'next';
 import { ProductCard } from '@/components/ProductCard';
 import { CategoryStrip } from '@/components/CategoryStrip';
 import { CultivationFilter } from '@/components/CultivationFilter';
-import { RatingFilter } from '@/components/RatingFilter';
 import { ProductSearchInput } from '@/components/ProductSearchInput';
 import { ProductSort } from '@/components/ProductSort';
 import { DEMO_PRODUCTS } from '@/data/demoProducts';
@@ -46,8 +45,7 @@ async function getData(
   category?: string,
   cultivationType?: string,
   sort?: string,
-  dir?: string,
-  minRating?: string
+  dir?: string
 ): Promise<{ items: ApiItem[]; total: number; isDemo: boolean; apiTotal: number }> {
   // Pass CI-SMOKE-STABILIZE-002: In CI mode, use internal Next.js API
   // which reads from Prisma DB (seeded with ci:seed) — same pattern as products/[id]/page.tsx
@@ -81,10 +79,6 @@ async function getData(
     if (dir) {
       params.set('dir', dir);
     }
-    if (minRating) {
-      params.set('min_rating', minRating);
-    }
-
     const res = await fetch(`${base}/public/products?${params.toString()}`, {
       next: { revalidate: 60 },
       headers: { 'Content-Type': 'application/json' },
@@ -223,7 +217,7 @@ const cultivationLabels: Record<string, string> = {
 export async function generateMetadata({
   searchParams,
 }: {
-  searchParams: Promise<{ cat?: string; search?: string; cult?: string; sort?: string; dir?: string; min_rating?: string }>;
+  searchParams: Promise<{ cat?: string; search?: string; cult?: string; sort?: string; dir?: string }>;
 }): Promise<Metadata> {
   const params = await searchParams;
   const parts: string[] = [];
@@ -236,7 +230,7 @@ export async function generateMetadata({
 }
 
 interface PageProps {
-  searchParams: Promise<{ cat?: string; search?: string; cult?: string; sort?: string; dir?: string; min_rating?: string }>;
+  searchParams: Promise<{ cat?: string; search?: string; cult?: string; sort?: string; dir?: string }>;
 }
 
 export default async function Page({ searchParams }: PageProps) {
@@ -244,7 +238,6 @@ export default async function Page({ searchParams }: PageProps) {
   const categoryFilter = params.cat || null;
   const searchQuery = params.search || null;
   const cultivationFilter = params.cult || null;
-  const ratingFilter = params.min_rating || null;
   const sortField = params.sort || undefined;
   const sortDir = params.dir || undefined;
 
@@ -254,8 +247,7 @@ export default async function Page({ searchParams }: PageProps) {
     categoryFilter || undefined,
     cultivationFilter || undefined,
     sortField,
-    sortDir,
-    ratingFilter || undefined
+    sortDir
   );
 
   // Fetch ALL products (without cult filter) to build cultivation counts for the strip
@@ -300,16 +292,11 @@ export default async function Page({ searchParams }: PageProps) {
           </div>
         )}
 
-        <div className="mb-4">
-          <p className="text-sm font-medium text-accent-gold uppercase tracking-wider mb-2">
-            Αγορά Παραγωγών
-          </p>
-          <h1 className="text-3xl sm:text-4xl font-bold text-neutral-900">
-            {searchQuery
-              ? `Αποτελέσματα για "${searchQuery}"`
-              : 'Αυθεντικά Ελληνικά Προϊόντα'}
-          </h1>
-        </div>
+        <h1 className="text-2xl sm:text-3xl font-bold text-neutral-900 mb-3">
+          {searchQuery
+            ? `Αποτελέσματα για "${searchQuery}"`
+            : 'Αυθεντικά Ελληνικά Προϊόντα'}
+        </h1>
 
         {/* Category Cards (Wolt-style, standalone above filter) */}
         <div className="mb-4">
@@ -348,8 +335,8 @@ export default async function Page({ searchParams }: PageProps) {
             </div>
           </div>
 
-          {/* Row 2: All pills in one unified row */}
-          <div className="flex flex-wrap items-center gap-2">
+          {/* Row 2: Cultivation pills — scroll on mobile, wrap on desktop */}
+          <div className="flex items-center gap-2 overflow-x-auto sm:flex-wrap sm:overflow-visible pb-1 sm:pb-0 scrollbar-hide">
             {hasCultivationData && (
               <Suspense fallback={null}>
                 <CultivationFilter
@@ -358,12 +345,6 @@ export default async function Page({ searchParams }: PageProps) {
                 />
               </Suspense>
             )}
-            {hasCultivationData && (
-              <div className="hidden lg:block w-px h-5 bg-neutral-300/50 mx-0.5" aria-hidden="true" />
-            )}
-            <Suspense fallback={null}>
-              <RatingFilter selectedRating={ratingFilter} />
-            </Suspense>
           </div>
         </div>
 

--- a/frontend/src/components/CultivationFilter.tsx
+++ b/frontend/src/components/CultivationFilter.tsx
@@ -68,7 +68,7 @@ export function CultivationFilter({
           aria-pressed={!current}
           aria-label="Όλοι οι τρόποι καλλιέργειας"
           className={`
-            flex items-center gap-2 px-3.5 py-2 rounded-full text-sm font-medium
+            flex items-center gap-2 px-3.5 py-2 rounded-full text-sm font-medium whitespace-nowrap shrink-0
             transition-all duration-200
             ${
               !current
@@ -92,7 +92,7 @@ export function CultivationFilter({
               aria-pressed={isSelected}
               aria-label={`Καλλιέργεια: ${opt.label}`}
               className={`
-                flex items-center gap-1.5 px-3.5 py-2 rounded-full text-sm font-medium
+                flex items-center gap-1.5 px-3.5 py-2 rounded-full text-sm font-medium whitespace-nowrap shrink-0
                 transition-all duration-200 border
                 ${
                   isSelected

--- a/frontend/src/components/ProductSort.tsx
+++ b/frontend/src/components/ProductSort.tsx
@@ -6,6 +6,7 @@ const SORT_OPTIONS = [
   { value: 'created_at_desc', label: 'Νεότερα' },
   { value: 'price_asc', label: 'Τιμή: Χαμηλότερη' },
   { value: 'price_desc', label: 'Τιμή: Υψηλότερη' },
+  { value: 'rating_desc', label: 'Κορυφαία βαθμολογία' },
   { value: 'name_asc', label: 'Αλφαβητικά' },
 ] as const;
 


### PR DESCRIPTION
## Summary
- Remove rating filter pills from products page — replaced by sort dropdown option
- Add "Κορυφαία βαθμολογία" sort option (backend: AVG subquery with NULLS LAST)
- Mobile: cultivation pills now horizontal scroll instead of wrapping to 2-3 lines
- Remove "Αγορά Παραγωγών" subtitle, compact h1 for more product space

## Files changed (4)
- `backend/app/Http/Controllers/Public/ProductController.php` — add rating sort
- `frontend/src/app/(storefront)/products/page.tsx` — remove rating filter, compact header
- `frontend/src/components/CultivationFilter.tsx` — whitespace-nowrap + shrink-0 for scroll
- `frontend/src/components/ProductSort.tsx` — add rating_desc option

## Test plan
- [ ] Desktop: products page shows h1 without "Αγορά Παραγωγών" label
- [ ] Sort dropdown includes "Κορυφαία βαθμολογία" option
- [ ] Rating pills no longer appear in filter area
- [ ] Mobile: cultivation pills scroll horizontally
- [ ] Sort by rating returns products ordered by avg review rating