### PR TITLE
fix(ops): self-heal Umami after frontend deploys

### DIFF
--- a/docs/AGENT-STATE.md
+++ b/docs/AGENT-STATE.md
@@ -171,7 +171,7 @@ _(Older entries archived — see `docs/OPS/STATE.md`)_
 - **Categories**: 10 unified slugs in both backend + frontend. `toStorefrontSlug()` bridge in `category-map.ts`.
 - **i18n**: Single `i18n.ts` config file + `messages/` directory (el.json, en.json). NOT an `i18n/` directory.
 - **Deploy (auto)**: `deploy-frontend.yml` builds standalone bundle, rsync to VPS, restores .env, PM2 restart, 20x health proof. **WORKING** (verified 2026-02-28).
-- **Analytics**: Umami v3.0.3 self-hosted at `/var/www/dixis/umami/`, PM2 on port 3001. Cookieless (no GDPR consent needed). Proxied via Next.js rewrite `/u/*` → `localhost:3001/*`. Public dashboard: `https://umami.dixis.gr` (nginx reverse proxy, SSL via Let's Encrypt). Admin password: rotated 2026-05-05 — credentials in `~/.dixis-secrets/umami-admin.txt` (founder's local machine, NOT in repo).
+- **Analytics**: Umami v3.0.3 self-hosted at `/var/www/dixis/umami/`, PM2 on port 3001. Cookieless (no GDPR consent needed). Proxied via Next.js rewrite `/u/*` → `localhost:3001/*`. Public dashboard: `https://umami.dixis.gr` (nginx reverse proxy, SSL via Let's Encrypt). Admin password: rotated 2026-05-05 — credentials in `~/.dixis-secrets/umami-admin.txt` (founder's local machine, NOT in repo). **Self-heal**: cron `*/2` runs `/var/www/dixis/ensure-umami.sh` (source: `scripts/ops/ensure-umami.sh`) to recover Umami after frontend deploys, which `pm2 delete all` + `pm2 kill` the entire daemon. Workflow file is locked per project rules, so we patch around it.
 - **Deploy (manual fallback)**: `ssh dixis-prod` → `cd /var/www/dixis/current/frontend && pm2 restart dixis-frontend`. Do NOT `git pull` + `npm run build` — the VPS directory is managed by rsync `--delete`.
 
 ---

--- a/scripts/ops/ensure-umami.sh
+++ b/scripts/ops/ensure-umami.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# ensure-umami.sh — self-heal Umami if PM2 has lost it.
+#
+# WHY THIS EXISTS:
+#   The frontend deploy workflow (.github/workflows/deploy-frontend.yml) runs
+#   `pm2 delete all` followed by `pm2 kill` as part of an "AGGRESSIVE CLEANUP"
+#   step. That wipes the entire PM2 daemon, including the Umami analytics
+#   process on port 3001. The deploy then starts only `dixis-frontend` and
+#   calls `pm2 save`, which removes Umami from the on-disk PM2 dump file too.
+#   Result: every frontend deploy takes Umami down until manually restarted.
+#
+#   Per the Dixis project rules (CLAUDE.md line 60), this workflow file
+#   cannot be modified. So instead, we run this script on a 2-minute cron
+#   under the `deploy` user. It checks whether Umami is online in PM2, and
+#   if not, starts it from its ecosystem config and persists the state.
+#
+# DEPLOYED LOCATION: /var/www/dixis/scripts/ensure-umami.sh
+# CRONTAB ENTRY:
+#   */2 * * * * /var/www/dixis/scripts/ensure-umami.sh >> /tmp/ensure-umami.log 2>&1
+#
+# Idempotent: safe to run any number of times. Does nothing when Umami is healthy.
+
+set -euo pipefail
+
+UMAMI_DIR="/var/www/dixis/umami"
+ECOSYSTEM="${UMAMI_DIR}/ecosystem.config.cjs"
+LOG_PREFIX="[$(date -Iseconds)] ensure-umami:"
+
+# Quick check: is umami listed as online in PM2?
+if /usr/bin/pm2 list 2>/dev/null | grep -E '\bumami\b' | grep -q 'online'; then
+    # Healthy — nothing to do. Stay quiet to keep the log file small.
+    exit 0
+fi
+
+echo "${LOG_PREFIX} Umami not online in PM2 — restarting"
+
+if [ ! -f "${ECOSYSTEM}" ]; then
+    echo "${LOG_PREFIX} ERROR: ${ECOSYSTEM} missing, cannot recover"
+    exit 1
+fi
+
+cd "${UMAMI_DIR}"
+
+# `pm2 start` is idempotent on the app name: if it exists in any state it
+# restarts; if it doesn't, it creates it from the ecosystem file.
+if /usr/bin/pm2 start "${ECOSYSTEM}" 2>&1; then
+    /usr/bin/pm2 save 2>&1 || true
+    echo "${LOG_PREFIX} Umami restarted and PM2 dump saved"
+else
+    echo "${LOG_PREFIX} ERROR: pm2 start failed (exit $?)"
+    exit 1
+fi


### PR DESCRIPTION
## Problem

The frontend deploy workflow runs `pm2 delete all` + `pm2 kill` as part of an "AGGRESSIVE CLEANUP" step. That wipes the entire PM2 daemon, including Umami analytics on port 3001. After the deploy, only `dixis-frontend` is started and `pm2 save` removes Umami from the on-disk dump too.

**Result**: every frontend deploy takes Umami offline (502 Bad Gateway) until manually restarted. Confirmed today — Umami had been down ~10 hours after the PR #3286 deploy.

## Why not patch the workflow directly

Project rule (CLAUDE.md line 60): no changes to `.github/workflows/**`. So instead I'm patching around it from outside.

## Fix

New script `scripts/ops/ensure-umami.sh`:

- Checks if `umami` is online in PM2
- If yes → silent exit 0 (no log noise)
- If no → starts from `ecosystem.config.cjs` + `pm2 save`
- Idempotent, safe to run any number of times

Deployed to `/var/www/dixis/ensure-umami.sh` on the VPS and wired into the deploy user's crontab:

```
*/2 * * * * /var/www/dixis/ensure-umami.sh >> /tmp/ensure-umami.log 2>&1
```

**Worst-case Umami downtime after a frontend deploy: ~2 minutes.**

## Verification

- [x] Healthy state → script exits 0 silently (no log noise)
- [x] Killed Umami via `pm2 delete umami` → HTTP 502 confirmed
- [x] Manually ran script → Umami back online, HTTP 200 confirmed
- [x] PM2 dump saved (survives VPS reboot)

## Test plan

- [ ] Next frontend deploy: monitor `/tmp/ensure-umami.log` to confirm script picks up the kill within 2 min
- [ ] Reboot VPS at some point: confirm Umami starts from PM2 dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)