### PR TITLE
security: crypto OTP, open redirect fix, S3/JWT guards

### DIFF
--- a/frontend/src/app/auth/admin-login/page.tsx
+++ b/frontend/src/app/auth/admin-login/page.tsx
@@ -13,6 +13,19 @@ function LoadingSpinner() {
   );
 }
 
+/**
+ * Validate redirect URL to prevent open redirect attacks.
+ * Only allows paths starting with /admin.
+ */
+function safeAdminRedirect(url: string | null): string {
+  if (!url) return '/admin';
+  // Block absolute URLs, protocol-relative URLs, and data: URIs
+  if (url.startsWith('//') || url.includes('://') || url.startsWith('data:')) return '/admin';
+  // Admin login should only redirect to admin paths
+  if (!url.startsWith('/admin')) return '/admin';
+  return url;
+}
+
 function AdminLoginContent() {
   const [step, setStep] = useState<'phone' | 'otp'>('phone');
   const [phone, setPhone] = useState('');
@@ -23,7 +36,7 @@ function AdminLoginContent() {
 
   const router = useRouter();
   const searchParams = useSearchParams();
-  const from = searchParams.get('from') || '/admin';
+  const from = safeAdminRedirect(searchParams.get('from'));
 
   async function handleRequestOtp(e: React.FormEvent) {
     e.preventDefault();

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -6,6 +6,19 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTranslations } from '@/contexts/LocaleContext';
 
+/**
+ * Validate redirect URL to prevent open redirect attacks.
+ * Only allows relative paths starting with '/'.
+ */
+function safeRedirect(url: string | null): string {
+  if (!url) return '/';
+  // Block absolute URLs, protocol-relative URLs, and data: URIs
+  if (url.startsWith('//') || url.includes('://') || url.startsWith('data:')) return '/';
+  // Only allow paths starting with /
+  if (!url.startsWith('/')) return '/';
+  return url;
+}
+
 function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -17,7 +30,7 @@ function LoginForm() {
   const t = useTranslations();
 
   // Strategic Fix 2B: Read redirect param set by middleware
-  const redirectTo = searchParams.get('redirect') || '/';
+  const redirectTo = safeRedirect(searchParams.get('redirect'));
 
   // Redirect authenticated users away from login page
   useEffect(() => {

--- a/frontend/src/lib/auth/otp-store.ts
+++ b/frontend/src/lib/auth/otp-store.ts
@@ -1,3 +1,5 @@
+import { randomInt } from 'crypto';
+
 /**
  * In-memory OTP storage with automatic expiry
  *
@@ -26,14 +28,11 @@ const MAX_ATTEMPTS = 3;
 const OTP_LENGTH = 6;
 
 /**
- * Generate a random 6-digit OTP
+ * Generate a random 6-digit OTP using cryptographically secure randomness.
+ * Node.js crypto.randomInt() uses a CSPRNG, unlike Math.random().
  */
 export function generateOtp(): string {
-  // Generate cryptographically secure random number
-  const min = 100000;
-  const max = 999999;
-  const code = Math.floor(Math.random() * (max - min + 1)) + min;
-  return code.toString();
+  return randomInt(100000, 1000000).toString();
 }
 
 /**

--- a/frontend/src/lib/auth/session.ts
+++ b/frontend/src/lib/auth/session.ts
@@ -1,7 +1,19 @@
 import { cookies } from 'next/headers';
 import jwt from 'jsonwebtoken';
 
-const JWT_SECRET = process.env.JWT_SECRET || '';
+/**
+ * Lazy getter for JWT_SECRET — avoids throwing at module evaluation
+ * (which breaks `next build` page data collection).
+ * Throws at request time if missing in production.
+ */
+function getJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (secret) return secret;
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('JWT_SECRET must be set in production');
+  }
+  return '';
+}
 
 interface JwtPayload {
   phone: string;
@@ -26,7 +38,7 @@ export async function getSessionPhone(): Promise<string | null> {
   if (!session?.value) return null;
 
   try {
-    const decoded = jwt.verify(session.value, JWT_SECRET, {
+    const decoded = jwt.verify(session.value, getJwtSecret(), {
       algorithms: ['HS256'],
       issuer: 'dixis-auth',
     }) as JwtPayload;
@@ -55,7 +67,7 @@ export async function getSessionType(): Promise<'admin' | 'user' | null> {
   if (!session?.value) return null;
 
   try {
-    const decoded = jwt.verify(session.value, JWT_SECRET, {
+    const decoded = jwt.verify(session.value, getJwtSecret(), {
       algorithms: ['HS256'],
       issuer: 'dixis-auth',
     }) as JwtPayload;

--- a/frontend/src/lib/media/storage.ts
+++ b/frontend/src/lib/media/storage.ts
@@ -63,11 +63,20 @@ export async function putObjectS3(data: Buf, mime: string): Promise<PutResult>{
   const ext = extFromMime(mime);
   const folder = yyyymm();
   const Key = `uploads/${folder}/${hash}.${ext}`;
+  const accessKeyId = process.env.S3_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.S3_SECRET_ACCESS_KEY;
+  if (!accessKeyId || !secretAccessKey) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY must be set in production');
+    }
+    // Dev/CI: fall back to local MinIO defaults (only when env vars are missing)
+    console.warn('[storage] S3 credentials not set — using dev defaults');
+  }
   const client = new S3Client({
     region, endpoint, forcePathStyle,
     credentials: {
-      accessKeyId: process.env.S3_ACCESS_KEY_ID || 'minioadmin',
-      secretAccessKey: process.env.S3_SECRET_ACCESS_KEY || 'minioadmin'
+      accessKeyId: accessKeyId || 'minioadmin',
+      secretAccessKey: secretAccessKey || 'minioadmin'
     }
   });
   await client.send(new PutObjectCommand({ Bucket, Key, Body: processed, ContentType: mime, ACL: 'public-read' } as any));


### PR DESCRIPTION
## Summary

Security hardening follow-up (2 of N), addressing findings from the full-platform audit:

- **🔴 CRITICAL: OTP uses `Math.random()`** → Replaced with `crypto.randomInt()` (CSPRNG)
- **🔴 CRITICAL: S3 credentials default to `minioadmin`** → Throws in production if unset
- **🟡 HIGH: Open redirect in login pages** → Validates `?redirect=` and `?from=` params  
- **🟡 HIGH: JWT_SECRET falls back to empty string** → Throws in production if unset

### Changes

| File | Fix |
|------|-----|
| `src/lib/auth/otp-store.ts` | `Math.random()` → `crypto.randomInt()` |
| `src/lib/media/storage.ts` | Throw if S3 creds missing in production |
| `src/app/auth/login/page.tsx` | `safeRedirect()` validates redirect param |
| `src/app/auth/admin-login/page.tsx` | `safeAdminRedirect()` validates `from` param |
| `src/lib/auth/session.ts` | Throw if `JWT_SECRET` missing in production |

### Test Plan

- [ ] Verify OTP still generates valid 6-digit codes
- [ ] Verify login redirect works for relative paths (`/producer/dashboard`)
- [ ] Verify login redirect blocks absolute URLs (`https://evil.com`)
- [ ] Verify admin login only redirects to `/admin/*` paths
- [ ] Verify S3 uploads still work (env vars are set in production)
- [ ] Verify JWT session still works (JWT_SECRET is set in production)