### PR TITLE
fix: remove AuthGuard from admin categories — conflicted with OTP auth

### DIFF
--- a/frontend/src/app/admin/categories/page.tsx
+++ b/frontend/src/app/admin/categories/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import AuthGuard from '@/components/AuthGuard';
 import { useToast } from '@/contexts/ToastContext';
 
 interface Category {
@@ -14,15 +13,17 @@ interface Category {
   isActive: boolean;
 }
 
+/**
+ * Pass FIX-CATEGORIES-AUTH-01: Removed AuthGuard wrapper.
+ *
+ * AuthGuard uses useAuth() → apiClient.getProfile() which checks Laravel
+ * consumer/producer auth. Admin OTP login creates a dixis_session JWT,
+ * NOT a Laravel session, so AuthGuard always fails → redirect to /auth/login.
+ *
+ * Server-side auth is already handled by admin/layout.tsx (requireAdmin()),
+ * so the client-side AuthGuard was redundant AND broken for admin pages.
+ */
 export default function AdminCategoriesPage() {
-  return (
-    <AuthGuard requireAuth={true} requireRole="admin">
-      <AdminCategoriesContent />
-    </AuthGuard>
-  );
-}
-
-function AdminCategoriesContent() {
   const { showSuccess, showError } = useToast();
 
   // State

--- a/frontend/src/app/api/admin/categories/[id]/route.ts
+++ b/frontend/src/app/api/admin/categories/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db/client';
 import { requireAdmin } from '@/lib/auth/admin';
+import { handleAdminError } from '@/lib/admin/laravelProxy';
 import { logAdminAction } from '@/lib/audit/logger';
 
 /**
@@ -98,13 +99,9 @@ export async function PATCH(
     });
 
   } catch (error: unknown) {
-    // Handle admin auth errors
-    if (error instanceof Error && error.name === 'AdminError') {
-      return NextResponse.json(
-        { error: 'Απαιτείται πρόσβαση διαχειριστή' },
-        { status: 403 }
-      );
-    }
+    // Pass FIX-CATEGORIES-AUTH-01: Use shared handleAdminError for proper 401/403 distinction
+    const adminRes = handleAdminError(error);
+    if (adminRes.status !== 500) return adminRes;
 
     console.error('Update category error:', error);
     return NextResponse.json(


### PR DESCRIPTION
## Summary

- **Root cause**: Admin categories page used `AuthGuard` which calls `useAuth()` → `apiClient.getProfile()`. This checks Laravel consumer/producer auth. Admin OTP login creates only a `dixis_session` JWT, NOT a Laravel session, so AuthGuard always failed → redirect to `/auth/login` (wrong page, not even admin-login).
- Server-side auth is already handled by `admin/layout.tsx` (`requireAdmin()`), making the client-side AuthGuard both redundant AND broken for admin pages.
- Also standardized error handling in categories API route to use shared `handleAdminError()` for proper 401/403 distinction.

## Changes (2 files, ~30 LOC)

| File | Change |
|------|--------|
| `app/admin/categories/page.tsx` | Remove `AuthGuard` wrapper, remove unused import |
| `app/api/admin/categories/[id]/route.ts` | Use `handleAdminError()` instead of bare `instanceof` check |

## Why only categories was affected

All other admin pages are Server Components that use `requireAdmin()` directly. Categories was the ONLY admin page using the client-side `AuthGuard` component (which is designed for consumer/producer auth, not admin OTP auth).

## Test plan

- [ ] Login as admin via OTP → navigate to Κατηγορίες → page loads (no redirect)
- [ ] Edit a category → save works
- [ ] Toggle active/inactive → works
- [ ] Other admin sections (Orders, Producers, Products) still work
- [ ] TypeScript passes: `npx tsc --noEmit` ✅

Pass FIX-CATEGORIES-AUTH-01