### PR TITLE
feat: customer refund request form

### DIFF
--- a/frontend/src/app/account/orders/[orderId]/page.tsx
+++ b/frontend/src/app/account/orders/[orderId]/page.tsx
@@ -10,6 +10,7 @@ import LoadingSpinner from '@/components/LoadingSpinner';
 import { useToast } from '@/contexts/ToastContext';
 import { formatDate, formatStatus, safeMoney, safeText, formatShippingMethod, formatShippingAddress, hasShippingAddress, formatPaymentMethod } from '@/lib/orderUtils';
 import { useCart } from '@/lib/cart';
+import RefundRequestForm from '@/components/orders/RefundRequestForm';
 
 function OrderDetailsPage(): React.JSX.Element {
   const params = useParams();
@@ -434,6 +435,13 @@ function OrderDetailsPage(): React.JSX.Element {
                 </p>
               </div>
             </div>
+
+            {/* Refund Request */}
+            <RefundRequestForm
+              orderId={order.id}
+              orderTotal={`€${safeMoney(order.total_amount)}`}
+              paymentStatus={order.payment_status}
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/app/api/refund-request/route.ts
+++ b/frontend/src/app/api/refund-request/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { sendMail } from '@/lib/mail';
+
+const Schema = z.object({
+  orderId: z.number().int().positive(),
+  reason: z.string().min(10, 'Ο λόγος πρέπει να είναι τουλάχιστον 10 χαρακτήρες').max(2000),
+  email: z.string().email('Μη έγκυρο email'),
+  name: z.string().max(80).optional(),
+  hp: z.string().optional(), // honeypot
+});
+
+// Rate limiting — 5 requests / 10 minutes per IP
+const BUCKET = new Map<string, { c: number; t: number }>();
+const WINDOW_MS = 10 * 60 * 1000;
+const MAX_REQ = 5;
+
+function allow(ip: string) {
+  const now = Date.now();
+  const k = ip || 'unknown';
+  const v = BUCKET.get(k) ?? { c: 0, t: now };
+  if (now - v.t > WINDOW_MS) { v.c = 0; v.t = now; }
+  v.c++;
+  BUCKET.set(k, v);
+  return v.c <= MAX_REQ;
+}
+
+export async function POST(req: NextRequest) {
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  if (!allow(ip)) {
+    return NextResponse.json({ ok: false, error: 'rate_limited' }, { status: 429 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const parsed = Schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, errors: parsed.error.flatten() }, { status: 422 });
+  }
+
+  // Honeypot check
+  if (parsed.data.hp && parsed.data.hp.trim() !== '') {
+    return NextResponse.json({ ok: true });
+  }
+
+  const { orderId, reason, email, name } = parsed.data;
+  const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const adminTo = process.env.ADMIN_EMAIL ?? 'info@dixis.gr';
+
+  // Email to admin
+  const adminHtml = `
+<h2>Αίτημα Επιστροφής</h2>
+<p><b>Παραγγελία:</b> #${orderId}</p>
+<p><b>Πελάτης:</b> ${name ? esc(name) + ' — ' : ''}${esc(email)}</p>
+<p><b>Λόγος:</b><br/>${esc(reason).replace(/\n/g, '<br/>')}</p>
+<p><b>Ημερομηνία:</b> ${new Date().toLocaleString('el-GR', { timeZone: 'Europe/Athens' })}</p>
+<hr/>
+<p><small>Διαχείριση: <a href="${process.env.NEXT_PUBLIC_APP_URL || 'https://dixis.gr'}/admin/orders/${orderId}">Admin Panel</a></small></p>`;
+
+  await sendMail(adminTo, `Αίτημα Επιστροφής — Παραγγελία #${orderId}`, adminHtml, email);
+
+  // Autoreply to customer
+  try {
+    await sendMail(
+      email,
+      'Λάβαμε το αίτημα επιστροφής σας — Dixis',
+      `<p>Αγαπητέ/ή πελάτη,</p>
+<p>Λάβαμε το αίτημα επιστροφής για την παραγγελία <b>#${orderId}</b>.</p>
+<p>Θα το εξετάσουμε και θα επικοινωνήσουμε μαζί σας εντός <b>2 εργάσιμων ημερών</b>.</p>
+<p>Ευχαριστούμε,<br/>Η ομάδα Dixis</p>`
+    );
+  } catch { /* autoreply failure should not block */ }
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/components/orders/RefundRequestForm.tsx
+++ b/frontend/src/components/orders/RefundRequestForm.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+interface RefundRequestFormProps {
+  orderId: number;
+  orderTotal: string;
+  paymentStatus: string;
+}
+
+type FormState = 'idle' | 'sending' | 'ok' | 'error';
+
+export default function RefundRequestForm({ orderId, orderTotal, paymentStatus }: RefundRequestFormProps) {
+  const [state, setState] = useState<FormState>('idle');
+  const [expanded, setExpanded] = useState(false);
+
+  // Only show for paid orders
+  const isPaid = paymentStatus === 'completed' || paymentStatus === 'paid';
+  if (!isPaid) return null;
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setState('sending');
+    const fd = new FormData(e.currentTarget);
+    const payload = {
+      orderId,
+      reason: fd.get('reason') as string,
+      email: fd.get('email') as string,
+      name: fd.get('name') as string || undefined,
+      hp: fd.get('hp') as string || undefined,
+    };
+
+    try {
+      const res = await fetch('/api/refund-request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      setState(res.ok ? 'ok' : 'error');
+    } catch {
+      setState('error');
+    }
+  };
+
+  if (state === 'ok') {
+    return (
+      <div data-testid="refund-request-section" className="bg-white rounded-lg shadow-sm border border-neutral-200">
+        <div className="p-6">
+          <div className="p-4 rounded-lg bg-primary-pale border border-primary/20 text-primary text-sm">
+            <span className="font-medium">Το αίτημά σας καταχωρήθηκε!</span>
+            <p className="mt-1 text-neutral-600">
+              Θα επικοινωνήσουμε μαζί σας εντός 2 εργάσιμων ημερών.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="refund-request-section" className="bg-white rounded-lg shadow-sm border border-neutral-200">
+      <div className="p-6">
+        {!expanded ? (
+          <>
+            <button
+              onClick={() => setExpanded(true)}
+              data-testid="refund-request-toggle"
+              className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 border border-neutral-300 text-sm font-medium rounded-lg text-neutral-700 bg-white hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-colors"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+              </svg>
+              Αίτημα Επιστροφής
+            </button>
+            <p className="mt-2 text-xs text-neutral-500 text-center">
+              <Link href="/legal/returns" className="hover:underline text-primary">
+                Πολιτική Επιστροφών
+              </Link>
+            </p>
+          </>
+        ) : (
+          <>
+            <h3 className="text-sm font-semibold text-neutral-900 mb-3">Αίτημα Επιστροφής — #{orderId}</h3>
+            <p className="text-xs text-neutral-500 mb-4">
+              Ποσό παραγγελίας: {orderTotal}. Δείτε την{' '}
+              <Link href="/legal/returns" className="text-primary hover:underline">
+                Πολιτική Επιστροφών
+              </Link>.
+            </p>
+
+            {state === 'error' && (
+              <div className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 text-red-800 text-sm">
+                Κάτι πήγε στραβά. Δοκιμάστε ξανά ή επικοινωνήστε στο info@dixis.gr.
+              </div>
+            )}
+
+            <form onSubmit={onSubmit} className="space-y-4">
+              {/* Honeypot */}
+              <input type="text" name="hp" tabIndex={-1} autoComplete="off" className="hidden" aria-hidden="true" />
+
+              <div>
+                <label htmlFor="refund-reason" className="block text-sm font-medium text-neutral-700 mb-1">
+                  Λόγος αιτήματος *
+                </label>
+                <textarea
+                  id="refund-reason"
+                  name="reason"
+                  required
+                  minLength={10}
+                  maxLength={2000}
+                  rows={3}
+                  placeholder="Περιγράψτε τον λόγο (π.χ. ελαττωματικό προϊόν, λάθος παραγγελία...)"
+                  className="w-full border border-neutral-300 rounded-lg px-3 py-2 text-sm text-neutral-900 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary resize-none"
+                  data-testid="refund-reason"
+                />
+              </div>
+
+              <div>
+                <label htmlFor="refund-email" className="block text-sm font-medium text-neutral-700 mb-1">
+                  Email επικοινωνίας *
+                </label>
+                <input
+                  id="refund-email"
+                  name="email"
+                  type="email"
+                  required
+                  placeholder="you@example.com"
+                  className="w-full border border-neutral-300 rounded-lg px-3 py-2 text-sm text-neutral-900 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                  data-testid="refund-email"
+                />
+              </div>
+
+              <div className="flex gap-2">
+                <button
+                  type="submit"
+                  disabled={state === 'sending'}
+                  data-testid="refund-submit"
+                  className="flex-1 inline-flex items-center justify-center px-4 py-2.5 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {state === 'sending' ? 'Αποστολή...' : 'Υποβολή Αιτήματος'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setExpanded(false)}
+                  className="px-4 py-2.5 border border-neutral-300 text-sm font-medium rounded-lg text-neutral-700 bg-white hover:bg-neutral-50 transition-colors"
+                >
+                  Ακύρωση
+                </button>
+              </div>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -216,3 +216,16 @@ test('@smoke privacy page loads', async ({ page }) => {
 
   await expect(page.locator('body')).toBeVisible({ timeout: 10000 });
 });
+
+// @smoke — Refund request API validates input
+// CI-safe: POST with empty body should return 422 (PR L)
+test('@smoke refund-request API validates input', async ({ request }) => {
+  const res = await request.post('/api/refund-request', {
+    data: {},
+    headers: { 'Content-Type': 'application/json' },
+    timeout: 10000,
+  });
+  expect(res.status()).toBe(422);
+  const json = await res.json();
+  expect(json.ok).toBe(false);
+});


### PR DESCRIPTION
## Summary
- **NEW** `/api/refund-request` API route — Zod-validated, rate-limited, sends structured email to admin + autoreply to customer
- **NEW** `RefundRequestForm` component — expandable form on order detail page for paid orders
- **MODIFIED** Order detail page (`/account/orders/[orderId]`) — integrates refund request form in sidebar
- **Smoke test** for API validation (422 on empty body)

## How it works
1. Customer opens order detail page → sees "Αίτημα Επιστροφής" button (only for paid orders)
2. Clicks to expand form → fills reason + email → submits
3. Admin receives structured email with order ID, reason, and link to admin panel
4. Customer receives autoreply confirmation (2 business days)
5. Admin processes refund via existing admin panel (`/admin/orders/[id]`)

## Design decisions
- **No direct Stripe refund from customer** — admin must approve (anti-fraud)
- **Same pattern as `/api/contact`** — Zod, rate limit, honeypot, sendMail
- **No backend changes** — leverages existing `RefundController` for admin actions
- **Expandable UI** — doesn't clutter the order page; collapsed by default

## AC
- [x] Refund form visible only for paid orders
- [x] Form validates reason (min 10 chars) + email
- [x] Admin gets structured email with order details
- [x] Customer gets autoreply confirmation
- [x] Rate limited (5 requests / 10min)
- [x] Honeypot anti-spam
- [x] Smoke test for API validation
- [x] ≤300 LOC (252 LOC)

## Test plan
- [ ] `npm run build` — no errors
- [ ] `npx playwright test tests/e2e/smoke.spec.ts` — refund API test passes
- [ ] Manual: Order detail → click "Αίτημα Επιστροφής" → fill form → submit → check admin email