### PR TITLE
ops: persist uploads across deploys via symlink

### DIFF
--- a/scripts/prod-deploy-clean.sh
+++ b/scripts/prod-deploy-clean.sh
@@ -203,7 +203,11 @@ echo "Deploy metadata written to .deploy-meta.json (post-build)"
 cp -r .next/static .next/standalone/.next/ 2>/dev/null || true
 cp -r public .next/standalone/ 2>/dev/null || true
 cp .deploy-meta.json .next/standalone/ 2>/dev/null || true
-echo "Standalone prepared"
+
+# Persistent uploads: symlink so uploaded files survive deploys
+mkdir -p /var/www/dixis/shared/uploads
+ln -sfn /var/www/dixis/shared/uploads .next/standalone/public/uploads
+echo "Standalone prepared (uploads symlinked to shared/)"
 
 echo ""
 echo "--- H2) Restore .env symlink (OPS-DEPLOY-GUARD-01) ---"


### PR DESCRIPTION
## Summary
- Uploaded files (product images, onboarding docs) were wiped on every deploy because `.next/standalone/public/uploads/` gets rebuilt
- Adds `mkdir -p /var/www/dixis/shared/uploads` + `ln -sfn` in the deploy script so uploads persist across deploys
- The uploads route handler (from #3151) reads from `cwd/public/uploads/` which now follows the symlink to shared/

## Test plan
- [ ] Run deploy script → uploads directory symlinked to shared/
- [ ] Upload product image → file appears in /var/www/dixis/shared/uploads/
- [ ] Re-deploy → previously uploaded files still accessible