### PR TITLE
fix: block product creation for non-approved producers + guard error state

### DIFF
--- a/backend/app/Policies/ProductPolicy.php
+++ b/backend/app/Policies/ProductPolicy.php
@@ -27,10 +27,17 @@ class ProductPolicy
 
     /**
      * Determine whether the user can create products.
+     * Producers must be approved (status=active) to create products.
      */
     public function create(User $user): bool
     {
-        return $user->role === 'producer' || $user->role === 'admin';
+        if ($user->role === 'admin') {
+            return true;
+        }
+
+        return $user->role === 'producer'
+            && $user->producer
+            && $user->producer->status === 'active';
     }
 
     /**

--- a/frontend/src/app/producer/dashboard/page.tsx
+++ b/frontend/src/app/producer/dashboard/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { apiClient, ProducerStats, Product } from '@/lib/api';
 import AuthGuard from '@/components/AuthGuard';
-import ProducerOnboardingGuard from '@/components/ProducerOnboardingGuard';
+import ProducerOnboardingGuard, { useProducerStatus } from '@/components/ProducerOnboardingGuard';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTranslations } from '@/contexts/LocaleContext';
@@ -29,6 +29,8 @@ export default function ProducerDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { user } = useAuth();
+  const producerStatus = useProducerStatus();
+  const isPending = producerStatus === 'pending';
 
   useEffect(() => {
     loadDashboardData();
@@ -198,7 +200,9 @@ export default function ProducerDashboard() {
                     </p>
                     <button
                       onClick={() => router.push('/my/products/create')}
-                      className="bg-primary hover:bg-primary-light text-white px-6 py-2 rounded-lg"
+                      disabled={isPending}
+                      className="bg-primary hover:bg-primary-light text-white px-6 py-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                      title={isPending ? 'Αναμένεται έγκριση λογαριασμού' : undefined}
                     >
                       {t('producerDashboard.addProduct')}
                     </button>
@@ -329,9 +333,11 @@ export default function ProducerDashboard() {
               </h2>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
                 <button
-                  onClick={() => router.push('/my/products/create')}
-                  className="flex items-center justify-center px-4 py-3 border border-neutral-300 rounded-lg hover:bg-neutral-50 transition-colors"
+                  onClick={() => !isPending && router.push('/my/products/create')}
+                  disabled={isPending}
+                  className="flex items-center justify-center px-4 py-3 border border-neutral-300 rounded-lg hover:bg-neutral-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-white"
                   data-testid="quick-action-add-product"
+                  title={isPending ? 'Αναμένεται έγκριση λογαριασμού' : undefined}
                 >
                   <svg className="w-5 h-5 text-neutral-600 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />

--- a/frontend/src/app/producer/onboarding/page.tsx
+++ b/frontend/src/app/producer/onboarding/page.tsx
@@ -157,8 +157,13 @@ export default function ProducerOnboardingPage() {
         if (p.cpnp_notification_number) setCpnpNumber(p.cpnp_notification_number);
         if (p.responsible_person_name) setResponsiblePerson(p.responsible_person_name);
       }
-    } catch {
-      // No profile yet — show form (expected for new registrations)
+    } catch (err: unknown) {
+      // 404 = no profile yet → show form (expected for new registrations)
+      // Other errors = real API failure → show error message
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status && status !== 404) {
+        setError('Σφάλμα φόρτωσης προφίλ. Παρακαλώ ανανεώστε τη σελίδα.');
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/ProducerOnboardingGuard.tsx
+++ b/frontend/src/components/ProducerOnboardingGuard.tsx
@@ -1,11 +1,21 @@
 'use client';
 
-import { useState, useEffect, ReactNode } from 'react';
+import { useState, useEffect, createContext, useContext, ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
 import LoadingSpinner from '@/components/LoadingSpinner';
 
-type GuardState = 'loading' | 'active' | 'pending' | 'redirect';
+type GuardState = 'loading' | 'active' | 'pending' | 'redirect' | 'error';
+
+/**
+ * Context exposing producer approval status to child components.
+ * Used by dashboard to disable product creation when pending.
+ */
+const ProducerStatusContext = createContext<'active' | 'pending'>('active');
+
+export function useProducerStatus() {
+  return useContext(ProducerStatusContext);
+}
 
 interface Props {
   children: ReactNode;
@@ -60,9 +70,8 @@ export default function ProducerOnboardingGuard({ children }: Props) {
       router.replace('/producer/onboarding');
       setState('redirect');
     } catch {
-      // API error — redirect to onboarding as safest fallback
-      router.replace('/producer/onboarding');
-      setState('redirect');
+      // API error — show error state with retry instead of blind redirect
+      setState('error');
     }
   };
 
@@ -82,8 +91,34 @@ export default function ProducerOnboardingGuard({ children }: Props) {
     );
   }
 
+  if (state === 'error') {
+    return (
+      <div className="min-h-screen bg-neutral-50 flex items-center justify-center">
+        <div className="text-center p-8 max-w-sm">
+          <div className="w-12 h-12 mx-auto mb-4 rounded-full bg-red-100 flex items-center justify-center">
+            <svg className="w-6 h-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+          </div>
+          <p className="text-neutral-700 mb-4">
+            Σφάλμα φόρτωσης. Παρακαλώ δοκιμάστε ξανά.
+          </p>
+          <button
+            onClick={() => { setState('loading'); checkOnboardingStatus(); }}
+            className="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors"
+            data-testid="retry-button"
+          >
+            Δοκιμάστε ξανά
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const producerStatus = state === 'pending' ? 'pending' : 'active';
+
   return (
-    <>
+    <ProducerStatusContext.Provider value={producerStatus}>
       {state === 'pending' && (
         <div
           className="bg-yellow-50 border-b border-yellow-200"
@@ -113,6 +148,6 @@ export default function ProducerOnboardingGuard({ children }: Props) {
         </div>
       )}
       {children}
-    </>
+    </ProducerStatusContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- **Backend**: `ProductPolicy::create()` now checks `producer->status === 'active'`, not just role. Pending/inactive producers get 403.
- **Frontend Guard**: `ProducerOnboardingGuard` catch-all redirect replaced with error state + retry button. Added `ProducerStatusContext` so child components know pending status.
- **Frontend Dashboard**: "Προσθήκη Προϊόντος" buttons disabled when producer is pending, with tooltip.
- **Frontend Onboarding**: `loadProfile()` distinguishes 404 (no profile → show form) from real API errors (show error message).

Supersedes #3159 (onboarding guard error state — now included here).

## Test plan
- [ ] Login as pending producer → dashboard shows "under review" banner + "Add Product" buttons are disabled/grayed
- [ ] Login as approved producer → "Add Product" works normally
- [ ] Pending producer tries `POST /api/products` directly → 403 Forbidden
- [ ] Simulate network error on producer dashboard → error screen with retry button (not blank onboarding form)
- [ ] New producer registration → onboarding form shows correctly
- [ ] API error during profile load on onboarding → shows error, not blank form