### PR TITLE
fix(auth): exempt auth endpoints from CSRF verification

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -23,6 +23,14 @@ return Application::configure(basePath: dirname(__DIR__))
         // API routes should return JSON 401, not redirect to login
         $middleware->redirectGuestsTo(fn () => null);
 
+        // Exempt auth endpoints from CSRF — frontend uses Bearer tokens
+        // (localStorage), making session CSRF redundant for login/register.
+        // Fixes production 419 where nginx routes /sanctum/csrf-cookie
+        // to Next.js instead of Laravel.
+        $middleware->validateCsrfTokens(except: [
+            'api/v1/auth/*',
+        ]);
+
         // Register custom middleware aliases
         $middleware->alias([
             'auth.optional' => \App\Http\Middleware\OptionalSanctumAuth::class,


### PR DESCRIPTION
## Summary
- Exempt `api/v1/auth/*` endpoints from CSRF token verification in Laravel middleware
- Frontend uses Bearer tokens (localStorage), making session CSRF redundant for login/register
- Fixes production 419 where nginx routes `/sanctum/csrf-cookie` to Next.js instead of Laravel

## Root Cause
The SPA CSRF flow (`/sanctum/csrf-cookie` → XSRF-TOKEN → login POST) breaks when nginx routing changes redirect `/sanctum/*` to Next.js. Since the frontend uses Bearer tokens after login (not session cookies), CSRF protection on auth endpoints is unnecessary overhead that creates fragility.

## What Changed
- **`backend/bootstrap/app.php`**: Added `$middleware->validateCsrfTokens(except: ['api/v1/auth/*'])` — 1 line change
- All other POST endpoints (cart, checkout, admin) remain CSRF-protected
- `Auth::login()` still sets session cookie + XSRF-TOKEN for subsequent requests

## Security Analysis
- Login/register endpoints validate credentials (email+password) — CSRF adds no security value
- Bearer tokens are not auto-sent by browsers → inherently CSRF-safe
- This is the standard approach for API-token-based auth (Stripe, GitHub, etc.)

## Deploy Instructions
**Deploy BEFORE the frontend cleanup PR.**
```bash
ssh dixis-prod
cd /var/www/dixis/current/backend
git pull origin main
php artisan config:clear && php artisan cache:clear
```

## Test plan
- [ ] `curl -X POST https://dixis.gr/api/v1/auth/login -H 'Content-Type: application/json' -d '{"email":"wrong","password":"wrong"}'` returns 401 (not 419)
- [ ] Login with valid credentials in browser succeeds
- [ ] Cart/checkout operations still require CSRF (unchanged)