### PR TITLE
feat(orders): customer order cancellation (pending only)

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/OrderController.php
+++ b/backend/app/Http/Controllers/Api/V1/OrderController.php
@@ -10,6 +10,7 @@ use App\Models\CheckoutSession;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\OrderShippingLine;
+use App\Models\OrderStatusHistory;
 use App\Models\Producer;
 use App\Models\Product;
 use App\Services\CheckoutService;
@@ -75,6 +76,59 @@ class OrderController extends Controller
         $order->load(['orderItems.producer', 'shippingLines'])->loadCount('orderItems');
 
         return new OrderResource($order);
+    }
+
+    /**
+     * Cancel a pending order (customer-facing).
+     * Only the order owner can cancel, and only while status is 'pending'.
+     * Restores stock for cancelled items.
+     */
+    public function cancel(Request $request, Order $order): \Illuminate\Http\JsonResponse
+    {
+        // Only the order owner can cancel
+        if ($order->user_id === null || $order->user_id !== auth()->id()) {
+            return response()->json(['message' => 'Order not found'], 404);
+        }
+
+        // Only pending orders can be cancelled by the customer
+        if ($order->status !== 'pending') {
+            return response()->json([
+                'message' => 'Μόνο παραγγελίες σε εκκρεμότητα μπορούν να ακυρωθούν',
+                'status' => $order->status,
+            ], 422);
+        }
+
+        DB::transaction(function () use ($order, $request) {
+            $order->update(['status' => 'cancelled']);
+
+            // Restore stock (same logic as AdminOrderController)
+            $order->load('orderItems.product');
+            foreach ($order->orderItems as $item) {
+                if ($item->product && $item->product->stock !== null) {
+                    $item->product->increment('stock', $item->quantity);
+                }
+            }
+
+            // Record in status history
+            OrderStatusHistory::create([
+                'order_id' => $order->id,
+                'old_status' => 'pending',
+                'new_status' => 'cancelled',
+                'changed_by' => $request->user()->id,
+                'note' => 'Ακυρώθηκε από τον πελάτη',
+                'changed_at' => now(),
+            ]);
+        });
+
+        \Log::info('Order cancelled by customer', [
+            'order_id' => $order->id,
+            'user_id' => auth()->id(),
+        ]);
+
+        return response()->json([
+            'message' => 'Η παραγγελία ακυρώθηκε επιτυχώς',
+            'order' => new OrderResource($order->fresh()->load(['orderItems.producer', 'shippingLines'])),
+        ]);
     }
 
     /**

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -308,6 +308,12 @@ Route::prefix('v1')->group(function () {
         Route::get('orders/{order}/shipment', [App\Http\Controllers\Api\ShippingController::class, 'getOrderShipment']);
     });
 
+    // Customer order cancellation (authenticated, only pending orders)
+    Route::middleware('auth:sanctum')->group(function () {
+        Route::post('orders/{order}/cancel', [App\Http\Controllers\Api\V1\OrderController::class, 'cancel'])
+            ->middleware('throttle:5,1'); // 5 cancellations per minute
+    });
+
     // Payment methods (public - no auth required)
     Route::get('payment/methods', [App\Http\Controllers\Api\PaymentController::class, 'getPaymentMethods']);
 

--- a/frontend/src/app/account/orders/[orderId]/page.tsx
+++ b/frontend/src/app/account/orders/[orderId]/page.tsx
@@ -19,6 +19,8 @@ function OrderDetailsPage(): React.JSX.Element {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reordering, setReordering] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const { showToast } = useToast();
   const addToCart = useCart(s => s.add);
 
@@ -163,6 +165,23 @@ function OrderDetailsPage(): React.JSX.Element {
       router.push('/checkout');
     } else {
       showToast('error', 'Δεν υπάρχουν διαθέσιμα προϊόντα για επαναπαραγγελία');
+    }
+  };
+
+  const handleCancel = async () => {
+    if (cancelling) return;
+    setCancelling(true);
+    try {
+      apiClient.refreshToken();
+      const result = await apiClient.cancelOrder(orderId);
+      setOrder(result.order);
+      setShowCancelConfirm(false);
+      showToast('success', 'Η παραγγελία ακυρώθηκε επιτυχώς');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Αποτυχία ακύρωσης';
+      showToast('error', msg);
+    } finally {
+      setCancelling(false);
     }
   };
 
@@ -402,6 +421,49 @@ function OrderDetailsPage(): React.JSX.Element {
                 )}
               </div>
             </div>
+
+            {/* Order Cancellation — only for pending orders */}
+            {order.status === 'pending' && (
+              <div data-testid="cancel-section" className="bg-white rounded-lg shadow-sm border border-neutral-200">
+                <div className="p-6">
+                  {!showCancelConfirm ? (
+                    <button
+                      onClick={() => setShowCancelConfirm(true)}
+                      data-testid="cancel-order-button"
+                      className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 border border-red-300 text-sm font-medium rounded-lg text-red-700 bg-white hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+                    >
+                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                      Ακύρωση Παραγγελίας
+                    </button>
+                  ) : (
+                    <div className="space-y-3">
+                      <p className="text-sm text-neutral-700 text-center">
+                        Είστε σίγουροι ότι θέλετε να ακυρώσετε αυτή την παραγγελία;
+                      </p>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => setShowCancelConfirm(false)}
+                          disabled={cancelling}
+                          className="flex-1 px-3 py-2 text-sm font-medium rounded-lg border border-neutral-300 text-neutral-700 bg-white hover:bg-neutral-50 transition-colors"
+                        >
+                          Όχι
+                        </button>
+                        <button
+                          onClick={handleCancel}
+                          disabled={cancelling}
+                          data-testid="confirm-cancel-button"
+                          className="flex-1 px-3 py-2 text-sm font-medium rounded-lg border border-transparent text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 transition-colors"
+                        >
+                          {cancelling ? 'Ακύρωση...' : 'Ναι, ακύρωση'}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
 
             {/* Pass REORDER-01: Reorder Button */}
             <div data-testid="reorder-section" className="bg-white rounded-lg shadow-sm border border-neutral-200">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -848,6 +848,16 @@ class ApiClient {
     return this.request<Order>(`orders/${id}`);
   }
 
+  /**
+   * Cancel a pending order (customer-facing).
+   * Only works for orders with status='pending' owned by the current user.
+   */
+  async cancelOrder(id: number | string): Promise<{ message: string; order: Order }> {
+    return this.request<{ message: string; order: Order }>(`orders/${id}/cancel`, {
+      method: 'POST',
+    });
+  }
+
   // SECURITY FIX: Removed getPublicOrders() — was exposing ALL orders without auth.
   // Orders list is now only available via authenticated getOrders() endpoint.
 


### PR DESCRIPTION
## Summary
- Customers can now cancel their own orders while status is `pending`
- New backend endpoint `POST /orders/{order}/cancel` with ownership check + stock restoration
- Cancel button with inline confirmation dialog on `/account/orders/[id]` detail page
- Only visible when `order.status === 'pending'` — hidden for confirmed/shipped/etc

## Files changed (4 files, 132 ins)
| File | Change |
|------|--------|
| `OrderController.php` | New `cancel()` method: ownership check, status guard, stock restore, history log |
| `routes/api.php` | New route `POST orders/{order}/cancel` (auth:sanctum, throttle:5/min) |
| `[orderId]/page.tsx` | Cancel button + confirmation dialog + handler |
| `api.ts` | New `cancelOrder()` method |

## Business rules
- Only `pending` → `cancelled` transition allowed (422 otherwise)
- Stock restored in DB transaction (same pattern as AdminOrderController)
- Status change recorded in `OrderStatusHistory` for audit trail
- Greek UI text throughout

## Test plan
- [x] TypeScript compilation passes (no errors in changed files)
- [ ] Manual: pending order shows "Ακύρωση Παραγγελίας" button
- [ ] Manual: clicking cancel shows confirmation, confirming cancels order
- [ ] Manual: non-pending orders do NOT show cancel button
- [ ] Manual: stock restored after cancellation