### PR TITLE
fix: remove COD payment method from backend

### DIFF
--- a/backend/app/Http/Controllers/Api/ShippingController.php
+++ b/backend/app/Http/Controllers/Api/ShippingController.php
@@ -35,7 +35,7 @@ class ShippingController extends Controller
             'items.*.quantity' => 'required|integer|min:1',
             'postal_code' => 'required|string|regex:/^\d{5}$/',
             'producer_profile' => 'nullable|string|in:flat_rate,free_shipping,premium_producer,local_producer',
-            'payment_method' => 'nullable|string|in:CARD,COD',
+            'payment_method' => 'nullable|string|in:CARD',
         ]);
 
         try {

--- a/backend/app/Http/Controllers/Api/V1/OrderController.php
+++ b/backend/app/Http/Controllers/Api/V1/OrderController.php
@@ -182,7 +182,7 @@ class OrderController extends Controller
                 // Pass ORDER-SHIPPING-SPLIT-01: Include quoted_shipping for mismatch detection
                 $checkoutResult = $checkoutService->processCheckout($userId, $productData, [
                     'shipping_method' => $validated['shipping_method'] ?? 'HOME',
-                    'payment_method' => $validated['payment_method'] ?? 'COD',
+                    'payment_method' => $validated['payment_method'] ?? 'CARD',
                     'currency' => $validated['currency'],
                     'shipping_address' => $validated['shipping_address'] ?? null,
                     'notes' => $validated['notes'] ?? null,
@@ -200,28 +200,8 @@ class OrderController extends Controller
                 return new OrderResource($checkoutResult['orders'][0]);
             });
 
-            // Pass 53 + HOTFIX: Send email notifications AFTER transaction commits
-            // HOTFIX-MP-CHECKOUT-GUARD-01: Only send for COD orders.
-            // Card payments send email after payment confirmation (in PaymentController).
-            if ($checkoutResult) {
-                $paymentMethod = $checkoutResult['orders'][0]->payment_method ?? 'COD';
-
-                if ($paymentMethod === 'COD') {
-                    try {
-                        // Send email for each order (for multi-producer, each producer gets their own email)
-                        foreach ($checkoutResult['orders'] as $order) {
-                            $emailService->sendOrderPlacedNotifications($order);
-                        }
-                    } catch (\Exception $e) {
-                        // Log but don't fail the order creation
-                        \Log::error('Pass 53: Email notification failed (order still created)', [
-                            'checkout_session_id' => $checkoutResult['checkout_session']?->id,
-                            'order_count' => count($checkoutResult['orders']),
-                            'error' => $e->getMessage(),
-                        ]);
-                    }
-                }
-            }
+            // Pass 53: Email notifications sent after payment confirmation (PaymentController).
+            // COD removed — all orders go through card payment flow now.
 
             return $result;
         } catch (ShippingChangedException $e) {

--- a/backend/app/Http/Controllers/Api/V1/ShippingQuoteController.php
+++ b/backend/app/Http/Controllers/Api/V1/ShippingQuoteController.php
@@ -179,12 +179,12 @@ class ShippingQuoteController extends Controller
             'items' => 'required|array|min:1',
             'items.*.product_id' => 'required|integer|exists:products,id',
             'items.*.quantity' => 'required|integer|min:1',
-            'payment_method' => 'sometimes|string|in:COD,CARD',
+            'payment_method' => 'sometimes|string|in:CARD',
         ]);
 
         $postalCode = $validated['postal_code'];
         $method = $validated['method'];
-        $paymentMethod = $validated['payment_method'] ?? 'COD';
+        $paymentMethod = 'CARD'; // COD removed from marketplace
         $isPickup = $method === 'PICKUP';
         $quotedAt = now();
 
@@ -243,11 +243,8 @@ class ShippingQuoteController extends Controller
             $producerGroups[$producerId]['weight_grams'] += (int) ($weightPerUnit * $quantity);
         }
 
-        // Pass COD-COMPLETE: Calculate COD fee (applied once, not per-producer)
-        $codEnabled = config('shipping.enable_cod', false);
-        $codFeeEur = ($paymentMethod === 'COD' && $codEnabled)
-            ? (float) config('shipping.cod_fee_eur', 4.00)
-            : 0.00;
+        // COD removed — always zero
+        $codFeeEur = 0.00;
 
         // Calculate shipping per producer
         $producersResult = [];

--- a/backend/app/Http/Requests/StoreOrderRequest.php
+++ b/backend/app/Http/Requests/StoreOrderRequest.php
@@ -42,8 +42,8 @@ class StoreOrderRequest extends FormRequest
             'shipping_address.country' => 'nullable|string|max:100',
             // Shipping cost (Pass 48 - Frontend-calculated, EUR)
             'shipping_cost' => 'nullable|numeric|min:0|max:100',
-            // Payment method (optional, defaults to COD)
-            'payment_method' => 'nullable|string|in:COD,CARD,BANK_TRANSFER',
+            // Payment method (COD removed — card only)
+            'payment_method' => 'nullable|string|in:CARD,BANK_TRANSFER',
             // Pass ORDER-SHIPPING-SPLIT-01: Quoted shipping for mismatch detection
             'quoted_shipping' => 'nullable|numeric|min:0|max:200',
             'quoted_at' => 'nullable|date',
@@ -67,7 +67,7 @@ class StoreOrderRequest extends FormRequest
             'notes.max' => 'Notes cannot exceed 1000 characters.',
             'shipping_address.array' => 'Shipping address must be an object.',
             'shipping_address.email.email' => 'Invalid email address format.',
-            'payment_method.in' => 'Payment method must be COD, CARD, or BANK_TRANSFER.',
+            'payment_method.in' => 'Payment method must be CARD or BANK_TRANSFER.',
         ];
     }
 }

--- a/backend/app/Services/CheckoutService.php
+++ b/backend/app/Services/CheckoutService.php
@@ -60,6 +60,18 @@ class CheckoutService
      */
     public function processCheckout(?int $userId, array $productData, array $options): array
     {
+        // COD payment method removed — multi-producer marketplace makes flat COD fee impossible
+        $paymentMethod = $options['payment_method'] ?? 'COD';
+        if (strtoupper($paymentMethod) === 'COD') {
+            throw new \Illuminate\Validation\ValidationException(
+                validator([], []),
+                response()->json([
+                    'message' => 'Η αντικαταβολή δεν είναι πλέον διαθέσιμη. Παρακαλώ χρησιμοποιήστε κάρτα.',
+                    'errors' => ['payment_method' => ['COD is no longer available']],
+                ], 422)
+            );
+        }
+
         // Group items by producer
         $producerGroups = collect($productData)->groupBy(fn ($item) => $item['product']->producer_id ?? 0);
         $producerIds = $producerGroups->keys()->filter()->values();

--- a/backend/config/payments.php
+++ b/backend/config/payments.php
@@ -40,13 +40,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | COD (Cash on Delivery) - Always enabled
+    | COD (Cash on Delivery) - Disabled
     |--------------------------------------------------------------------------
     |
-    | COD is the default payment method and cannot be disabled.
+    | COD removed: multi-producer marketplace makes flat COD fee impossible.
+    | Each courier charges per-shipment COD, so 3 producers = 3 separate fees.
+    | May be re-enabled when carrier integration provides exact COD pricing.
     |
     */
-    'cod_enabled' => true,
+    'cod_enabled' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/backend/config/shipping.php
+++ b/backend/config/shipping.php
@@ -46,15 +46,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Cash on Delivery (COD)
+    | Cash on Delivery (COD) — Disabled
     |--------------------------------------------------------------------------
     |
-    | Configuration for Cash on Delivery payment method.
-    | When enabled, adds COD fee to shipping quotes.
+    | COD removed from marketplace. Keys retained for backward compatibility
+    | (existing orders may reference cod_fee). Always returns 0.
     |
     */
-    'enable_cod' => env('SHIPPING_ENABLE_COD', false),
-    'cod_fee_eur' => env('SHIPPING_COD_FEE_EUR', 4.00),
+    'enable_cod' => false,
+    'cod_fee_eur' => 0.00,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Disable COD (αντικαταβολή) across all backend endpoints
- Multi-producer marketplace makes flat COD fee impossible: each courier charges per-shipment COD, so 3 producers = 3 separate unpredictable fees
- Reject COD at checkout (422), remove from validation rules, always return cod_fee: 0
- Preserve `cod_fee` column and admin COD confirmation for existing orders

## Files changed (7 files, 75 LOC)
- `config/payments.php` — `cod_enabled: true` → `false`
- `config/shipping.php` — COD keys locked to 0
- `CheckoutService.php` — Reject COD with 422 + Greek message
- `ShippingQuoteController.php` — Remove COD from payment_method validation, cod_fee always 0
- `OrderController.php` — Default payment to CARD, remove COD email branch
- `ShippingController.php` — Remove COD from payment_method validation
- `StoreOrderRequest.php` — Remove COD from allowed payment methods

## AC Checklist
- [x] COD rejected at checkout with clear error message
- [x] All shipping quotes return cod_fee: 0
- [x] Existing orders with COD preserved (no migration changes)
- [x] Admin COD confirmation button still works for old orders
- [x] ≤300 LOC

## Test plan
- [ ] POST `/api/v1/orders` with payment_method=COD → 422
- [ ] POST `/api/v1/public/shipping/quote-cart` returns cod_fee: 0
- [ ] Old COD orders still display correctly in admin
- [ ] `php artisan test` passes