### PR TITLE
fix: admin producer review UX — auto-expand, Greek categories, visible details button

### DIFF
--- a/frontend/src/app/admin/producers/page.tsx
+++ b/frontend/src/app/admin/producers/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useToast } from '@/contexts/ToastContext'
 import AdminLoading from '@/app/admin/components/AdminLoading'
 import AdminEmptyState from '@/app/admin/components/AdminEmptyState'
+import { getCategoryBySlug } from '@/data/categories'
 
 interface Producer {
   id: string
@@ -111,6 +112,11 @@ function AdminProducersContent() {
       }
 
       setProducers(items)
+      // Auto-expand first pending producer for immediate review
+      const firstPending = items.find(p => p.approvalStatus === 'pending')
+      if (firstPending && !expandedId) {
+        setExpandedId(firstPending.id)
+      }
     } catch {
       showError('Αποτυχία φόρτωσης παραγωγών')
     } finally {
@@ -263,9 +269,13 @@ function AdminProducersContent() {
                           </button>
                         </div>
                       )}
-                      <span className="text-xs text-gray-400 ml-2">
-                        {expandedId === p.id ? '▲' : '▼'}
-                      </span>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); setExpandedId(expandedId === p.id ? null : p.id) }}
+                        className="px-2.5 py-1 text-xs font-medium text-blue-600 hover:text-blue-800 hover:bg-blue-50 rounded-md transition-colors ml-2"
+                        data-testid={`detail-btn-${p.id}`}
+                      >
+                        {expandedId === p.id ? 'Κλείσιμο ▲' : 'Λεπτομέρειες ▼'}
+                      </button>
                     </td>
                   </tr>
 
@@ -293,11 +303,14 @@ function AdminProducersContent() {
                             <div className="sm:col-span-2 mt-2">
                               <span className="text-gray-500">Κατηγορίες: </span>
                               <div className="inline-flex flex-wrap gap-1 ml-1">
-                                {p.productCategories.map((cat: string) => (
-                                  <span key={cat} className="px-2 py-0.5 bg-blue-100 text-blue-800 rounded-full text-xs font-medium">
-                                    {cat}
-                                  </span>
-                                ))}
+                                {p.productCategories.map((slug: string) => {
+                                  const cat = getCategoryBySlug(slug)
+                                  return (
+                                    <span key={slug} className="px-2 py-0.5 bg-blue-100 text-blue-800 rounded-full text-xs font-medium">
+                                      {cat ? cat.labelEl : slug}
+                                    </span>
+                                  )
+                                })}
                               </div>
                             </div>
                           )}


### PR DESCRIPTION
## Summary
- **Auto-expand first pending**: When admin opens the producers page, the first pending producer is automatically expanded so their details are immediately visible for review
- **Visible details button**: Replaced tiny `▲/▼` arrow with a clear "Λεπτομέρειες ▼" / "Κλείσιμο ▲" button that's easy to spot
- **Greek category labels**: Category slugs (e.g., `olive-oil-olives`) now display as Greek labels (e.g., `Ελαιόλαδο & Ελιές`) using the SSOT `getCategoryBySlug()` helper

## Test plan
- [ ] Admin → Παραγωγοί → first pending producer is auto-expanded
- [ ] Click "Λεπτομέρειες" on any producer row → expands details
- [ ] Category chips show Greek labels (not raw slugs like `herbs-spices-tea`)
- [ ] Unknown/legacy slugs still display raw slug as fallback
- [ ] Approve/Reject buttons still work correctly