### PR TITLE
fix: eradicate all remaining localStorage auth_token reads

### DIFF
--- a/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
+++ b/frontend/src/app/admin/orders/_components/AdminOrdersMain.tsx
@@ -241,12 +241,11 @@ export default function AdminOrdersMain() {
         qs.set('per_page', String(pageSize));
         qs.set('sort', sort === 'createdAt' ? 'created_at' : '-created_at');
 
-        // Build headers with Authorization from localStorage
-        const headers: Record<string, string> = { 'Accept': 'application/json' };
-        const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
-        if (token) headers['Authorization'] = `Bearer ${token}`;
-
-        const res = await fetch(`/api/admin/orders?${qs.toString()}`, { cache:'no-store', headers });
+        const res = await fetch(`/api/admin/orders?${qs.toString()}`, {
+          cache: 'no-store',
+          headers: { 'Accept': 'application/json' },
+          credentials: 'include',
+        });
         if (res.status === 401 || res.status === 403) {
           // Unauthenticated - show clear message
           setErrNote('Απαιτείται σύνδεση διαχειριστή');

--- a/frontend/src/components/product/ReviewSection.tsx
+++ b/frontend/src/components/product/ReviewSection.tsx
@@ -67,13 +67,12 @@ export default function ReviewSection({ productId }: { productId: number }) {
 
     try {
       const base = process.env.NEXT_PUBLIC_API_BASE_URL || '/api/v1';
-      const token = localStorage.getItem('auth_token');
       const res = await fetch(`${base}/products/${productId}/reviews`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
         },
+        credentials: 'include',
         body: JSON.stringify({ rating, title: title || undefined, comment: comment || undefined }),
       });
       const json = await res.json();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -523,14 +523,16 @@ class ApiClient {
     return match ? decodeURIComponent(match[1]) : null;
   }
 
+  /**
+   * @deprecated OTP auth uses HttpOnly dixis_session cookie — no localStorage token.
+   * Kept as no-op for backward compatibility (callers still reference it).
+   */
   private loadTokenFromStorage(): void {
-    if (typeof window !== 'undefined') {
-      this.token = localStorage.getItem('auth_token');
-    }
+    // No-op: OTP auth uses HttpOnly cookie, not localStorage.
   }
 
   refreshToken(): void {
-    this.loadTokenFromStorage();
+    // No-op: OTP auth uses HttpOnly cookie.
   }
 
   private getHeaders(): HeadersInit {
@@ -538,11 +540,6 @@ class ApiClient {
       'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
-
-    // Bearer token for backward compatibility (migration period)
-    if (this.token) {
-      headers['Authorization'] = `Bearer ${this.token}`;
-    }
 
     // XSRF token from Sanctum cookie (Strategic Fix 2A — SPA auth)
     const xsrf = this.getXsrfToken();
@@ -553,42 +550,13 @@ class ApiClient {
     return headers;
   }
 
+  /**
+   * @deprecated OTP auth uses HttpOnly dixis_session cookie.
+   * Kept for backward compatibility — sets in-memory token only.
+   * No longer persists to localStorage.
+   */
   setToken(token: string | null) {
-    // DEBUG: Token instrumentation (masked for security) - enable with NEXT_PUBLIC_DEBUG_AUTH=1
-    const DEBUG_AUTH = typeof window !== 'undefined' &&
-      (process.env.NEXT_PUBLIC_DEBUG_AUTH === '1' || localStorage.getItem('DEBUG_AUTH') === '1');
-
-    const maskToken = (t: string | null | undefined) =>
-      t ? `${t.slice(0, 6)}...${t.slice(-4)}` : 'null';
-
-    if (DEBUG_AUTH && token && typeof window !== 'undefined') {
-      const parts = token.split('|');
-      console.log('🔐 [setToken] BEFORE save:', {
-        masked: maskToken(token),
-        totalLen: token.length,
-        plainLen: parts[1]?.length,
-      });
-    }
-
     this.token = token;
-    if (typeof window !== 'undefined') {
-      if (token) {
-        localStorage.setItem('auth_token', token);
-
-        if (DEBUG_AUTH) {
-          const saved = localStorage.getItem('auth_token');
-          const savedParts = saved?.split('|');
-          console.log('🔐 [setToken] AFTER save:', {
-            masked: maskToken(saved),
-            totalLen: saved?.length,
-            plainLen: savedParts?.[1]?.length,
-            MATCH: saved === token ? '✅ YES' : '❌ NO - TRUNCATION',
-          });
-        }
-      } else {
-        localStorage.removeItem('auth_token');
-      }
-    }
   }
 
   getToken(): string | null {

--- a/frontend/src/lib/api/notifications.ts
+++ b/frontend/src/lib/api/notifications.ts
@@ -46,11 +46,6 @@ export const notificationApi = {
    * Get paginated notifications for the authenticated user
    */
   async getNotifications(page = 1, perPage = 20, showRead = true): Promise<NotificationResponse> {
-    const token = localStorage.getItem('auth_token');
-    if (!token) {
-      throw new Error('No authentication token found');
-    }
-
     const params = new URLSearchParams({
       per_page: perPage.toString(),
       show_read: showRead.toString(),
@@ -64,8 +59,8 @@ export const notificationApi = {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
       },
+      credentials: 'include',
     });
 
     if (!response.ok) {
@@ -79,17 +74,12 @@ export const notificationApi = {
    * Get unread notifications count
    */
   async getUnreadCount(): Promise<UnreadCountResponse> {
-    const token = localStorage.getItem('auth_token');
-    if (!token) {
-      throw new Error('No authentication token found');
-    }
-
     const response = await fetch(`${API_BASE_URL}/notifications/unread-count`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
       },
+      credentials: 'include',
     });
 
     if (!response.ok) {
@@ -103,17 +93,12 @@ export const notificationApi = {
    * Get latest unread notifications for the notification bell
    */
   async getLatestNotifications(limit = 5): Promise<LatestNotificationsResponse> {
-    const token = localStorage.getItem('auth_token');
-    if (!token) {
-      throw new Error('No authentication token found');
-    }
-
     const response = await fetch(`${API_BASE_URL}/notifications/latest?limit=${limit}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
       },
+      credentials: 'include',
     });
 
     if (!response.ok) {
@@ -127,17 +112,12 @@ export const notificationApi = {
    * Mark a specific notification as read
    */
   async markAsRead(notificationId: number): Promise<{ success: boolean; message: string }> {
-    const token = localStorage.getItem('auth_token');
-    if (!token) {
-      throw new Error('No authentication token found');
-    }
-
     const response = await fetch(`${API_BASE_URL}/notifications/${notificationId}/read`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
       },
+      credentials: 'include',
     });
 
     if (!response.ok) {
@@ -151,17 +131,12 @@ export const notificationApi = {
    * Mark all notifications as read
    */
   async markAllAsRead(): Promise<{ success: boolean; message: string }> {
-    const token = localStorage.getItem('auth_token');
-    if (!token) {
-      throw new Error('No authentication token found');
-    }
-
     const response = await fetch(`${API_BASE_URL}/notifications/read-all`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
       },
+      credentials: 'include',
     });
 
     if (!response.ok) {

--- a/frontend/src/lib/api/payment.ts
+++ b/frontend/src/lib/api/payment.ts
@@ -69,7 +69,6 @@ class PaymentApiClient {
     endpoint: string,
     options: RequestInit = {}
   ): Promise<T> {
-    const token = localStorage.getItem('auth_token');
     const url = `${API_BASE_URL}${endpoint}`;
 
     const controller = new AbortController();
@@ -79,9 +78,9 @@ class PaymentApiClient {
       const response = await fetch(url, {
         ...options,
         signal: controller.signal,
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
-          ...(token && { 'Authorization': `Bearer ${token}` }),
           ...options.headers,
         },
       });

--- a/frontend/src/lib/api/refunds.ts
+++ b/frontend/src/lib/api/refunds.ts
@@ -38,9 +38,9 @@ export const refundApi = {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${localStorage.getItem('auth_token')}`,
         'Accept': 'application/json',
       },
+      credentials: 'include',
     });
 
     if (!response.ok) {
@@ -58,9 +58,9 @@ export const refundApi = {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${localStorage.getItem('auth_token')}`,
         'Accept': 'application/json',
       },
+      credentials: 'include',
       body: JSON.stringify(refundData),
     });
 
@@ -80,9 +80,9 @@ export const refundApi = {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${localStorage.getItem('auth_token')}`,
         'Accept': 'application/json',
       },
+      credentials: 'include',
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

OTP auth uses HttpOnly `dixis_session` cookie — `localStorage.getItem('auth_token')` is **never set**, causing silent auth failures across 6 modules.

**This PR removes ALL remaining instances** (follows up on #3144 and #3145 which fixed producer analytics + uploads).

### Changes

| File | Instances | Impact |
|------|-----------|--------|
| `notifications.ts` | 5 removed | **BLOCKER** — producer dashboard notifications |
| `payment.ts` | 1 removed | **BLOCKER** — card checkout auth |
| `api.ts` | 2 removed | Core — dead `loadTokenFromStorage()` + Bearer header logic |
| `ReviewSection.tsx` | 1 removed | Medium — customer review submission |
| `refunds.ts` | 3 removed | Admin — refund management |
| `AdminOrdersMain.tsx` | 1 removed | Admin — orders list |

**Universal fix pattern:** Remove `localStorage.getItem('auth_token')` + Bearer headers → add `credentials: 'include'` → browser auto-sends HttpOnly cookie.

### After this PR

- `grep -r "localStorage.getItem('auth_token')" src/` → only `AuthContext.tsx` (test-only MSW mock — intentionally kept)
- Net: -60 lines (28 added, 88 removed)

## Test plan

- [ ] `npx tsc --noEmit` ✅
- [ ] `npm run build` ✅
- [ ] Login as OTP producer → dashboard → notifications load
- [ ] Customer checkout → card payment form works
- [ ] Admin orders page loads correctly
- [ ] Grep confirms only AuthContext.tsx (test-only) remains