### PR TITLE
fix: upload auth for regular users — forward Laravel session cookies

### DIFF
--- a/frontend/src/app/api/me/uploads/route.ts
+++ b/frontend/src/app/api/me/uploads/route.ts
@@ -7,18 +7,19 @@ const ALLOWED = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf'];
 const MAX = 10 * 1024 * 1024; // 10MB limit (PDFs can be larger)
 
 /**
- * Validate Laravel Sanctum Bearer token by calling Laravel /api/v1/user.
- * Returns true if the token is valid (any authenticated role).
+ * Validate Laravel Sanctum session by forwarding cookies to Laravel /api/v1/user.
+ * Works for regular users who login via email/password (not OTP).
+ * The browser sends laravel_session + XSRF-TOKEN cookies via credentials: 'include'.
  */
-async function validateLaravelToken(req: Request): Promise<boolean> {
-  const authHeader = req.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) return false;
+async function validateLaravelSession(req: Request): Promise<boolean> {
+  const cookieHeader = req.headers.get('cookie');
+  if (!cookieHeader) return false;
 
   const laravelBase = process.env.NEXT_PUBLIC_API_BASE_URL || process.env.LARAVEL_API_URL || 'http://127.0.0.1:8001/api/v1';
   try {
     const resp = await fetch(`${laravelBase}/user`, {
       headers: {
-        'Authorization': authHeader,
+        'Cookie': cookieHeader,
         'Accept': 'application/json',
       },
     });
@@ -29,12 +30,12 @@ async function validateLaravelToken(req: Request): Promise<boolean> {
 }
 
 export async function POST(req: Request) {
-  // Auth: Support both admin phone-session AND Laravel Sanctum Bearer token
+  // Auth: Support both admin OTP session AND regular user Laravel session
   const phone = await getSessionPhone();
-  const hasLaravelAuth = !phone ? await validateLaravelToken(req) : false;
+  const hasLaravelAuth = !phone ? await validateLaravelSession(req) : false;
 
   if (!phone && !hasLaravelAuth) {
-    return new NextResponse('Auth required', { status: 401 });
+    return NextResponse.json({ error: 'Auth required' }, { status: 401 });
   }
 
   const form = await (req as any).formData().catch((): null => null);

--- a/frontend/src/app/api/ops/notify-onboarding/route.ts
+++ b/frontend/src/app/api/ops/notify-onboarding/route.ts
@@ -5,14 +5,31 @@ import { getSessionPhone } from '@/lib/auth/session';
 /**
  * Onboarding V2: Notify admin when a producer submits onboarding.
  * Called fire-and-forget from the onboarding form — failure is non-blocking.
- * Auth: OTP session cookie (dixis_session) or Laravel Sanctum Bearer token.
+ * Auth: OTP session cookie (dixis_session) OR Laravel session cookies.
  */
 
+async function validateLaravelSession(req: Request): Promise<boolean> {
+  const cookieHeader = req.headers.get('cookie');
+  if (!cookieHeader) return false;
+
+  const laravelBase = process.env.NEXT_PUBLIC_API_BASE_URL || process.env.LARAVEL_API_URL || 'http://127.0.0.1:8001/api/v1';
+  try {
+    const resp = await fetch(`${laravelBase}/user`, {
+      headers: { 'Cookie': cookieHeader, 'Accept': 'application/json' },
+    });
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
+
 export async function POST(req: Request) {
-  // Auth check — support both OTP session and Bearer token
+  // Auth check — support both OTP session and Laravel session
   const phone = await getSessionPhone();
-  if (!phone) {
-    return new NextResponse('Auth required', { status: 401 });
+  const hasLaravelAuth = !phone ? await validateLaravelSession(req) : false;
+
+  if (!phone && !hasLaravelAuth) {
+    return NextResponse.json({ error: 'Auth required' }, { status: 401 });
   }
 
   try {

--- a/frontend/src/components/UploadDocument.client.tsx
+++ b/frontend/src/components/UploadDocument.client.tsx
@@ -44,11 +44,12 @@ export default function UploadDocument({
         body: fd,
         credentials: 'include',
       });
-      const j = await r.json();
       if (!r.ok) {
-        setErr(j?.error || 'Σφάλμα ανεβάσματος');
+        const j = await r.json().catch((): null => null);
+        setErr(j?.error || (r.status === 401 ? 'Απαιτείται σύνδεση' : 'Σφάλμα ανεβάσματος'));
         return;
       }
+      const j = await r.json();
       onChange(j.url);
     } finally {
       setBusy(false);

--- a/frontend/src/components/UploadImage.client.tsx
+++ b/frontend/src/components/UploadImage.client.tsx
@@ -26,8 +26,8 @@ export default function UploadImage({ value, onChange, accept='image/*', maxMB=5
         body: fd,
         credentials: 'include',
       });
+      if(!r.ok){ const j = await r.json().catch((): null=>null); setErr(j?.error||(r.status===401?'Απαιτείται σύνδεση':'Σφάλμα ανεβάσματος')); return; }
       const j = await r.json();
-      if(!r.ok){ setErr(j?.error||'Σφάλμα ανεβάσματος'); return; }
       onChange(j.url);
     } finally { setBusy(false); }
   }


### PR DESCRIPTION
## Summary

**BLOCKER:** Regular users (producers/customers) cannot upload files on `/producer/onboarding`. Console shows: `SyntaxError: "Auth required" is not valid JSON`.

**Root cause:** Two auth systems coexist:
- Admin → OTP → `dixis_session` JWT cookie
- Regular users → email/password → Laravel session cookies (`laravel_session` + `XSRF-TOKEN`)

The upload route checked for Bearer token (removed in #3146) or `dixis_session` (admin-only). After #3146, **no regular user could upload**.

### Fix

Replace `validateLaravelToken(req)` (Bearer header check) with `validateLaravelSession(req)` — forwards the browser's cookies to `Laravel /api/v1/user` to validate the session.

| File | Change |
|------|--------|
| `uploads/route.ts` | Cookie forwarding + JSON 401 response |
| `notify-onboarding/route.ts` | Same Laravel session fallback |
| `UploadDocument.client.tsx` | Check `r.ok` before `r.json()` |
| `UploadImage.client.tsx` | Same safer error handling |

## Test plan

- [ ] `npx tsc --noEmit` ✅
- [ ] `npm run build` ✅
- [ ] Login as regular user → `/producer/onboarding` → upload TAXIS PDF → succeeds
- [ ] Login as admin OTP → upload still works (backwards compatible)
- [ ] No console `SyntaxError` on 401 responses