### PR TITLE
fix: middleware auth redirect uses localhost in production

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -70,7 +70,11 @@ export default function middleware(req: NextRequest) {
   if (requiresAuth(pathname)) {
     const hasSession = req.cookies.has('dixis_session') || req.cookies.has('mock_session')
     if (!hasSession) {
-      const loginUrl = new URL(LOGIN_PATH, req.url)
+      // Use nextUrl.clone() to preserve the public hostname from the Host header.
+      // req.url contains the internal PM2 URL (localhost:3000), which would
+      // redirect users to localhost instead of dixis.gr in production.
+      const loginUrl = req.nextUrl.clone()
+      loginUrl.pathname = LOGIN_PATH
       loginUrl.searchParams.set('redirect', pathname)
       return NextResponse.redirect(loginUrl)
     }


### PR DESCRIPTION
## Summary

- **Bug**: Auth redirect for protected pages (`/producer/*`, `/admin/*`, `/account/*`, `/ops/*`) was sending users to `https://localhost:3000/auth/login` instead of `https://dixis.gr/auth/login`
- **Root cause**: `new URL(LOGIN_PATH, req.url)` — `req.url` contains the internal PM2 URL (`http://localhost:3000/...`) since Next.js standalone server runs behind nginx
- **Fix**: Use `req.nextUrl.clone()` which preserves the public hostname from the `Host` header forwarded by nginx, matching the pattern already used for the www→apex canonical redirect

## Evidence

```
$ curl -s -o /dev/null -D - https://dixis.gr/producer/onboarding
HTTP/2 307
location: https://localhost:3000/auth/login?redirect=%2Fproducer%2Fonboarding
```

## Test plan

- [ ] CI passes (typecheck, build, E2E)
- [ ] After deploy: `curl -D - https://dixis.gr/producer/onboarding` redirects to `https://dixis.gr/auth/login?redirect=%2Fproducer%2Fonboarding`
- [ ] Admin redirect: `curl -D - https://dixis.gr/admin` redirects to `https://dixis.gr/auth/login?redirect=%2Fadmin`
- [ ] Logged-in users bypass redirect as before