### PR TITLE
fix: correct shipping weight calculation after kg→grams migration

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/ShippingQuoteController.php
+++ b/backend/app/Http/Controllers/Api/V1/ShippingQuoteController.php
@@ -231,7 +231,7 @@ class ShippingQuoteController extends Controller
 
             $quantity = $item['quantity'];
             $itemTotal = $product->price * $quantity;
-            $weightPerUnit = ($product->weight_per_unit ?? 0.5) * 1000; // Convert kg to grams
+            $weightPerUnit = $product->weight_per_unit ?? 500; // Already in grams (migration 2026_02_22_400000), default 500g
 
             $producerGroups[$producerId]['items'][] = [
                 'product_id' => $product->id,

--- a/backend/app/Services/CheckoutService.php
+++ b/backend/app/Services/CheckoutService.php
@@ -382,12 +382,12 @@ class CheckoutService
             return 0.0;
         }
 
-        // Calculate total weight from items (default 0.5kg per item)
+        // Calculate total weight from items (weight_per_unit is in grams since migration 2026_02_22_400000)
         $totalWeightKg = 0.0;
         foreach ($items as $item) {
             $product = $item['product'];
             $qty = $item['quantity'] ?? 1;
-            $weightPerUnit = $product->weight_per_unit ?? 0.5; // Default 0.5kg
+            $weightPerUnit = ($product->weight_per_unit ?? 500) / 1000; // grams → kg, default 500g
             $totalWeightKg += $weightPerUnit * $qty;
         }
 
@@ -413,12 +413,12 @@ class CheckoutService
      */
     private function calculateProducerShippingWithDetails(array $items, float $subtotal, array $options, bool $isPickup, ?Producer $producer = null): array
     {
-        // Calculate total weight from items (default 0.5kg per item)
+        // Calculate total weight from items (weight_per_unit is in grams since migration 2026_02_22_400000)
         $totalWeightKg = 0.0;
         foreach ($items as $item) {
             $product = $item['product'];
             $qty = $item['quantity'] ?? 1;
-            $weightPerUnit = $product->weight_per_unit ?? 0.5; // Default 0.5kg
+            $weightPerUnit = ($product->weight_per_unit ?? 500) / 1000; // grams → kg, default 500g
             $totalWeightKg += $weightPerUnit * $qty;
         }
         $weightGrams = (int) round($totalWeightKg * 1000);

--- a/backend/app/Services/ShippingService.php
+++ b/backend/app/Services/ShippingService.php
@@ -199,7 +199,7 @@ class ShippingService
 
         foreach ($order->orderItems as $item) {
             $product = $item->product;
-            $itemWeight = ($product->weight_per_unit ?? 0.5) * $item->quantity; // Default 0.5kg if not set
+            $itemWeight = (($product->weight_per_unit ?? 500) / 1000) * $item->quantity; // weight_per_unit is grams (migration 2026_02_22_400000), convert to kg
             $totalWeight += $itemWeight;
 
             // Estimate dimensions if not provided (fallback)


### PR DESCRIPTION
## Summary
- Fix critical bug causing €352.10 shipping for a single €7.90 honey jar
- Migration `2026_02_22_400000` converted `weight_per_unit` from kg → grams in DB, but 3 code paths still treated values as kg
- A product with `weight_per_unit=500` (grams) was treated as 500 kg, causing extreme shipping costs

## Changes (3 files, 6 lines)
- **ShippingQuoteController.php**: Remove `* 1000` multiplication (value already in grams), default 0.5 → 500
- **CheckoutService.php**: Add `/ 1000` to convert grams→kg for both `calculateProducerShipping()` and `calculateProducerShippingWithDetails()`
- **ShippingService.php**: Add `/ 1000` to convert grams→kg in `getQuote()` method

## Math proof (GR_ATTICA zone)
Before fix: 500kg → base €2.90 + (3×€0.90) + (495×€0.70) = **€352.10**
After fix: 0.5kg → base €2.90 (≤2kg tier) = **€2.90** ✅

## Test plan
- [ ] API test: `POST /api/v1/public/shipping/quote-cart` with single item → shipping ~€2.90 (not €352)
- [ ] Browser test: checkout with single item → shipping shows reasonable amount
- [ ] Multi-item test: 2+ items from same producer → shipping ≤€10 for GR_ATTICA