### PR TITLE
feat: print/save receipt button (PR N)

### DIFF
--- a/frontend/src/app/(storefront)/thank-you/page.tsx
+++ b/frontend/src/app/(storefront)/thank-you/page.tsx
@@ -156,7 +156,13 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
     <main className="min-h-screen bg-neutral-50 py-8 px-4" data-testid="thank-you-page">
       <div className="max-w-2xl mx-auto">
         <div className="bg-white border rounded-xl p-8 text-center">
-          <div className="mb-6">
+          {/* Print-only receipt header */}
+          <div className="hidden print:block text-center mb-6 pb-4 border-b">
+            <h1 className="text-2xl font-bold">ΑΠΟΔΕΙΞΗ ΠΑΡΑΓΓΕΛΙΑΣ</h1>
+            <p className="text-sm text-neutral-500 mt-1">dixis.gr — Φρέσκα τοπικά προϊόντα από παραγωγούς</p>
+          </div>
+
+          <div className="mb-6 print:hidden">
             <div className="text-5xl mb-4">✓</div>
             <h1 className="text-3xl font-bold text-primary mb-2">Ευχαριστούμε!</h1>
             <p className="text-neutral-600">Η παραγγελία σας καταχωρήθηκε επιτυχώς.</p>
@@ -278,7 +284,22 @@ export default function ThankYouPage({ searchParams }: { searchParams?: Record<s
             )}
           </div>
 
-          <div className="flex gap-3 justify-center">
+          {/* Print-only footer */}
+          <div className="hidden print:block text-center mt-6 pt-4 border-t text-xs text-neutral-500">
+            <p>dixis.gr — Ευχαριστούμε για την παραγγελία σας!</p>
+          </div>
+
+          <div className="flex gap-3 justify-center no-print">
+            <button
+              onClick={() => window.print()}
+              data-testid="print-button"
+              className="inline-flex items-center gap-2 border border-neutral-300 text-neutral-700 px-6 py-3 rounded-lg hover:bg-neutral-50 font-medium"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+              </svg>
+              Αποθήκευση / Εκτύπωση
+            </button>
             <a
               href="/products"
               className="inline-block bg-primary text-white px-6 py-3 rounded-lg hover:bg-primary-light font-medium"

--- a/frontend/src/app/account/orders/[orderId]/page.tsx
+++ b/frontend/src/app/account/orders/[orderId]/page.tsx
@@ -169,9 +169,15 @@ function OrderDetailsPage(): React.JSX.Element {
   return (
     <div className="min-h-screen bg-neutral-50">
       <div className="max-w-4xl mx-auto py-8 px-4">
+        {/* Print-only receipt header */}
+        <div className="hidden print:block text-center mb-6 pb-4 border-b">
+          <h1 className="text-2xl font-bold">ΑΠΟΔΕΙΞΗ ΠΑΡΑΓΓΕΛΙΑΣ</h1>
+          <p className="text-sm text-neutral-500 mt-1">dixis.gr — Φρέσκα τοπικά προϊόντα από παραγωγούς</p>
+        </div>
+
         {/* Header with back navigation */}
         <div className="mb-8">
-          <div className="flex items-center mb-4">
+          <div className="flex items-center mb-4 no-print">
             <Link
               href="/account/orders"
               data-testid="back-to-orders-link"
@@ -403,8 +409,27 @@ function OrderDetailsPage(): React.JSX.Element {
               </div>
             </div>
 
+            {/* Print / Save Receipt */}
+            <div className="bg-white rounded-lg shadow-sm border border-neutral-200 no-print">
+              <div className="p-6">
+                <button
+                  onClick={() => window.print()}
+                  data-testid="print-button"
+                  className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 border border-neutral-300 text-sm font-medium rounded-lg text-neutral-700 bg-white hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-colors"
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+                  </svg>
+                  Αποθήκευση / Εκτύπωση
+                </button>
+                <p className="mt-2 text-xs text-neutral-500 text-center">
+                  Αποθηκεύστε ως PDF ή εκτυπώστε
+                </p>
+              </div>
+            </div>
+
             {/* Pass REORDER-01: Reorder Button */}
-            <div data-testid="reorder-section" className="bg-white rounded-lg shadow-sm border border-neutral-200">
+            <div data-testid="reorder-section" className="bg-white rounded-lg shadow-sm border border-neutral-200 no-print">
               <div className="p-6">
                 <button
                   onClick={handleReorder}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -540,10 +540,12 @@ body {
    ============================================================================= */
 
 @media print {
-  .no-print, nav, [data-testid="print-button"] {
+  /* Hide non-print elements */
+  .no-print, nav, footer, [data-testid="print-button"] {
     display: none !important;
   }
 
+  /* Clean typography */
   a {
     text-decoration: none !important;
     color: black !important;
@@ -551,10 +553,23 @@ body {
 
   body {
     background: white !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
 
-  .card {
-    box-shadow: none;
+  /* Remove card shadows, let content breathe */
+  .card, .bg-white {
+    box-shadow: none !important;
     border: 1px solid #ddd;
+  }
+
+  /* Fill page width for receipt */
+  .max-w-2xl, .max-w-4xl {
+    max-width: 100% !important;
+  }
+
+  /* Page margins */
+  @page {
+    margin: 15mm;
   }
 }


### PR DESCRIPTION
## Summary
- Added "Αποθήκευση / Εκτύπωση" button to **thank-you page** and **order detail page**
- Print-only receipt header (`ΑΠΟΔΕΙΞΗ ΠΑΡΑΓΓΕΛΙΑΣ`) and footer appear only on print
- Enhanced print CSS: hides nav/footer/buttons, fills page width, sets page margins
- Zero dependencies — uses `window.print()` → browser "Save as PDF" / print

## Files Changed (3 files, 68 LOC)
| File | Change |
|------|--------|
| `thank-you/page.tsx` | Print button, receipt header/footer, `no-print` wrapper |
| `orders/[orderId]/page.tsx` | Print button card, receipt header, `no-print` on sidebar |
| `globals.css` | Enhanced `@media print` — footer hide, `print-color-adjust`, page margins |

## Acceptance Criteria
- [x] Thank-you page: print button visible, triggers browser print dialog
- [x] Order detail page: print button visible, triggers browser print dialog
- [x] Print preview: clean receipt with header, items, totals — no nav/buttons
- [x] Receipt fills page width on print
- [x] `data-testid="print-button"` auto-hidden on print (existing CSS rule)
- [x] ≤300 LOC (68 net)

## Test Plan
- [ ] Visit `/thank-you?token=<valid>` → print button visible → click → print dialog opens
- [ ] Visit `/account/orders/<id>` → print button in sidebar → click → print dialog opens  
- [ ] Print preview shows "ΑΠΟΔΕΙΞΗ ΠΑΡΑΓΓΕΛΙΑΣ" header + order details + "dixis.gr" footer
- [ ] Nav, buttons, sidebar hidden in print preview