### PR TITLE
fix: null-safe Stripe key initialization

### DIFF
--- a/frontend/src/components/payment/StripeProvider.tsx
+++ b/frontend/src/components/payment/StripeProvider.tsx
@@ -4,8 +4,10 @@ import React from 'react';
 import { loadStripe } from '@stripe/stripe-js';
 import { Elements } from '@stripe/react-stripe-js';
 
-// Initialize Stripe
-const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
+// Initialize Stripe — null-safe: returns null if key missing (prevents crash)
+const stripePromise = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  ? loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY)
+  : null;
 
 interface StripeProviderProps {
   children: React.ReactNode;


### PR DESCRIPTION
## Summary
- Prevent runtime crash when `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` is missing or undefined
- `loadStripe(undefined)` throws — now returns `null` gracefully
- Stripe Elements handles null stripe promise by showing loading state

## Changes
- `StripeProvider.tsx`: null-check before `loadStripe()` call

## Test plan
- [ ] Build succeeds
- [ ] Card payment form loads when Stripe key is configured
- [ ] No crash when Stripe key is absent