### PR TITLE
fix: reduce cron to */30 + block AI crawlers (Neon free-tier optimization)

### DIFF
--- a/backend/routes/console.php
+++ b/backend/routes/console.php
@@ -69,8 +69,8 @@ Schedule::call(function () {
 | VPS cron runs every 30 min to conserve Neon free-tier compute hours.
 | Idempotent — won't alert twice for the same order+producer.
 |
-| When real orders start flowing, switch VPS cron back to */10 or */5
-| and adjust --minutes accordingly.
+| When real orders start flowing, switch VPS cron back to every 5-10
+| minutes and adjust --minutes accordingly.
 |
 */
 Schedule::command('orders:check-unaccepted --minutes=30')

--- a/backend/routes/console.php
+++ b/backend/routes/console.php
@@ -65,13 +65,16 @@ Schedule::call(function () {
 | FIX-ORDER-ESCALATION-01: Check Unaccepted Orders
 |--------------------------------------------------------------------------
 |
-| Runs every minute. If an order is still "pending" after 2 minutes,
-| sends an alert email to admin with the producer's phone number.
+| Checks for "pending" orders older than 30 minutes and alerts admin.
+| VPS cron runs every 30 min to conserve Neon free-tier compute hours.
 | Idempotent — won't alert twice for the same order+producer.
 |
+| When real orders start flowing, switch VPS cron back to */10 or */5
+| and adjust --minutes accordingly.
+|
 */
-Schedule::command('orders:check-unaccepted --minutes=2')
-    ->everyMinute()
+Schedule::command('orders:check-unaccepted --minutes=30')
+    ->everyThirtyMinutes()
     ->timezone('Europe/Athens')
     ->withoutOverlapping()
     ->runInBackground();

--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -171,7 +171,7 @@ _(Older entries archived — see `docs/OPS/STATE.md`)_
 - **Categories**: 10 unified slugs in both backend + frontend. `toStorefrontSlug()` bridge in `category-map.ts`.
 - **i18n**: Single `i18n.ts` config file + `messages/` directory (el.json, en.json). NOT an `i18n/` directory.
 - **Deploy (auto)**: `deploy-frontend.yml` builds standalone bundle, rsync to VPS, restores .env, PM2 restart, 20x health proof. **WORKING** (verified 2026-02-28).
-- **Analytics**: Umami v3.0.3 self-hosted at `/var/www/dixis/umami/`, PM2 on port 3001. Cookieless (no GDPR consent needed). Proxied via Next.js rewrite `/u/*` → `localhost:3001/*`. Dashboard: SSH tunnel `ssh -L 3001:localhost:3001 dixis-prod` → `http://localhost:3001`. Default credentials: admin/umami (**CHANGE THIS**).
+- **Analytics**: Umami v3.0.3 self-hosted at `/var/www/dixis/umami/`, PM2 on port 3001. Cookieless (no GDPR consent needed). Proxied via Next.js rewrite `/u/*` → `localhost:3001/*`. Public dashboard: `https://umami.dixis.gr` (nginx reverse proxy, SSL via Let's Encrypt). Admin password: rotated 2026-05-05 — credentials in `~/.dixis-secrets/umami-admin.txt` (founder's local machine, NOT in repo).
 - **Deploy (manual fallback)**: `ssh dixis-prod` → `cd /var/www/dixis/current/frontend && pm2 restart dixis-frontend`. Do NOT `git pull` + `npm run build` — the VPS directory is managed by rsync `--delete`.
 
 ---

--- a/docs/MONTHLY-COSTS.md
+++ b/docs/MONTHLY-COSTS.md
@@ -27,7 +27,7 @@
 | Service | What | Cost | Billing | Status |
 |---------|------|------|---------|--------|
 | **Hostinger VPS** | KVM 2 (2 vCPU, 8GB RAM, 100GB NVMe) — hosts Next.js + Umami + nginx | **€20/mo** | Annual prepaid | ✅ Active |
-| **Neon PostgreSQL** | Free tier — production DB | €0 (free tier) | — | ✅ Active |
+| **Neon PostgreSQL** | Free tier — production DB (100 CU-hrs/mo). Umami on separate Neon project (free). VPS cron at */30 → DB active ~17% (~30 CU-hrs/mo). | €0 (free tier) | — | ✅ Active |
 | **Domain (dixis.gr)** | .gr domain registration | **€1.50/mo** (~€18/yr) | Annual | ✅ Active |
 | **SSL Certificate** | Let's Encrypt via certbot | €0 | Auto-renew | ✅ Active |
 | **GitHub** | Free tier — repo, CI/CD, issues | €0 | — | ✅ Active |
@@ -220,6 +220,9 @@
 | 2026-03-06 | Λογιστής: €150 ατομική, €400 ΙΚΕ | Confirmed by accountant |
 | 2026-03-07 | **ΙΚΕ confirmed** | Decision made — going with IKE for liability protection |
 | 2026-03-07 | Insurance needed | Professional liability ~€85-165/mo, budget from quotes |
+| 2026-03-20 | Neon optimization | Umami moved to separate Neon project (free). Cron from */1→*/10. |
+| 2026-03-20 | Umami subdomain | umami.dixis.gr (nginx proxy to port 3001). DB on separate Neon free project. |
+| 2026-04-10 | Neon cron → */30 | */10 + 5-min suspend = DB active 50% (~3 CU-hrs/day, ~90/mo). */30 → active 17% (~1 CU-hr/day, ~30/mo). Revert to */10 when orders start. |
 
 ---
 

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,30 @@
+# Dixis.gr — robots.txt
+# Allow search engines, block aggressive AI crawlers that waste DB compute
+
+User-agent: *
+Allow: /
+
+# Block AI training crawlers (save Neon compute hours)
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+# Sitemap
+Sitemap: https://dixis.gr/sitemap.xml


### PR DESCRIPTION
## Summary

- VPS crontab changed from `*/10` → `*/30` (already applied on VPS)
- `console.php`: `orders:check-unaccepted` updated to match (`everyThirtyMinutes()` with `--minutes=30`)
- `robots.txt`: blocks AI crawlers (GPTBot, ClaudeBot, Bytespider, etc.) to prevent unnecessary DB wakeups
- `MONTHLY-COSTS.md`: decision log entry

## Why

Neon free-tier (100 CU-hrs/month) was being exhausted. Root cause:
- `*/10` cron + 5-min auto-suspend = DB active **50%** of time → ~3 CU-hrs/day → ~90/month (tight)

Fix:
- `*/30` cron + 5-min auto-suspend = DB active **17%** of time → ~1 CU-hr/day → ~30/month (safe)

## Tradeoff

`orders:check-unaccepted` now runs every 30 min instead of every 10. Acceptable while pre-revenue (0 orders). Revert to `*/10` when real orders flow.

## Test plan

- [x] VPS crontab updated and verified
- [x] DB still reachable (post-deploy check passed)
- [x] Site response 200ms (dixis.gr & umami.dixis.gr)
- [x] Neon DB connection alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)