### PR TITLE
fix(auth): make fetchCsrfCookie non-blocking in login/register

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -692,8 +692,9 @@ class ApiClient {
 
   // Auth methods
   async login(email: string, password: string): Promise<AuthResponse> {
-    // Fetch CSRF cookie before auth request (Strategic Fix 2A — Sanctum SPA)
-    await this.fetchCsrfCookie();
+    // Best-effort CSRF cookie fetch — auth endpoints are CSRF-exempt on backend.
+    // Kept for defense-in-depth (sets XSRF-TOKEN for subsequent stateful requests).
+    try { await this.fetchCsrfCookie(); } catch { /* non-blocking: auth is CSRF-exempt */ }
 
     const response = validateApiResponse(
       await this.request<AuthResponse>('auth/login', {
@@ -732,8 +733,8 @@ class ApiClient {
     password_confirmation: string;
     role: 'consumer' | 'producer' | 'admin';
   }): Promise<AuthResponse> {
-    // Fetch CSRF cookie before auth request (Strategic Fix 2A — Sanctum SPA)
-    await this.fetchCsrfCookie();
+    // Best-effort CSRF cookie fetch — auth endpoints are CSRF-exempt on backend.
+    try { await this.fetchCsrfCookie(); } catch { /* non-blocking: auth is CSRF-exempt */ }
 
     const response = await this.request<AuthResponse>('auth/register', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- Wrap `fetchCsrfCookie()` in try/catch in `login()` and `register()` methods
- Auth endpoints are now CSRF-exempt on the backend (PR #3124)
- CSRF cookie fetch is kept for defense-in-depth but cannot break login if `/sanctum/csrf-cookie` is unreachable

## Context
Companion to PR #3124 (backend CSRF exemption). **Deploy PR #3124 first**, then this PR.

With the backend exemption in place, the CSRF token is no longer required for login/register. This PR makes the frontend resilient — if the CSRF cookie fetch fails for any reason (nginx routing, network), login still works.

## What Changed
- **`frontend/src/lib/api.ts`**: `login()` and `register()` now wrap `fetchCsrfCookie()` in try/catch
- No functional change to the CSRF flow — it still attempts to fetch the cookie, just doesn't fail hard

## Supersedes
PR #3123 (proxy route workaround) — with backend CSRF exemption, the proxy route is no longer needed. PR #3123 can be closed.

## Test plan
- [ ] Login with valid credentials works
- [ ] Login with invalid credentials shows proper error
- [ ] Register flow works  
- [ ] Cart/checkout operations unaffected