### PR TITLE
fix: multi-producer thank-you page + backend security hardening

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/OrderController.php
+++ b/backend/app/Http/Controllers/Api/V1/OrderController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreOrderRequest;
 use App\Http\Resources\CheckoutSessionResource;
 use App\Http\Resources\OrderResource;
+use App\Models\CheckoutSession;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\OrderShippingLine;
@@ -80,14 +81,28 @@ class OrderController extends Controller
      * SECURITY FIX: Public order lookup by UUID token (replaces sequential ID access).
      * Used by thank-you page and email confirmation links.
      * Token is a UUID v4, not guessable — safe for public access.
+     *
+     * Pass CHECKOUT-TOKEN-FIX-01: Also searches checkout_sessions for multi-producer orders.
+     * Returns CheckoutSessionResource (with child orders) if token matches a checkout session,
+     * otherwise returns OrderResource for single-producer orders.
      */
-    public function showByToken(string $token): OrderResource|Response
+    public function showByToken(string $token): OrderResource|CheckoutSessionResource|Response
     {
         // Validate UUID v4 format
         if (!preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i', $token)) {
             abort(400, 'Invalid token format');
         }
 
+        // First: check checkout_sessions (multi-producer orders)
+        $checkoutSession = CheckoutSession::with(['orders.orderItems.producer', 'orders.shippingLines'])
+            ->where('public_token', $token)
+            ->first();
+
+        if ($checkoutSession) {
+            return new CheckoutSessionResource($checkoutSession);
+        }
+
+        // Fallback: check single orders
         $order = Order::with(['orderItems.producer', 'shippingLines'])
             ->where('public_token', $token)
             ->first();

--- a/backend/app/Http/Controllers/Api/V1/StripeWebhookController.php
+++ b/backend/app/Http/Controllers/Api/V1/StripeWebhookController.php
@@ -8,6 +8,7 @@ use App\Models\Order;
 use App\Services\OrderEmailService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -147,6 +148,7 @@ class StripeWebhookController extends Controller
      * Updates CheckoutSession and all child orders, then sends emails.
      *
      * Pass MP-PAYMENT-EMAIL-TRUTH-01: Ensures emails only sent after payment confirmation.
+     * Pass CHECKOUT-TOKEN-FIX-01: Wrapped in DB::transaction to prevent partial paid state.
      */
     private function handleMultiProducerPaymentSuccess(int $checkoutSessionId, $stripeSession): void
     {
@@ -168,22 +170,26 @@ class StripeWebhookController extends Controller
             return;
         }
 
-        // Update CheckoutSession status
-        $checkoutSession->update([
-            'status' => CheckoutSession::STATUS_PAID,
-            'stripe_payment_intent_id' => $stripeSession->payment_intent ?? $stripeSession->id,
-        ]);
+        // Atomic: update session + all child orders in a single transaction
+        DB::transaction(function () use ($checkoutSession, $stripeSession) {
+            // Update CheckoutSession status
+            $checkoutSession->update([
+                'status' => CheckoutSession::STATUS_PAID,
+                'stripe_payment_intent_id' => $stripeSession->payment_intent ?? $stripeSession->id,
+            ]);
 
-        // Update all child orders to paid
-        $orders = $checkoutSession->orders;
-        foreach ($orders as $order) {
-            if ($order->payment_status !== 'paid') {
-                $order->update([
-                    'payment_status' => 'paid',
-                    'payment_reference' => $stripeSession->id,
-                ]);
+            // Update all child orders to paid
+            foreach ($checkoutSession->orders as $order) {
+                if ($order->payment_status !== 'paid') {
+                    $order->update([
+                        'payment_status' => 'paid',
+                        'payment_reference' => $stripeSession->id,
+                    ]);
+                }
             }
-        }
+        });
+
+        $orders = $checkoutSession->orders;
 
         Log::info('Stripe webhook: Multi-producer checkout marked as paid', [
             'checkout_session_id' => $checkoutSessionId,
@@ -192,7 +198,7 @@ class StripeWebhookController extends Controller
             'amount_total' => $stripeSession->amount_total,
         ]);
 
-        // Send emails for all orders
+        // Send emails for all orders (outside transaction — email failure shouldn't roll back payment)
         $this->sendPaymentConfirmationEmails($orders->all());
     }
 

--- a/backend/app/Http/Controllers/OpsDbController.php
+++ b/backend/app/Http/Controllers/OpsDbController.php
@@ -9,11 +9,11 @@ class OpsDbController extends Controller
 {
     public function slow(Request $request): JsonResponse
     {
-        // Απλή προστασία: απαιτείται X-Ops-Key να ταιριάζει με OPS_KEY
+        // Pass CHECKOUT-TOKEN-FIX-01: Timing-safe token comparison
         if (app()->environment('production')) {
-            $hdr = $request->header('X-Ops-Key');
-            $key = config('ops.key');
-            if (!$key || $hdr !== $key) {
+            $hdr = (string) $request->header('X-Ops-Key', '');
+            $key = (string) config('ops.key', '');
+            if (empty($key) || !hash_equals($key, $hdr)) {
                 abort(403, 'Forbidden');
             }
         }

--- a/backend/app/Http/Resources/CheckoutSessionResource.php
+++ b/backend/app/Http/Resources/CheckoutSessionResource.php
@@ -21,6 +21,8 @@ class CheckoutSessionResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            // Pass CHECKOUT-TOKEN-FIX-01: UUID token for safe public access
+            'public_token' => $this->public_token,
             'type' => 'checkout_session',
             'status' => $this->status,
             'is_multi_producer' => $this->order_count > 1,

--- a/backend/app/Models/CheckoutSession.php
+++ b/backend/app/Models/CheckoutSession.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 
 /**
  * Pass MP-ORDERS-SCHEMA-01: CheckoutSession Model
@@ -14,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * to a single Stripe PaymentIntent.
  *
  * @property int $id
+ * @property string|null $public_token
  * @property int|null $user_id
  * @property string|null $stripe_payment_intent_id
  * @property string $subtotal
@@ -37,6 +39,7 @@ class CheckoutSession extends Model
     public const STATUS_CANCELLED = 'cancelled';
 
     protected $fillable = [
+        'public_token',
         'user_id',
         'stripe_payment_intent_id',
         'subtotal',
@@ -46,6 +49,21 @@ class CheckoutSession extends Model
         'currency',
         'order_count',
     ];
+
+    /**
+     * Pass CHECKOUT-TOKEN-FIX-01: Auto-generate UUID public_token on creation.
+     * Same pattern as Order model — safe for public access (not guessable).
+     */
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (self $session) {
+            if (empty($session->public_token)) {
+                $session->public_token = (string) Str::uuid();
+            }
+        });
+    }
 
     protected $casts = [
         'subtotal' => 'decimal:2',

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -27,10 +27,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // Pass COMM-ENGINE-TOGGLE-01: Commission engine controlled via env var
+        // Pass CHECKOUT-TOKEN-FIX-01: Use config() instead of env() to survive config:cache
         // Defaults to false — set COMMISSION_ENGINE_ENABLED=true in .env to activate
-        // Can also be toggled at runtime via admin settings (Pennant activate/deactivate)
-        Feature::define('commission_engine_v1', fn() => (bool) env('COMMISSION_ENGINE_ENABLED', false));
+        Feature::define('commission_engine_v1', fn() => (bool) config('payments.commission_engine_enabled', false));
 
         $this->configureRateLimiting();
     }

--- a/backend/config/payments.php
+++ b/backend/config/payments.php
@@ -47,4 +47,26 @@ return [
     |
     */
     'cod_enabled' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Commission Engine
+    |--------------------------------------------------------------------------
+    |
+    | Pass CHECKOUT-TOKEN-FIX-01: Moved from env() to config().
+    | Controls Laravel Pennant feature flag 'commission_engine_v1'.
+    | Default false — no commission deducted from producer payouts.
+    |
+    */
+    'commission_engine_enabled' => env('COMMISSION_ENGINE_ENABLED', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Ops Token (Internal admin endpoints)
+    |--------------------------------------------------------------------------
+    |
+    | Token for /ops/* endpoints. Compared with hash_equals() for timing safety.
+    |
+    */
+    'ops_token' => env('OPS_TOKEN', ''),
 ];

--- a/backend/database/migrations/2026_02_21_100000_add_public_token_to_checkout_sessions.php
+++ b/backend/database/migrations/2026_02_21_100000_add_public_token_to_checkout_sessions.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+/**
+ * Pass CHECKOUT-TOKEN-FIX-01: Add public_token to checkout_sessions
+ *
+ * CheckoutSession needs a UUID public_token for safe public access,
+ * same as orders table. Without this, the thank-you page breaks for
+ * multi-producer orders because it redirects with an integer ID
+ * but the showByToken endpoint expects a UUID.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('checkout_sessions', function (Blueprint $table) {
+            $table->uuid('public_token')->nullable()->unique()->after('id');
+        });
+
+        // Backfill existing rows with UUIDs
+        $sessions = \App\Models\CheckoutSession::whereNull('public_token')->get();
+        foreach ($sessions as $session) {
+            $session->update(['public_token' => (string) Str::uuid()]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('checkout_sessions', function (Blueprint $table) {
+            $table->dropColumn('public_token');
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -217,15 +217,10 @@ Route::prefix('v1')->group(function () {
             ->middleware('throttle:10,1');
     });
 
-    // Authenticated user orders
-    Route::middleware('auth:sanctum')->group(function () {
-        Route::get('orders', [App\Http\Controllers\Api\OrderController::class, 'index'])->name('api.v1.orders.index');
-        Route::get('orders/{order}', [App\Http\Controllers\Api\OrderController::class, 'show'])->name('api.v1.orders.show');
-        Route::post('orders', [App\Http\Controllers\Api\OrderController::class, 'store'])->name('api.v1.orders.store')
-            ->middleware('throttle:10,1'); // 10 requests per minute for order creation
-        Route::post('orders/checkout', [App\Http\Controllers\Api\OrderController::class, 'checkout'])->name('api.v1.orders.checkout')
-            ->middleware('throttle:5,1'); // 5 checkouts per minute
-    });
+    // DEPRECATED: Legacy OrderController routes removed (Pass CHECKOUT-TOKEN-FIX-01)
+    // These used flat 10% tax, no multi-producer support, no stock locking.
+    // All order creation now goes through V1\OrderController at POST /public/orders.
+    // User order listing migrated to V1\OrderController::index (line above).
 
     // Producers (public, read-only) — T4: rate-limited
     Route::get('producers', [App\Http\Controllers\Api\V1\ProducerController::class, 'index'])->name('api.v1.producers.index')
@@ -1100,9 +1095,11 @@ Route::middleware('auth:sanctum')->prefix('v1/producer')->group(function () {
 });
 
 // === OPS: Commission preview (simple JSON) ===
-Route::get('/ops/commission/preview', function (Illuminate\Http\Request $request) {
-    // Simple token auth
-    if ($request->header('x-ops-token') !== env('OPS_TOKEN')) {
+// Pass CHECKOUT-TOKEN-FIX-01: Added throttle + hash_equals for timing-safe token comparison
+Route::middleware('throttle:10,1')->get('/ops/commission/preview', function (Illuminate\Http\Request $request) {
+    // Timing-safe token auth (prevents timing side-channel attacks)
+    $opsToken = (string) config('payments.ops_token', '');
+    if (empty($opsToken) || !hash_equals($opsToken, (string) $request->header('x-ops-token', ''))) {
         abort(404);
     }
 
@@ -1170,7 +1167,9 @@ Route::get('/orders/{order}/commission-preview', [OrderCommissionPreviewControll
     ->middleware('auth:sanctum');
 
 // Ops: DB slow queries endpoint (guarded by X-Ops-Key in production)
+// Pass CHECKOUT-TOKEN-FIX-01: Added throttle to prevent abuse
 Route::get('/ops/db/slow-queries', [OpsDbController::class, 'slow'])
+    ->middleware('throttle:10,1')
     ->name('ops.db.slow');
 
 // Internal: AdminUser lookup for OTP email delivery (Next.js → Laravel)

--- a/docs/AGENT/BACKEND-AUDIT-2026-02-21.md
+++ b/docs/AGENT/BACKEND-AUDIT-2026-02-21.md
@@ -1,0 +1,84 @@
+# Backend Architecture Audit — 2026-02-21
+
+**Trigger**: Test order with 3 producers hit 500 (missing `features` table) + broken thank-you page.
+**Scope**: Laravel 11 backend — models, controllers, routes, services, migrations.
+
+---
+
+## Critical Findings (Fix Now)
+
+### BUG-01: Thank-you page broken for multi-producer orders
+- **Symptom**: POST `/api/v1/public/orders` returns 201 with `CheckoutSessionResource.id = 7` (integer).
+  Frontend redirects to `/thank-you?token=7`. GET `/public/orders/by-token/7` returns 400 because
+  `showByToken()` expects UUID `public_token`, not integer ID.
+- **Root cause**: `CheckoutSession` model has no `public_token` column. `CheckoutSessionResource` returns
+  integer `id`. Frontend `useCheckout.ts` uses `order.public_token || order.id` — falls back to integer.
+- **Fix**:
+  1. Add migration: `public_token` UUID column on `checkout_sessions`
+  2. Add `boot()` with auto-UUID generation in `CheckoutSession` model
+  3. Add `public_token` to `CheckoutSessionResource`
+  4. Add new route `GET /public/checkout-sessions/by-token/{token}` or update `showByToken` to check both tables
+  5. Frontend: read `public_token` from response, update thank-you page to handle both order and checkout session
+
+### BUG-02: Commission engine ON with zero rules
+- **Symptom**: Feature flag `commission_engine_v1` queries `features` table (Pennant). Table was missing
+  until manually migrated. Even with table present, **zero CommissionRules** exist in DB. Engine returns
+  0 commission for all orders — silent data loss if rules were expected.
+- **Root cause**: Pennant migration never ran. Commission engine code is deployed but not configured.
+- **Fix**: Set `COMMISSION_ENGINE_ENABLED=false` in production `.env` until rules are configured.
+  The Pennant feature check in `CommissionService` will then short-circuit immediately.
+
+### BUG-03: Legacy OrderController still active
+- **Routes**: Lines 222-226 in `routes/api.php` mount `Api\OrderController` (legacy):
+  - `GET orders` — uses flat 10% tax, no multi-producer
+  - `POST orders` — bypasses CheckoutService, no stock locking, no shipping validation
+  - `POST orders/checkout` — creates from cart items with hardcoded tax
+- **Risk**: Any authenticated user can hit legacy routes and create orders with wrong pricing.
+- **Fix**: Comment out or remove legacy routes. Add deprecation notice.
+
+### BUG-04: Stripe webhook lacks DB::transaction
+- **File**: `StripeWebhookController::handleMultiProducerPaymentSuccess()`
+- **Risk**: Updates CheckoutSession status, then iterates child orders. If crash after session update
+  but before all child orders updated → partial paid state.
+- **Fix**: Wrap in `DB::transaction()`.
+
+---
+
+## Important Findings (Fix Soon)
+
+### IMP-01: `env()` used at runtime instead of `config()`
+- **File**: `AppServiceProvider.php` line 34: `env('COMMISSION_ENGINE_ENABLED', false)`
+- **File**: `routes/api.php` line 1105: `env('OPS_TOKEN')`
+- **Problem**: `env()` returns `null` when config is cached (`php artisan config:cache`).
+- **Fix**: Add to `config/app.php` or `config/payments.php`, reference via `config()`.
+
+### IMP-02: Ops routes without rate limiting or constant-time auth
+- **Routes**: `/ops/commission/preview`, `/ops/db/slow-queries`
+- **Problem**: Token comparison via `!==` (timing-side-channel). No rate limiting.
+- **Fix**: Use `hash_equals()`, add throttle middleware.
+
+### IMP-03: 1,200-line routes file
+- **Not blocking**: But increasingly hard to maintain. Consider splitting into route files
+  (`routes/api/admin.php`, `routes/api/producer.php`, etc.).
+
+---
+
+## Good Architecture (No Changes Needed)
+
+- Clean V1 controller hierarchy with proper service delegation
+- `CheckoutService` handles multi-producer split with DB::transaction + stock locking
+- Orders have UUID `public_token` for safe public access (auto-generated in boot)
+- Proper Sanctum auth with admin/producer role guards
+- Comprehensive logging throughout the payment flow
+- Idempotent webhook handling (checks `payment_status` before updating)
+
+---
+
+## Fix Priority Order
+
+1. **BUG-01** — Thank-you page (user-facing, blocks all multi-producer orders)
+2. **BUG-02** — Disable commission engine (safety: prevent silent 0% commission)
+3. **BUG-03** — Remove legacy routes (security: prevent wrong-price orders)
+4. **BUG-04** — Stripe webhook transaction (data integrity)
+5. **IMP-01** — env() → config() (reliability)
+6. **IMP-02** — Rate limit ops routes (security hardening)

--- a/frontend/src/app/(storefront)/thank-you/page.tsx
+++ b/frontend/src/app/(storefront)/thank-you/page.tsx
@@ -47,40 +47,79 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
     async function fetchOrder() {
       try {
         // SECURITY FIX: Fetch by UUID token instead of sequential ID
+        // Pass CHECKOUT-TOKEN-FIX-01: showByToken now returns either OrderResource
+        // or CheckoutSessionResource (for multi-producer orders)
         const laravelOrder = await apiClient.getOrderByToken(orderToken)
 
-        // Transform Laravel order format to thank-you page format
-        const orderItems = laravelOrder.items || laravelOrder.order_items || []
-        // Pass MP-MULTI-PRODUCER-CHECKOUT-02: Prefer shipping_total (multi-producer sum)
-        // over shipping_amount (single-producer). Backend provides shipping_total when
-        // order has multiple producers with separate shipments.
-        const shippingAmount = laravelOrder.shipping_total
-          ? parseFloat(laravelOrder.shipping_total)
-          : (parseFloat(laravelOrder.shipping_amount) || laravelOrder.shipping_cost || 0)
-        // Pass MP-SHIPPING-BREAKDOWN-TRUTH-01: Include per-producer shipping lines
-        // Pass TRACKING-DISPLAY-01: Include public_token for tracking link
-        const transformedOrder: Order = {
-          id: String(laravelOrder.id),
-          status: laravelOrder.status,
-          total: parseFloat(laravelOrder.total_amount) || 0,
-          subtotal: parseFloat(laravelOrder.subtotal) || 0,
-          shipping: shippingAmount,
-          codFee: parseFloat(laravelOrder.cod_fee) || 0,
-          vat: parseFloat(laravelOrder.tax_amount) || 0,
-          zone: 'mainland', // Default, could be derived from shipping_address if needed
-          email: null, // Not exposed in public order response for privacy
-          name: null,
-          isMultiProducer: laravelOrder.is_multi_producer || false,
-          shippingLines: laravelOrder.shipping_lines || [],
-          publicToken: laravelOrder.public_token || undefined,
-          items: orderItems.map((item) => ({
-            id: String(item.id),
-            qty: item.quantity,
-            price: parseFloat(item.unit_price || item.price) || 0,
-            titleSnap: item.product_name || 'Προϊόν',
-          })),
+        // Detect if this is a CheckoutSession (multi-producer) or single Order
+        const isCheckoutSession = (laravelOrder as any).type === 'checkout_session'
+
+        if (isCheckoutSession) {
+          // Multi-producer: flatten child orders into a single thank-you view
+          const session = laravelOrder as any
+          const allItems: OrderItem[] = []
+
+          // Collect items from all child orders
+          const childOrders = session.orders || []
+          for (const childOrder of childOrders) {
+            const items = childOrder.items || childOrder.order_items || []
+            for (const item of items) {
+              allItems.push({
+                id: String(item.id),
+                qty: item.quantity,
+                price: parseFloat(item.unit_price || item.price) || 0,
+                titleSnap: item.product_name || 'Προϊόν',
+              })
+            }
+          }
+
+          const transformedOrder: Order = {
+            id: String(session.id),
+            status: session.status,
+            total: parseFloat(session.total) || 0,
+            subtotal: parseFloat(session.subtotal) || 0,
+            shipping: parseFloat(session.shipping_total) || 0,
+            codFee: parseFloat(session.cod_fee) || 0,
+            vat: 0,
+            zone: 'mainland',
+            email: null,
+            name: null,
+            isMultiProducer: session.is_multi_producer || false,
+            shippingLines: session.shipping_lines || [],
+            publicToken: session.public_token || undefined,
+            items: allItems,
+          }
+          setOrder(transformedOrder)
+        } else {
+          // Single-producer: existing logic
+          const orderItems = laravelOrder.items || laravelOrder.order_items || []
+          const shippingAmount = laravelOrder.shipping_total
+            ? parseFloat(laravelOrder.shipping_total)
+            : (parseFloat(laravelOrder.shipping_amount) || laravelOrder.shipping_cost || 0)
+          const transformedOrder: Order = {
+            id: String(laravelOrder.id),
+            status: laravelOrder.status,
+            total: parseFloat(laravelOrder.total_amount) || 0,
+            subtotal: parseFloat(laravelOrder.subtotal) || 0,
+            shipping: shippingAmount,
+            codFee: parseFloat(laravelOrder.cod_fee) || 0,
+            vat: parseFloat(laravelOrder.tax_amount) || 0,
+            zone: 'mainland',
+            email: null,
+            name: null,
+            isMultiProducer: laravelOrder.is_multi_producer || false,
+            shippingLines: laravelOrder.shipping_lines || [],
+            publicToken: laravelOrder.public_token || undefined,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            items: orderItems.map((item: any) => ({
+              id: String(item.id),
+              qty: item.quantity,
+              price: parseFloat(item.unit_price || item.price) || 0,
+              titleSnap: item.product_name || 'Προϊόν',
+            })),
+          }
+          setOrder(transformedOrder)
         }
-        setOrder(transformedOrder)
       } catch {
         setError('Αποτυχία φόρτωσης παραγγελίας')
       } finally {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -813,9 +813,12 @@ class ApiClient {
    * Used by thank-you page and email confirmation links.
    * Replaces the old getPublicOrder(id) which used sequential IDs.
    */
-  async getOrderByToken(token: string): Promise<Order> {
-    const response = await this.request<{ data: Order }>(`public/orders/by-token/${token}`);
-    return validateApiResponse(response.data, OrderSchema, 'getOrderByToken');
+  // Pass CHECKOUT-TOKEN-FIX-01: Returns either Order or CheckoutSession
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getOrderByToken(token: string): Promise<any> {
+    const response = await this.request<{ data: any }>(`public/orders/by-token/${token}`);
+    // Skip strict schema validation — response can be OrderResource or CheckoutSessionResource
+    return response.data;
   }
 
   /**


### PR DESCRIPTION
## Summary
- **BUG FIX**: Multi-producer orders now get UUID `public_token` on `checkout_sessions` table, fixing the broken thank-you page (was redirecting with integer ID instead of UUID)
- **SECURITY**: Removed legacy `Api\OrderController` routes that used flat 10% tax, no stock locking, and no multi-producer support
- **DATA INTEGRITY**: Wrapped Stripe webhook `handleMultiProducerPaymentSuccess` in `DB::transaction()` to prevent partial payment state
- **RELIABILITY**: Migrated `env('COMMISSION_ENGINE_ENABLED')` → `config('payments.commission_engine_enabled')` to survive `config:cache`
- **SECURITY**: Added `hash_equals()` for timing-safe ops token comparison + throttle middleware on ops routes

## Changes
| File | Change |
|------|--------|
| `backend/database/migrations/...add_public_token_to_checkout_sessions.php` | New migration: adds `public_token` UUID column |
| `backend/app/Models/CheckoutSession.php` | Auto-generate UUID in `boot()` |
| `backend/app/Http/Resources/CheckoutSessionResource.php` | Return `public_token` in response |
| `backend/app/Http/Controllers/Api/V1/OrderController.php` | `showByToken` now searches both `checkout_sessions` and `orders` |
| `backend/app/Http/Controllers/Api/V1/StripeWebhookController.php` | Wrap multi-producer handler in `DB::transaction()` |
| `backend/app/Providers/AppServiceProvider.php` | `env()` → `config()` for commission flag |
| `backend/config/payments.php` | Add `commission_engine_enabled` and `ops_token` config keys |
| `backend/routes/api.php` | Remove legacy OrderController, add throttle to ops, use `hash_equals()` |
| `backend/app/Http/Controllers/OpsDbController.php` | `hash_equals()` for timing-safe comparison |
| `frontend/src/app/(storefront)/thank-you/page.tsx` | Handle `CheckoutSessionResource` response format |
| `frontend/src/lib/api.ts` | `getOrderByToken` returns `any` to support both response types |

## Test plan
- [ ] Place multi-producer order (3 different producers) → verify thank-you page loads correctly
- [ ] Place single-producer order → verify thank-you page still works
- [ ] Verify legacy order routes return 404
- [ ] Verify ops endpoints still work with correct token
- [ ] Run migration on production: `php artisan migrate --force`