### PR TITLE
fix(checkout): sync COD fee with backend SSOT (€2→€4)

### DIFF
--- a/frontend/src/contracts/shipping.ts
+++ b/frontend/src/contracts/shipping.ts
@@ -96,7 +96,7 @@ export const DEFAULT_OPTIONS: Array<{
 }> = [
   { code: 'PICKUP', label: 'Παραλαβή από κατάστημα', etaDays: 0, baseCost: 0 },
   { code: 'COURIER', label: 'Παράδοση με κούριερ', etaDays: 2, baseCost: 3.5 },
-  { code: 'COURIER_COD', label: 'Αντικαταβολή', etaDays: 2, baseCost: 3.5, codFee: 1.5 },
+  { code: 'COURIER_COD', label: 'Αντικαταβολή', etaDays: 2, baseCost: 3.5, codFee: 4.0 },
 ];
 
 export function calculateShippingCost(

--- a/frontend/src/lib/cart/totals-wire.ts
+++ b/frontend/src/lib/cart/totals-wire.ts
@@ -39,9 +39,10 @@ export function computeTotalsFromContext(ctx: {
   }
 
   // Add COD fee if payment method is COD
+  // Default 400 cents (€4.00) — matches backend SSOT: backend/config/shipping.php → cod_fee_eur
   if ((ctx?.payment?.method || '').toUpperCase() === 'COD') {
     opts.codFee =
-      typeof ctx?.shipping?.codFeeCents === 'number' ? ctx.shipping.codFeeCents : 200;
+      typeof ctx?.shipping?.codFeeCents === 'number' ? ctx.shipping.codFeeCents : 400;
   }
 
   // Calculate totals

--- a/frontend/src/lib/payment/__tests__/paymentMethods.test.ts
+++ b/frontend/src/lib/payment/__tests__/paymentMethods.test.ts
@@ -19,7 +19,7 @@ describe('Payment Methods Configuration', () => {
     expect(codMethod.id).toBe('cash_on_delivery');
     expect(codMethod.type).toBe('cash_on_delivery');
     expect(codMethod.name).toBe('Αντικαταβολή');
-    expect(codMethod.fixed_fee).toBe(2.00);
+    expect(codMethod.fixed_fee).toBe(4.00);
 
     const cardMethod = PAYMENT_METHODS[1];
     expect(cardMethod.id).toBe('card');
@@ -52,15 +52,15 @@ describe('Payment Methods Configuration', () => {
     const cardMethod = getPaymentMethodById('card')!;
 
     // Cash on delivery: fixed fee only
-    expect(calculatePaymentFees(codMethod, 100)).toBe(2.00);
-    expect(calculatePaymentFees(codMethod, 50)).toBe(2.00);
+    expect(calculatePaymentFees(codMethod, 100)).toBe(4.00);
+    expect(calculatePaymentFees(codMethod, 50)).toBe(4.00);
 
     // Card payment: percentage + fixed fee
     expect(calculatePaymentFees(cardMethod, 100)).toBe(3.20); // 2.9% of 100 + 0.30 = 2.90 + 0.30 = 3.20
     expect(calculatePaymentFees(cardMethod, 50)).toBe(1.75);  // 2.9% of 50 + 0.30 = 1.45 + 0.30 = 1.75
 
     // Edge case: zero amount
-    expect(calculatePaymentFees(codMethod, 0)).toBe(2.00);
+    expect(calculatePaymentFees(codMethod, 0)).toBe(4.00);
     expect(calculatePaymentFees(cardMethod, 0)).toBe(0.30);
   });
 

--- a/frontend/src/lib/payment/paymentMethods.ts
+++ b/frontend/src/lib/payment/paymentMethods.ts
@@ -11,7 +11,7 @@ export const PAYMENT_METHODS: PaymentMethod[] = [
     type: 'cash_on_delivery',
     name: 'Αντικαταβολή',
     description: 'Πληρωμή κατά την παραλαβή',
-    fixed_fee: 2.00,
+    fixed_fee: 4.00, // Must match backend SSOT: backend/config/shipping.php → cod_fee_eur
   },
   {
     id: 'card',

--- a/frontend/src/lib/shipping/engine.v2.ts
+++ b/frontend/src/lib/shipping/engine.v2.ts
@@ -5,7 +5,9 @@
 import { RateRow, ZoneRow, QuoteInput, QuoteResult, Surcharge } from './config/types';
 
 const round2 = (n: number) => Math.round((n + Number.EPSILON) * 100) / 100;
-const codFeeFor = (m: string) => (m === 'COURIER_COD' ? 2.0 : 0);
+// COD fee must match backend SSOT: backend/config/shipping.php → cod_fee_eur = 4.00
+const COD_FEE_EUR = Number(process.env.NEXT_PUBLIC_COD_FEE_EUR ?? '4.0');
+const codFeeFor = (m: string) => (m === 'COURIER_COD' ? COD_FEE_EUR : 0);
 const FREE_SHIPPING_THRESHOLD = Number(process.env.NEXT_PUBLIC_SHIP_FREE_THRESHOLD_EUR ?? '35');
 
 export function volumetricKg(
@@ -130,7 +132,7 @@ export function quoteV2(
 
   let cost = rate.base;
   const cod = codFeeFor(i.method);
-  if (cod > 0) trace.push('COD=2.0');
+  if (cod > 0) trace.push(`COD=${COD_FEE_EUR}`);
 
   // free shipping threshold (business rule)
   if (i.subtotal >= FREE_SHIPPING_THRESHOLD) {


### PR DESCRIPTION
## Summary
- **Bug**: Frontend showed COD fee as €2.00 while backend SSOT charges €4.00
- Customers saw wrong price at checkout — billing discrepancy
- Fixed all 4 hardcoded COD fee values across frontend to match `backend/config/shipping.php → cod_fee_eur = 4.00`
- `engine.v2.ts` now reads `NEXT_PUBLIC_COD_FEE_EUR` env var (configurable, default €4)

## Files changed (5 files, 12 ins, 9 del)
| File | Change |
|------|--------|
| `engine.v2.ts` | `codFeeFor: 2.0` → configurable via env, default `4.0` |
| `totals-wire.ts` | fallback COD: `200` → `400` cents |
| `contracts/shipping.ts` | `codFee: 1.5` → `4.0` |
| `paymentMethods.ts` | `fixed_fee: 2.00` → `4.00` |
| `paymentMethods.test.ts` | assertions updated to `4.00` |

## Test plan
- [x] TypeScript compilation passes (no errors in changed files)
- [x] `paymentMethods.test.ts` assertions updated and pass
- [x] 9 pre-existing test failures confirmed (same count before/after — not caused by this PR)
- [ ] Manual: verify checkout shows €4.00 COD fee
- [ ] Manual: verify order total matches backend calculation