### PR TITLE
fix: auth redirect uses Host header for correct public URL

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -70,12 +70,18 @@ export default function middleware(req: NextRequest) {
   if (requiresAuth(pathname)) {
     const hasSession = req.cookies.has('dixis_session') || req.cookies.has('mock_session')
     if (!hasSession) {
-      // Use nextUrl.clone() to preserve the public hostname from the Host header.
-      // req.url contains the internal PM2 URL (localhost:3000), which would
-      // redirect users to localhost instead of dixis.gr in production.
+      // In standalone mode behind nginx, both req.url and req.nextUrl contain
+      // the internal PM2 URL (http://localhost:3000/...). We must reconstruct
+      // the URL from the Host header to redirect to the correct public domain,
+      // matching the pattern used by the www→apex canonical redirect above.
       const loginUrl = req.nextUrl.clone()
       loginUrl.pathname = LOGIN_PATH
       loginUrl.searchParams.set('redirect', pathname)
+      if (host && host !== 'localhost:3000') {
+        loginUrl.hostname = host.split(':')[0]
+        loginUrl.port = ''
+        loginUrl.protocol = 'https:'
+      }
       return NextResponse.redirect(loginUrl)
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to PR #3101. The initial fix (`req.nextUrl.clone()`) still contained the internal `localhost:3000` URL because Next.js standalone mode constructs `nextUrl` from `req.url`, not from the `Host` header.

- **Root cause**: In standalone mode behind nginx, both `req.url` and `req.nextUrl` contain `http://localhost:3000/...` — the internal PM2 URL
- **Fix**: Manually override `hostname`, `port`, and `protocol` from the `Host` header, matching the exact pattern already used for the `www → apex` canonical redirect (lines 58-62)

## Evidence

Before (production with PR #3101):
```
$ curl -s -o /dev/null -D - https://dixis.gr/producer/onboarding
location: https://localhost:3000/auth/login?redirect=%2Fproducer%2Fonboarding
```

Expected after:
```
location: https://dixis.gr/auth/login?redirect=%2Fproducer%2Fonboarding
```

## Test plan

- [ ] CI passes
- [ ] After deploy: `curl -D - https://dixis.gr/producer/onboarding` → `https://dixis.gr/auth/login?redirect=%2Fproducer%2Fonboarding`
- [ ] `curl -D - https://dixis.gr/admin` → `https://dixis.gr/auth/login?redirect=%2Fadmin`
- [ ] Local dev (`localhost:3000`) still works (condition skips Host override)