### PR TITLE
feat: multi-image product infrastructure (backend + component)

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/ProductController.php
+++ b/backend/app/Http/Controllers/Api/V1/ProductController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\StoreProductRequest;
 use App\Http\Requests\UpdateProductRequest;
 use App\Http\Resources\ProductResource;
 use App\Models\Product;
+use App\Models\ProductImage;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -35,7 +36,7 @@ class ProductController extends Controller
         ]);
 
         $query = Product::query()
-            ->with('producer');
+            ->with(['producer', 'images']);
 
         // Filter by active status (default: only active products)
         $isActive = $request->get('is_active', true);
@@ -138,7 +139,7 @@ class ProductController extends Controller
         }
 
         $product = Product::create($data);
-        $product->load('producer');
+        $product->load(['producer', 'images']);
 
         return new ProductResource($product);
     }
@@ -151,8 +152,8 @@ class ProductController extends Controller
         // Only show active products
         abort_if(! $product->is_active, 404);
 
-        // Eager load producer
-        $product->load('producer');
+        // Eager load producer and images
+        $product->load(['producer', 'images']);
 
         return new ProductResource($product);
     }
@@ -172,7 +173,7 @@ class ProductController extends Controller
         }
 
         $product->update($data);
-        $product->load('producer');
+        $product->load(['producer', 'images']);
 
         return new ProductResource($product);
     }
@@ -187,5 +188,110 @@ class ProductController extends Controller
         $product->delete();
 
         return response()->json(['message' => 'Product deleted successfully'], 204);
+    }
+
+    /**
+     * Add an image to a product.
+     * Max 6 images per product. First image auto-set as primary.
+     */
+    public function addImage(Request $request, Product $product): JsonResponse
+    {
+        $this->authorize('update', $product);
+
+        $request->validate([
+            'url' => 'required|url|max:500',
+        ]);
+
+        // Limit: max 6 images per product
+        if ($product->images()->count() >= 6) {
+            return response()->json([
+                'message' => 'Μέγιστο 6 εικόνες ανά προϊόν',
+            ], 422);
+        }
+
+        $isPrimary = $product->images()->count() === 0; // First image is primary
+        $nextSort = ($product->images()->max('sort_order') ?? -1) + 1;
+
+        $image = ProductImage::create([
+            'product_id' => $product->id,
+            'url' => $request->url,
+            'is_primary' => $isPrimary,
+            'sort_order' => $nextSort,
+        ]);
+
+        // Sync image_url with primary image (backward compatibility)
+        if ($isPrimary) {
+            $product->update(['image_url' => $request->url]);
+        }
+
+        return response()->json([
+            'message' => 'Η εικόνα προστέθηκε',
+            'image' => [
+                'id' => $image->id,
+                'url' => $image->url,
+                'is_primary' => $image->is_primary,
+                'sort_order' => $image->sort_order,
+            ],
+        ], 201);
+    }
+
+    /**
+     * Remove an image from a product.
+     * If deleted image was primary, next image becomes primary.
+     */
+    public function removeImage(Product $product, ProductImage $image): JsonResponse
+    {
+        $this->authorize('update', $product);
+
+        if ($image->product_id !== $product->id) {
+            return response()->json(['message' => 'Image not found'], 404);
+        }
+
+        $wasPrimary = $image->is_primary;
+        $image->delete();
+
+        // If deleted image was primary, promote the next one
+        if ($wasPrimary) {
+            $nextImage = $product->images()->orderBy('sort_order')->first();
+            if ($nextImage) {
+                $nextImage->update(['is_primary' => true]);
+                $product->update(['image_url' => $nextImage->url]);
+            } else {
+                $product->update(['image_url' => null]);
+            }
+        }
+
+        return response()->json(['message' => 'Η εικόνα αφαιρέθηκε']);
+    }
+
+    /**
+     * Set an image as the primary image for a product.
+     */
+    public function setPrimaryImage(Product $product, ProductImage $image): JsonResponse
+    {
+        $this->authorize('update', $product);
+
+        if ($image->product_id !== $product->id) {
+            return response()->json(['message' => 'Image not found'], 404);
+        }
+
+        // Unset current primary
+        $product->images()->update(['is_primary' => false]);
+
+        // Set new primary
+        $image->update(['is_primary' => true]);
+
+        // Sync legacy image_url
+        $product->update(['image_url' => $image->url]);
+
+        return response()->json([
+            'message' => 'Η εικόνα ορίστηκε ως κύρια',
+            'image' => [
+                'id' => $image->id,
+                'url' => $image->url,
+                'is_primary' => true,
+                'sort_order' => $image->sort_order,
+            ],
+        ]);
     }
 }

--- a/backend/app/Http/Resources/ProductResource.php
+++ b/backend/app/Http/Resources/ProductResource.php
@@ -36,6 +36,14 @@ class ProductResource extends JsonResource
             'storage_instructions' => $this->storage_instructions,
             'shelf_life' => $this->shelf_life,
             'image_url' => $this->image_url,
+            'images' => $this->when($this->relationLoaded('images'), function () {
+                return $this->images->map(fn ($img) => [
+                    'id' => $img->id,
+                    'url' => $img->url,
+                    'is_primary' => $img->is_primary,
+                    'sort_order' => $img->sort_order,
+                ]);
+            }, []),
             'status' => $this->status,
             'is_active' => $this->is_active,
             'created_at' => $this->created_at?->toISOString(),

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -209,6 +209,12 @@ Route::prefix('v1')->group(function () {
         Route::post('products', [App\Http\Controllers\Api\V1\ProductController::class, 'store'])->name('api.v1.products.store');
         Route::patch('products/{product}', [App\Http\Controllers\Api\V1\ProductController::class, 'update'])->name('api.v1.products.update');
         Route::delete('products/{product}', [App\Http\Controllers\Api\V1\ProductController::class, 'destroy'])->name('api.v1.products.destroy');
+
+        // Product image management (max 6 per product)
+        Route::post('products/{product}/images', [App\Http\Controllers\Api\V1\ProductController::class, 'addImage'])
+            ->middleware('throttle:30,1');
+        Route::delete('products/{product}/images/{image}', [App\Http\Controllers\Api\V1\ProductController::class, 'removeImage']);
+        Route::patch('products/{product}/images/{image}/primary', [App\Http\Controllers\Api\V1\ProductController::class, 'setPrimaryImage']);
     });
 
     // S1-02: Authenticated reviews (create)

--- a/frontend/src/components/MultiImageUpload.client.tsx
+++ b/frontend/src/components/MultiImageUpload.client.tsx
@@ -1,0 +1,103 @@
+'use client';
+import React, { useRef, useState } from 'react';
+
+export interface ImageItem {
+  id?: number;
+  url: string;
+  is_primary: boolean;
+}
+
+type Props = {
+  images: ImageItem[];
+  onChange: (images: ImageItem[]) => void;
+  maxImages?: number;
+  maxMB?: number;
+};
+
+export default function MultiImageUpload({ images, onChange, maxImages = 6, maxMB = 5 }: Props) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function doUpload(file: File) {
+    setErr(null);
+    if (file.size > maxMB * 1024 * 1024) { setErr(`Max ${maxMB}MB`); return; }
+    if (images.length >= maxImages) { setErr(`Max ${maxImages} images`); return; }
+    setBusy(true);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      const headers: Record<string, string> = {};
+      const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      const r = await fetch('/api/me/uploads', { method: 'POST', body: fd, headers });
+      const j = await r.json();
+      if (!r.ok) { setErr(j?.error || 'Upload failed'); return; }
+      onChange([...images, { url: j.url, is_primary: images.length === 0 }]);
+    } finally { setBusy(false); }
+  }
+
+  function removeImage(idx: number) {
+    const updated = images.filter((_, i) => i !== idx);
+    if (images[idx].is_primary && updated.length > 0) updated[0] = { ...updated[0], is_primary: true };
+    onChange(updated);
+  }
+
+  function setPrimary(idx: number) {
+    onChange(images.map((img, i) => ({ ...img, is_primary: i === idx })));
+  }
+
+  const StarIcon = () => (
+    <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+    </svg>
+  );
+  const XIcon = () => (
+    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  );
+
+  return (
+    <div>
+      <label className="block mb-1.5 font-semibold text-sm text-neutral-700">
+        Εικόνες Προϊόντος <span className="font-normal text-neutral-400">({images.length}/{maxImages})</span>
+      </label>
+      {images.length > 0 && (
+        <div className="grid grid-cols-3 gap-3 mb-3">
+          {images.map((img, idx) => (
+            <div key={img.url} className="relative group rounded-lg overflow-hidden border border-neutral-200 aspect-square bg-neutral-100">
+              <img src={img.url} alt={`Εικόνα ${idx + 1}`} className="w-full h-full object-cover" />
+              {img.is_primary && (
+                <span className="absolute top-1.5 left-1.5 bg-primary text-white text-[10px] font-bold px-1.5 py-0.5 rounded">Κύρια</span>
+              )}
+              <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
+                {!img.is_primary && (
+                  <button type="button" onClick={() => setPrimary(idx)} className="p-1.5 bg-white rounded-full shadow text-neutral-700 hover:text-primary" title="Κύρια">
+                    <StarIcon />
+                  </button>
+                )}
+                <button type="button" onClick={() => removeImage(idx)} className="p-1.5 bg-white rounded-full shadow text-neutral-700 hover:text-red-600" title="Αφαίρεση">
+                  <XIcon />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {images.length < maxImages && (
+        <div
+          onDragOver={e => e.preventDefault()}
+          onDrop={e => { e.preventDefault(); const f = e.dataTransfer.files[0]; if (f) void doUpload(f); }}
+          onClick={() => inputRef.current?.click()}
+          className="p-4 border-2 border-dashed border-neutral-300 rounded-lg bg-neutral-50 text-center cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-colors"
+        >
+          <p className="text-sm text-neutral-500">{busy ? 'Ανέβασμα…' : 'Σύρε εδώ ή κλίκαρε για εικόνα'}</p>
+          <p className="text-xs text-neutral-400 mt-1">JPG, PNG, WebP — μέχρι {maxMB}MB</p>
+        </div>
+      )}
+      {err && <p className="mt-2 text-sm text-red-600">{err}</p>}
+      <input ref={inputRef} type="file" accept="image/*" className="hidden" onChange={e => { const f = e.target.files?.[0]; if (f) void doUpload(f); if (inputRef.current) inputRef.current.value = ''; }} aria-label="Επιλογή εικόνας" />
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1354,6 +1354,30 @@ class ApiClient {
       body: JSON.stringify(data),
     });
   }
+
+  // --- Product Image Management ---
+
+  /** Add an image to a product (max 6). */
+  async addProductImage(productId: number | string, url: string): Promise<{ message: string; image: ProductImage }> {
+    return this.request<{ message: string; image: ProductImage }>(`products/${productId}/images`, {
+      method: 'POST',
+      body: JSON.stringify({ url }),
+    });
+  }
+
+  /** Remove an image from a product. */
+  async removeProductImage(productId: number | string, imageId: number): Promise<{ message: string }> {
+    return this.request<{ message: string }>(`products/${productId}/images/${imageId}`, {
+      method: 'DELETE',
+    });
+  }
+
+  /** Set an image as the primary/main image. */
+  async setPrimaryProductImage(productId: number | string, imageId: number): Promise<{ message: string; image: ProductImage }> {
+    return this.request<{ message: string; image: ProductImage }>(`products/${productId}/images/${imageId}/primary`, {
+      method: 'PATCH',
+    });
+  }
 }
 
 export const apiClient = new ApiClient();


### PR DESCRIPTION
## Summary
- **Backend**: Product image CRUD endpoints (add/delete/set-primary) with max 6 images per product, auto-primary for first image, backward-compatible `image_url` sync
- **Backend**: `ProductResource` now includes `images` array; `ProductController` eager-loads images in all operations
- **Frontend**: New `MultiImageUpload.client.tsx` component with drag & drop upload, primary image selection (star icon), and remove (X icon)
- **Frontend**: `apiClient` methods: `addProductImage`, `removeProductImage`, `setPrimaryProductImage`

## What this PR does NOT do (deferred to PR H)
- Wire `MultiImageUpload` into create/edit product pages (kept as `UploadImage` for now)
- Product detail gallery view for customers

## API Endpoints Added
| Method | Endpoint | Purpose |
|--------|----------|---------|
| `POST` | `/api/v1/products/{id}/images` | Add image (URL) to product |
| `DELETE` | `/api/v1/products/{id}/images/{imageId}` | Remove image |
| `PATCH` | `/api/v1/products/{id}/images/{imageId}/primary` | Set as primary |

## Test plan
- [ ] Create product → verify `images: []` in API response
- [ ] POST image URL to `/products/{id}/images` → returns 201 with image data
- [ ] First image auto-set as `is_primary: true`
- [ ] POST 7th image → returns 422 (max 6)
- [ ] DELETE primary image → next image promoted to primary
- [ ] PATCH set-primary → old primary cleared, new primary set, `image_url` synced
- [ ] `MultiImageUpload` component renders grid, drag & drop, star/X buttons