### PR TITLE
feat(email): Add order tracking link to confirmation email

### DIFF
--- a/backend/app/Mail/ConsumerOrderPlaced.php
+++ b/backend/app/Mail/ConsumerOrderPlaced.php
@@ -42,6 +42,9 @@ class ConsumerOrderPlaced extends Mailable
                 'subtotal' => number_format($this->order->subtotal, 2),
                 'shippingCost' => number_format($this->order->shipping_cost ?? 0, 2),
                 'total' => number_format($this->order->total, 2),
+                'trackingUrl' => $this->order->public_token
+                    ? rtrim(config('app.frontend_url', 'https://dixis.gr'), '/') . '/track/' . $this->order->public_token
+                    : null,
             ],
         );
     }

--- a/backend/resources/views/emails/orders/consumer-placed.blade.php
+++ b/backend/resources/views/emails/orders/consumer-placed.blade.php
@@ -57,6 +57,14 @@
             </div>
         </div>
 
+        @if(!empty($trackingUrl))
+        <div style="text-align: center; margin: 20px 0;">
+            <a href="{{ $trackingUrl }}" style="display: inline-block; background: #16a34a; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: bold;">
+                Παρακολούθηση Παραγγελίας
+            </a>
+        </div>
+        @endif
+
         <p>Θα λάβετε ειδοποίηση όταν η παραγγελία σας αποσταλεί.</p>
     </div>
 


### PR DESCRIPTION
## Summary
- Confirmation email now includes a **"Παρακολούθηση Παραγγελίας"** button
- Links to `/track/{public_token}` — the tracking page already exists
- The `public_token` was auto-generated on every order but never shown in the email

## Problem
After placing an order, the customer received a confirmation email with order details but **no way to check the order status later**. The tracking page (`/track/{token}`) existed, and the thank-you page showed a link, but once the customer left that page, the link was lost.

## Changes
| File | Change |
|------|--------|
| `Mail/ConsumerOrderPlaced.php` | Added `trackingUrl` to template data |
| `emails/orders/consumer-placed.blade.php` | Added green CTA button with tracking link |

## Test plan
- [ ] Place a test order → receive confirmation email
- [ ] Email contains green "Παρακολούθηση Παραγγελίας" button
- [ ] Button links to `/track/{uuid}` and shows correct order status
- [ ] If `public_token` is null (edge case), button is not shown