### PR TITLE
fix: validateLaravelSession hits correct Laravel /api/user endpoint

### DIFF
--- a/frontend/src/app/api/me/uploads/route.ts
+++ b/frontend/src/app/api/me/uploads/route.ts
@@ -7,17 +7,22 @@ const ALLOWED = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf'];
 const MAX = 10 * 1024 * 1024; // 10MB limit (PDFs can be larger)
 
 /**
- * Validate Laravel Sanctum session by forwarding cookies to Laravel /api/v1/user.
+ * Validate Laravel Sanctum session by forwarding cookies to Laravel /api/user.
  * Works for regular users who login via email/password (not OTP).
  * The browser sends laravel_session + XSRF-TOKEN cookies via credentials: 'include'.
+ *
+ * IMPORTANT: Laravel's auth route is /api/user (NOT /api/v1/user).
+ * We call the Laravel backend directly (127.0.0.1:8001), not through the
+ * public URL which would loop back through Next.js.
  */
 async function validateLaravelSession(req: Request): Promise<boolean> {
   const cookieHeader = req.headers.get('cookie');
   if (!cookieHeader) return false;
 
-  const laravelBase = process.env.NEXT_PUBLIC_API_BASE_URL || process.env.LARAVEL_API_URL || 'http://127.0.0.1:8001/api/v1';
+  // Use internal Laravel URL — NOT NEXT_PUBLIC_API_BASE_URL which points to Next.js itself
+  const laravelOrigin = process.env.LARAVEL_INTERNAL_URL || 'http://127.0.0.1:8001';
   try {
-    const resp = await fetch(`${laravelBase}/user`, {
+    const resp = await fetch(`${laravelOrigin}/api/user`, {
       headers: {
         'Cookie': cookieHeader,
         'Accept': 'application/json',

--- a/frontend/src/app/api/ops/notify-onboarding/route.ts
+++ b/frontend/src/app/api/ops/notify-onboarding/route.ts
@@ -12,9 +12,10 @@ async function validateLaravelSession(req: Request): Promise<boolean> {
   const cookieHeader = req.headers.get('cookie');
   if (!cookieHeader) return false;
 
-  const laravelBase = process.env.NEXT_PUBLIC_API_BASE_URL || process.env.LARAVEL_API_URL || 'http://127.0.0.1:8001/api/v1';
+  // Use internal Laravel URL — NOT NEXT_PUBLIC_API_BASE_URL which points to Next.js itself
+  const laravelOrigin = process.env.LARAVEL_INTERNAL_URL || 'http://127.0.0.1:8001';
   try {
-    const resp = await fetch(`${laravelBase}/user`, {
+    const resp = await fetch(`${laravelOrigin}/api/user`, {
       headers: { 'Cookie': cookieHeader, 'Accept': 'application/json' },
     });
     return resp.ok;


### PR DESCRIPTION
## Summary
- `validateLaravelSession()` was calling `NEXT_PUBLIC_API_BASE_URL/user` → `https://dixis.gr/api/v1/user` → **404** (loops through Next.js, and Laravel route is `/api/user` not `/api/v1/user`)
- Changed to call Laravel backend directly: `LARAVEL_INTERNAL_URL` || `http://127.0.0.1:8001` + `/api/user`
- Affects both `uploads/route.ts` and `notify-onboarding/route.ts`

## Root cause
`NEXT_PUBLIC_API_BASE_URL=https://dixis.gr/api/v1` is for client-side API calls through the Next.js proxy. Server-side validation must call Laravel directly on its internal port.

## Test plan
- [ ] Deploy to VPS
- [ ] Login as producer on dixis.gr
- [ ] Navigate to /producer/onboarding
- [ ] Upload TAXIS PDF → should succeed (no more "Auth required")
- [ ] Console: zero SyntaxError exceptions