### PR TITLE
fix: gate COD payment behind env flag

### DIFF
--- a/frontend/src/app/(storefront)/checkout/useCheckout.ts
+++ b/frontend/src/app/(storefront)/checkout/useCheckout.ts
@@ -30,7 +30,9 @@ export function useCheckout() {
   // --- State ---
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
-  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('cod')
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>(
+    process.env.NEXT_PUBLIC_ENABLE_COD === 'true' ? 'cod' : 'card'
+  )
   const [cardProcessing, setCardProcessing] = useState(false)
   const [isMounted, setIsMounted] = useState(false)
   const [stripeClientSecret, setStripeClientSecret] = useState<string | null>(null)

--- a/frontend/src/components/checkout/PaymentMethodSelector.tsx
+++ b/frontend/src/components/checkout/PaymentMethodSelector.tsx
@@ -19,9 +19,11 @@ export default function PaymentMethodSelector({
   codFee,
 }: PaymentMethodSelectorProps) {
   // Card payments gated by build-time env flag AND user authentication
-  // Guest users can only use COD; logged-in users can use card
   const { isAuthenticated, loading: authLoading } = useAuth()
   const [cardEnabled, setCardEnabled] = useState(false)
+
+  // COD gated by build-time env flag (NEXT_PUBLIC_ENABLE_COD)
+  const codEnabled = process.env.NEXT_PUBLIC_ENABLE_COD === 'true'
 
   useEffect(() => {
     // NEXT_PUBLIC_* vars are replaced at build time
@@ -29,45 +31,52 @@ export default function PaymentMethodSelector({
     const flagEnabled = process.env.NEXT_PUBLIC_PAYMENTS_CARD_FLAG === 'true'
     setCardEnabled(flagEnabled && isAuthenticated)
 
-    // If user not authenticated and card was selected, reset to COD
-    if (!isAuthenticated && value === 'card') {
+    // Auto-select card when COD is disabled and card is available
+    if (!codEnabled && flagEnabled && isAuthenticated && value === 'cod') {
+      onChange('card')
+    }
+
+    // If user not authenticated and card was selected, reset to COD (only if COD enabled)
+    if (!isAuthenticated && value === 'card' && codEnabled) {
       onChange('cod')
     }
-  }, [isAuthenticated, value, onChange])
+  }, [isAuthenticated, value, onChange, codEnabled])
 
   return (
     <fieldset className="space-y-3" disabled={disabled}>
       <legend className="font-semibold mb-3">Τρόπος Πληρωμής</legend>
 
-      {/* Cash on Delivery - Always available */}
-      <label
-        htmlFor="payment-cod"
-        className={`flex items-center gap-3 p-4 border rounded-lg cursor-pointer transition-colors ${
-          value === 'cod'
-            ? 'border-primary bg-primary-pale'
-            : 'border-neutral-200 hover:border-neutral-300'
-        } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-      >
-        <input
-          type="radio"
-          id="payment-cod"
-          name="paymentMethod"
-          value="cod"
-          checked={value === 'cod'}
-          onChange={() => onChange('cod')}
-          className="w-5 h-5 text-primary focus:ring-primary"
-          data-testid="payment-cod"
-        />
-        <div className="flex-1">
-          <span className="font-medium">Αντικαταβολή</span>
-          <p className="text-sm text-neutral-500">Πληρωμή κατά την παράδοση</p>
-          {codFee != null && codFee > 0 && (
-            <p className="text-xs text-amber-600 mt-0.5" data-testid="cod-fee-note">
-              +{new Intl.NumberFormat('el-GR', { style: 'currency', currency: 'EUR' }).format(codFee)} χρέωση αντικαταβολής
-            </p>
-          )}
-        </div>
-      </label>
+      {/* Cash on Delivery - Only if NEXT_PUBLIC_ENABLE_COD=true */}
+      {codEnabled && (
+        <label
+          htmlFor="payment-cod"
+          className={`flex items-center gap-3 p-4 border rounded-lg cursor-pointer transition-colors ${
+            value === 'cod'
+              ? 'border-primary bg-primary-pale'
+              : 'border-neutral-200 hover:border-neutral-300'
+          } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+        >
+          <input
+            type="radio"
+            id="payment-cod"
+            name="paymentMethod"
+            value="cod"
+            checked={value === 'cod'}
+            onChange={() => onChange('cod')}
+            className="w-5 h-5 text-primary focus:ring-primary"
+            data-testid="payment-cod"
+          />
+          <div className="flex-1">
+            <span className="font-medium">Αντικαταβολή</span>
+            <p className="text-sm text-neutral-500">Πληρωμή κατά την παράδοση</p>
+            {codFee != null && codFee > 0 && (
+              <p className="text-xs text-amber-600 mt-0.5" data-testid="cod-fee-note">
+                +{new Intl.NumberFormat('el-GR', { style: 'currency', currency: 'EUR' }).format(codFee)} χρέωση αντικαταβολής
+              </p>
+            )}
+          </div>
+        </label>
+      )}
 
       {/* Card (Stripe) - Only if feature flag enabled AND user is logged in */}
       {cardEnabled && (
@@ -107,7 +116,7 @@ export default function PaymentMethodSelector({
         </p>
       )}
 
-      {/* Pass PAY-GUEST-CARD-GATE-01: Message for guests when card flag is enabled but user not logged in */}
+      {/* Message for guests when card flag is enabled but user not logged in */}
       {/* Only render after auth loading completes to avoid hydration mismatch */}
       {!authLoading && !isAuthenticated && process.env.NEXT_PUBLIC_PAYMENTS_CARD_FLAG === 'true' && (
         <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg" data-testid="guest-card-notice">

--- a/frontend/src/lib/payment/paymentMethods.ts
+++ b/frontend/src/lib/payment/paymentMethods.ts
@@ -6,13 +6,14 @@
 import type { PaymentMethod } from '../validation/checkout';
 
 export const PAYMENT_METHODS: PaymentMethod[] = [
-  {
-    id: 'cash_on_delivery',
-    type: 'cash_on_delivery',
+  // COD gated by env flag — can be re-enabled with NEXT_PUBLIC_ENABLE_COD=true
+  ...(process.env.NEXT_PUBLIC_ENABLE_COD === 'true' ? [{
+    id: 'cash_on_delivery' as const,
+    type: 'cash_on_delivery' as const,
     name: 'Αντικαταβολή',
     description: 'Πληρωμή κατά την παραλαβή',
     fixed_fee: 2.00,
-  },
+  }] : []),
   {
     id: 'card',
     type: 'card',
@@ -28,7 +29,8 @@ export function getPaymentMethodById(id: string): PaymentMethod | undefined {
 }
 
 export function getDefaultPaymentMethod(): PaymentMethod {
-  return PAYMENT_METHODS[0]; // Default to cash on delivery for compatibility
+  // When COD is disabled, first item is card
+  return PAYMENT_METHODS[0];
 }
 
 export function calculatePaymentFees(paymentMethod: PaymentMethod, subtotal: number): number {


### PR DESCRIPTION
## Summary
- COD removal commits existed on unmerged branches (`claude/remove-cod-frontend`, `claude/remove-cod-backend`) but were never merged to main
- Instead of hard-deleting COD code, gate it behind `NEXT_PUBLIC_ENABLE_COD` env flag
- When flag is `false` (or absent): COD hidden from UI, card auto-selected
- When flag is `true`: COD visible as before (backwards compatible)

## Changes
- `PaymentMethodSelector.tsx`: wrap COD radio in `codEnabled` conditional, auto-select card when COD disabled
- `useCheckout.ts`: default payment method based on COD flag (`'card'` when COD disabled)
- `paymentMethods.ts`: conditionally include COD in PAYMENT_METHODS array

## Test plan
- [ ] Build succeeds with `NEXT_PUBLIC_ENABLE_COD=false`
- [ ] Checkout page shows only card option (no COD)
- [ ] Guest users see "login required" notice
- [ ] With `NEXT_PUBLIC_ENABLE_COD=true`: COD visible as before