### PR TITLE
fix: producer onboarding uploads broken — localStorage auth bug

### DIFF
--- a/frontend/src/app/api/ops/notify-onboarding/route.ts
+++ b/frontend/src/app/api/ops/notify-onboarding/route.ts
@@ -1,40 +1,24 @@
 import { NextResponse } from 'next/server';
 import { sendMail } from '@/server/mailer';
+import { getSessionPhone } from '@/lib/auth/session';
 
 /**
  * Onboarding V2: Notify admin when a producer submits onboarding.
  * Called fire-and-forget from the onboarding form — failure is non-blocking.
- * Auth: requires Laravel Sanctum Bearer token (producer role).
+ * Auth: OTP session cookie (dixis_session) or Laravel Sanctum Bearer token.
  */
 
-async function validateLaravelToken(req: Request): Promise<boolean> {
-  const authHeader = req.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) return false;
-  const laravelBase =
-    process.env.NEXT_PUBLIC_API_BASE_URL ||
-    process.env.LARAVEL_API_URL ||
-    'http://127.0.0.1:8001/api/v1';
-  try {
-    const resp = await fetch(`${laravelBase}/user`, {
-      headers: { Authorization: authHeader, Accept: 'application/json' },
-    });
-    return resp.ok;
-  } catch {
-    return false;
-  }
-}
-
 export async function POST(req: Request) {
-  // Auth check — must be authenticated
-  const isAuth = await validateLaravelToken(req);
-  if (!isAuth) {
+  // Auth check — support both OTP session and Bearer token
+  const phone = await getSessionPhone();
+  if (!phone) {
     return new NextResponse('Auth required', { status: 401 });
   }
 
   try {
     const body = await req.json();
     const businessName = String(body.business_name || '').slice(0, 200);
-    const phone = String(body.phone || '').slice(0, 50);
+    const phoneField = String(body.phone || '').slice(0, 50);
     const email = String(body.email || '').slice(0, 200);
     const city = String(body.city || '').slice(0, 100);
     const categories = Array.isArray(body.product_categories)
@@ -51,7 +35,7 @@ export async function POST(req: Request) {
       `Νέα αίτηση παραγωγού στο Dixis!`,
       ``,
       `Επωνυμία: ${businessName}`,
-      `Τηλέφωνο: ${phone}`,
+      `Τηλέφωνο: ${phoneField}`,
       `Email: ${email || '-'}`,
       `Πόλη: ${city || '-'}`,
       `Κατηγορίες: ${categories}`,

--- a/frontend/src/app/producer/onboarding/page.tsx
+++ b/frontend/src/app/producer/onboarding/page.tsx
@@ -176,12 +176,10 @@ export default function ProducerOnboardingPage() {
 
   /** Fire-and-forget admin email notification */
   const notifyAdmin = () => {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
-    if (token) headers['Authorization'] = `Bearer ${token}`;
     fetch('/api/ops/notify-onboarding', {
       method: 'POST',
-      headers,
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify({
         business_name: form.business_name,
         phone: form.phone,

--- a/frontend/src/components/UploadDocument.client.tsx
+++ b/frontend/src/components/UploadDocument.client.tsx
@@ -39,12 +39,11 @@ export default function UploadDocument({
     try {
       const fd = new FormData();
       fd.append('file', file);
-      const headers: Record<string, string> = {};
-      if (typeof window !== 'undefined') {
-        const token = localStorage.getItem('auth_token');
-        if (token) headers['Authorization'] = `Bearer ${token}`;
-      }
-      const r = await fetch('/api/me/uploads', { method: 'POST', body: fd, headers });
+      const r = await fetch('/api/me/uploads', {
+        method: 'POST',
+        body: fd,
+        credentials: 'include',
+      });
       const j = await r.json();
       if (!r.ok) {
         setErr(j?.error || 'Σφάλμα ανεβάσματος');

--- a/frontend/src/components/UploadImage.client.tsx
+++ b/frontend/src/components/UploadImage.client.tsx
@@ -21,13 +21,11 @@ export default function UploadImage({ value, onChange, accept='image/*', maxMB=5
     try{
       const fd = new FormData();
       fd.append('file', file);
-      // Include Bearer token for producer/consumer auth (Laravel Sanctum)
-      const headers: Record<string, string> = {};
-      if (typeof window !== 'undefined') {
-        const token = localStorage.getItem('auth_token');
-        if (token) headers['Authorization'] = `Bearer ${token}`;
-      }
-      const r = await fetch('/api/me/uploads', { method:'POST', body: fd, headers });
+      const r = await fetch('/api/me/uploads', {
+        method: 'POST',
+        body: fd,
+        credentials: 'include',
+      });
       const j = await r.json();
       if(!r.ok){ setErr(j?.error||'Σφάλμα ανεβάσματος'); return; }
       onChange(j.url);


### PR DESCRIPTION
## Summary

**BLOCKER fix** — Producer onboarding was completely broken: document uploads (TAXIS, EFET) failed silently because the upload components used `localStorage.getItem('auth_token')` which is never set by OTP auth.

User reported: "selected files to upload but the form says upload your PDFs and won't submit."

### Root cause

Same `localStorage.getItem('auth_token')` bug as PR #3144. The upload endpoint (`/api/me/uploads`) already supports `dixis_session` cookie via `getSessionPhone()`, but the client components sent a broken Bearer token instead of letting the cookie work.

### Changes (4 files, -40/+19 lines)

| File | Fix |
|------|-----|
| `UploadDocument.client.tsx` | Remove localStorage token, use `credentials: 'include'` |
| `UploadImage.client.tsx` | Same fix (product image uploads) |
| `notify-onboarding/route.ts` | Use `getSessionPhone()` instead of Bearer token validation |
| `onboarding/page.tsx` | Use `credentials: 'include'` for admin notification call |

## Test plan

- [ ] Log in as OTP producer → `/producer/onboarding`
- [ ] Upload PDF for TAXIS → green "Uploaded" indicator appears
- [ ] Upload PDF for EFET → same
- [ ] Submit form → succeeds (no more "upload your PDFs" error)
- [ ] Product image upload (`/my/products/create`) also works
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes